### PR TITLE
Add a GitHub Pages landing page (draft)

### DIFF
--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -1,0 +1,563 @@
+/* Meals marketing page.
+   Aesthetic: kitchen paper. Warm stock, ink, one tomato-red accent, and a
+   receipt as the hero object. Hand-written, no build step: this file and
+   index.html are the whole site. */
+
+:root {
+  --paper:    #f2ede3;
+  --paper-2:  #fbf8f2;
+  --ink:      #1b1917;
+  --ink-soft: #4a443c;
+  --ink-mute: #7c7368;
+  --accent:   #c2452c;
+  --olive:    #4f6141;
+  --rule:     rgba(27, 25, 23, .14);
+  --rule-2:   rgba(27, 25, 23, .28);
+
+  --display: "Fraunces", Georgia, serif;
+  --body:    "Instrument Sans", -apple-system, BlinkMacSystemFont, sans-serif;
+  --mono:    "DM Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+  --page: 1180px;
+  --ease: cubic-bezier(.22, 1, .36, 1);
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--body);
+  font-size: 17px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+
+/* Paper tooth. Cheap, and it does more for the feel than any gradient. */
+.grain {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+  pointer-events: none;
+  opacity: .32;
+  mix-blend-mode: multiply;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.85' numOctaves='3'/%3E%3C/filter%3E%3Crect width='180' height='180' filter='url(%23n)' opacity='.42'/%3E%3C/svg%3E");
+}
+
+a { color: inherit; }
+
+h1, h2, h3, h4 {
+  font-family: var(--display);
+  font-weight: 600;
+  letter-spacing: -.02em;
+  line-height: 1.06;
+  margin: 0;
+  font-variation-settings: "SOFT" 20, "WONK" 1;
+}
+
+em { font-style: italic; }
+
+.mono {
+  font-family: var(--mono);
+  font-size: .88em;
+  background: rgba(27, 25, 23, .06);
+  padding: .08em .34em;
+  border-radius: 3px;
+}
+
+/* ── masthead ───────────────────────────────────────────────────────── */
+
+.masthead {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 1.1rem clamp(1.2rem, 4vw, 3rem);
+  background: color-mix(in srgb, var(--paper) 88%, transparent);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--rule);
+}
+
+.wordmark {
+  font-family: var(--display);
+  font-size: 1.4rem;
+  font-weight: 800;
+  letter-spacing: -.03em;
+  text-decoration: none;
+}
+.wordmark .dot { color: var(--accent); }
+
+.masthead nav {
+  display: flex;
+  align-items: center;
+  gap: 1.6rem;
+  font-size: .92rem;
+}
+.masthead nav a {
+  text-decoration: none;
+  color: var(--ink-soft);
+  padding-bottom: 2px;
+  border-bottom: 1px solid transparent;
+  transition: color .2s, border-color .2s;
+}
+.masthead nav a:hover { color: var(--ink); border-bottom-color: var(--accent); }
+.masthead nav a.ghost {
+  border: 1px solid var(--rule-2);
+  border-radius: 999px;
+  padding: .3rem .85rem;
+  color: var(--ink);
+}
+.masthead nav a.ghost:hover { background: var(--ink); color: var(--paper); border-color: var(--ink); }
+
+/* ── hero ───────────────────────────────────────────────────────────── */
+
+.hero {
+  max-width: var(--page);
+  margin: 0 auto;
+  padding: clamp(3rem, 8vw, 6.5rem) clamp(1.2rem, 4vw, 3rem) clamp(3rem, 7vw, 5rem);
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, .85fr);
+  gap: clamp(2rem, 6vw, 5rem);
+  align-items: start;
+}
+
+.eyebrow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .5rem;
+  margin: 0 0 1.6rem;
+  font-family: var(--mono);
+  font-size: .72rem;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+}
+.eyebrow span {
+  border: 1px solid var(--rule-2);
+  border-radius: 999px;
+  padding: .25rem .7rem;
+  color: var(--ink-soft);
+}
+.eyebrow span:first-child { background: var(--ink); color: var(--paper); border-color: var(--ink); }
+
+h1 {
+  font-size: clamp(2.6rem, 6.2vw, 4.6rem);
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+  text-wrap: balance;
+}
+h1 em { color: var(--accent); font-variation-settings: "SOFT" 40, "WONK" 1; }
+
+.lede {
+  font-size: clamp(1.05rem, 1.7vw, 1.22rem);
+  color: var(--ink-soft);
+  max-width: 34em;
+  margin: 0 0 2rem;
+}
+
+.cta { display: flex; flex-wrap: wrap; gap: .8rem; }
+
+.btn {
+  display: inline-block;
+  font-weight: 500;
+  font-size: .98rem;
+  text-decoration: none;
+  padding: .78rem 1.5rem;
+  border-radius: 3px;
+  background: var(--ink);
+  color: var(--paper);
+  border: 1px solid var(--ink);
+  transition: transform .18s var(--ease), box-shadow .18s var(--ease), background .18s;
+}
+.btn:hover { transform: translateY(-2px); box-shadow: 0 8px 0 -2px rgba(27, 25, 23, .18); }
+.btn.ghost { background: transparent; color: var(--ink); border-color: var(--rule-2); }
+.btn.ghost:hover { border-color: var(--ink); }
+
+.footnote {
+  margin: 1.6rem 0 0;
+  font-size: .88rem;
+  color: var(--ink-mute);
+  max-width: 32em;
+  border-left: 2px solid var(--accent);
+  padding-left: .9rem;
+}
+
+/* ── the receipt ────────────────────────────────────────────────────── */
+
+.receipt-wrap {
+  filter: drop-shadow(0 18px 30px rgba(27, 25, 23, .16));
+  transform: rotate(1.1deg);
+  margin-top: .5rem;
+}
+
+.receipt {
+  position: relative;
+  background: var(--paper-2);
+  padding: 1.9rem 1.7rem 1.4rem;
+  font-family: var(--mono);
+  font-size: .82rem;
+  line-height: 1.5;
+  color: var(--ink);
+}
+/* torn bottom edge */
+.receipt::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0; bottom: -11px;
+  height: 12px;
+  background:
+    linear-gradient(-45deg, transparent 50%, var(--paper-2) 50%) 0 0 / 16px 12px repeat-x,
+    linear-gradient(45deg,  transparent 50%, var(--paper-2) 50%) 8px 0 / 16px 12px repeat-x;
+}
+.receipt p { margin: 0; }
+.receipt hr {
+  border: 0;
+  border-top: 1px dashed var(--rule-2);
+  margin: .9rem 0;
+}
+
+.r-head {
+  font-weight: 500;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  font-size: .74rem;
+}
+.r-sub { color: var(--ink-mute); font-size: .74rem; }
+
+.r-aisle {
+  margin-top: .95rem !important;
+  font-size: .74rem;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--olive);
+}
+
+.r-line {
+  display: flex;
+  align-items: baseline;
+  gap: .55rem;
+  padding: .12rem 0;
+}
+.r-line b { margin-left: auto; font-weight: 500; }
+.r-line i { font-style: normal; color: var(--ink-mute); font-size: .72rem; }
+.r-line .tick {
+  display: inline-block;
+  width: 1em;
+  color: var(--accent);
+}
+.r-line.done { color: var(--ink-mute); text-decoration: line-through; text-decoration-color: var(--rule-2); }
+.r-line.done b { text-decoration: line-through; text-decoration-color: var(--rule-2); }
+.r-line.adhoc b { margin-left: auto; }
+
+/* the "why": the thing no other list has */
+.r-why {
+  padding-left: 1.55rem;
+  font-size: .7rem;
+  color: var(--ink-mute);
+  font-style: italic;
+}
+
+.r-foot { font-size: .7rem; color: var(--ink-mute); }
+
+/* ── bands ──────────────────────────────────────────────────────────── */
+
+.band {
+  max-width: var(--page);
+  margin: 0 auto;
+  padding: clamp(3.5rem, 8vw, 6.5rem) clamp(1.2rem, 4vw, 3rem);
+  border-top: 1px solid var(--rule);
+}
+
+.section-kicker {
+  font-family: var(--mono);
+  font-size: .72rem;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 1rem;
+}
+
+.section-title {
+  font-size: clamp(1.9rem, 4vw, 3rem);
+  max-width: 18em;
+  text-wrap: balance;
+}
+.section-title.big { font-size: clamp(2.1rem, 5vw, 3.6rem); }
+
+.band-lede {
+  margin: 1.5rem 0 0;
+  font-size: 1.08rem;
+  color: var(--ink-soft);
+  max-width: 46em;
+}
+.centred { margin-left: auto; margin-right: auto; text-align: center; justify-content: center; }
+
+/* ── cards ──────────────────────────────────────────────────────────── */
+
+.cards {
+  margin-top: 3rem;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  background: var(--rule);
+  border: 1px solid var(--rule);
+}
+
+.card {
+  position: relative;
+  background: var(--paper);
+  padding: 2.2rem 1.9rem 2rem;
+  transition: background .25s;
+}
+.card:hover { background: var(--paper-2); }
+
+.card .num {
+  font-family: var(--mono);
+  font-size: .74rem;
+  color: var(--accent);
+  letter-spacing: .1em;
+}
+
+.card h3 {
+  font-size: 1.42rem;
+  margin: .7rem 0 .9rem;
+  max-width: 15em;
+}
+.card h3 em { color: var(--accent); }
+
+.card p {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: .96rem;
+}
+
+/* ── dark band ──────────────────────────────────────────────────────── */
+
+.band.dark {
+  max-width: none;
+  background: var(--ink);
+  color: var(--paper);
+  border: 0;
+  margin-top: 0;
+  padding-left: max(clamp(1.2rem, 4vw, 3rem), calc(50vw - var(--page) / 2));
+  padding-right: max(clamp(1.2rem, 4vw, 3rem), calc(50vw - var(--page) / 2));
+}
+.band.dark .section-kicker { color: #e8a08c; }
+.band.dark .band-lede { color: rgba(242, 237, 227, .74); }
+.band.dark .mono { background: rgba(242, 237, 227, .12); }
+
+.split {
+  margin-top: 3rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: clamp(1.5rem, 4vw, 3.5rem);
+  align-items: start;
+}
+
+/* chat */
+.chat {
+  border: 1px solid rgba(242, 237, 227, .18);
+  border-radius: 4px;
+  padding: 1.4rem;
+  background: rgba(242, 237, 227, .04);
+}
+.chat-turn {
+  margin: 0 0 1.2rem;
+  font-size: .95rem;
+  line-height: 1.55;
+}
+.chat-turn:last-child { margin-bottom: 0; }
+.chat-turn > span:first-child {
+  display: block;
+  font-family: var(--mono);
+  font-size: .68rem;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: rgba(242, 237, 227, .45);
+  margin-bottom: .4rem;
+}
+.chat-turn.you { color: rgba(242, 237, 227, .95); font-style: italic; }
+.chat-turn.ai { color: rgba(242, 237, 227, .74); }
+.tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .4rem;
+  margin-bottom: .7rem;
+}
+.tools b {
+  font-family: var(--mono);
+  font-size: .72rem;
+  font-weight: 400;
+  color: #a8c48f;
+  border: 1px solid rgba(168, 196, 143, .35);
+  border-radius: 999px;
+  padding: .12rem .6rem;
+}
+.tools b::before { content: "✓ "; }
+
+/* points */
+.ai-points { display: grid; gap: 1.5rem; }
+.pt { border-left: 2px solid rgba(242, 237, 227, .2); padding-left: 1.1rem; }
+.pt:first-child { border-left-color: var(--accent); }
+.pt h4 { font-size: 1.08rem; font-weight: 600; margin-bottom: .35rem; }
+.pt p { margin: 0; font-size: .92rem; color: rgba(242, 237, 227, .68); }
+
+/* ── terminal ───────────────────────────────────────────────────────── */
+
+.terminal {
+  margin-top: 3rem;
+  border-radius: 5px;
+  overflow: hidden;
+  background: #100f0e;
+  border: 1px solid rgba(242, 237, 227, .16);
+}
+.terminal.light {
+  background: var(--ink);
+  border-color: var(--rule-2);
+  box-shadow: 0 14px 28px rgba(27, 25, 23, .13);
+}
+
+.t-bar {
+  display: flex;
+  align-items: center;
+  gap: .4rem;
+  margin: 0;
+  padding: .6rem .9rem;
+  background: rgba(242, 237, 227, .07);
+  border-bottom: 1px solid rgba(242, 237, 227, .1);
+}
+.t-bar i { width: 9px; height: 9px; border-radius: 50%; background: rgba(242, 237, 227, .22); }
+.t-bar span {
+  margin-left: .6rem;
+  font-family: var(--mono);
+  font-size: .7rem;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: rgba(242, 237, 227, .4);
+}
+
+.terminal pre {
+  margin: 0;
+  padding: 1.3rem 1.2rem;
+  overflow-x: auto;
+  font-family: var(--mono);
+  font-size: .84rem;
+  line-height: 1.85;
+  color: rgba(242, 237, 227, .9);
+}
+.terminal .c  { color: var(--accent); }
+.terminal .s  { color: #d9b26a; }
+.terminal .cm { color: rgba(242, 237, 227, .38); }
+.terminal .ok { color: #a8c48f; }
+
+.band-foot {
+  margin: 1.4rem 0 0;
+  font-size: .92rem;
+  color: rgba(242, 237, 227, .58);
+  max-width: 46em;
+}
+
+.run-note {
+  margin: 1.4rem 0 0;
+  font-size: .95rem;
+  color: var(--ink-soft);
+  max-width: 46em;
+}
+
+/* ── honest box ─────────────────────────────────────────────────────── */
+
+.honest {
+  position: relative;
+  margin-top: 3.5rem;
+  padding: 2.2rem 2rem 1.8rem;
+  background: var(--paper-2);
+  border: 1px solid var(--rule-2);
+  border-radius: 3px;
+  max-width: 46em;
+}
+.honest p { margin: 0 0 .9rem; color: var(--ink-soft); font-size: .98rem; }
+.honest p:last-child { margin-bottom: 0; }
+.honest b { color: var(--ink); }
+.honest .thin { font-size: .88rem; color: var(--ink-mute); }
+.honest a { color: var(--accent); text-underline-offset: 3px; }
+
+.stamp {
+  position: absolute;
+  top: -.85rem;
+  left: 1.6rem;
+  font-family: var(--mono);
+  font-size: .68rem !important;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  color: var(--accent) !important;
+  background: var(--paper);
+  border: 1px solid var(--accent);
+  border-radius: 2px;
+  padding: .18rem .6rem;
+  transform: rotate(-1.5deg);
+}
+
+/* ── close + footer ─────────────────────────────────────────────────── */
+
+.close { text-align: center; }
+.close .section-title { margin-inline: auto; }
+.close .cta { margin-top: 2rem; }
+
+footer {
+  border-top: 1px solid var(--rule);
+  padding: 2.5rem clamp(1.2rem, 4vw, 3rem) 3.5rem;
+  max-width: var(--page);
+  margin: 0 auto;
+  font-size: .88rem;
+  color: var(--ink-mute);
+}
+footer p { margin: 0 0 .5rem; max-width: 44em; }
+footer b { color: var(--ink); font-family: var(--display); font-weight: 600; }
+footer a { color: var(--ink-soft); text-underline-offset: 3px; }
+footer .thin { margin-top: 1.2rem; font-size: .82rem; }
+
+/* ── entrance ───────────────────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: no-preference) {
+  .hero-copy > *, .receipt-wrap {
+    animation: rise .8s var(--ease) both;
+  }
+  .hero-copy > *:nth-child(1) { animation-delay: .05s; }
+  .hero-copy > *:nth-child(2) { animation-delay: .12s; }
+  .hero-copy > *:nth-child(3) { animation-delay: .19s; }
+  .hero-copy > *:nth-child(4) { animation-delay: .26s; }
+  .hero-copy > *:nth-child(5) { animation-delay: .33s; }
+  .receipt-wrap { animation-delay: .3s; animation-name: rise-tilt; }
+
+  @keyframes rise {
+    from { opacity: 0; transform: translateY(14px); }
+    to   { opacity: 1; transform: none; }
+  }
+  @keyframes rise-tilt {
+    from { opacity: 0; transform: translateY(22px) rotate(3deg); }
+    to   { opacity: 1; transform: rotate(1.1deg); }
+  }
+}
+
+/* ── responsive ─────────────────────────────────────────────────────── */
+
+@media (max-width: 900px) {
+  .hero { grid-template-columns: 1fr; }
+  .receipt-wrap { max-width: 420px; }
+  .split { grid-template-columns: 1fr; }
+  .cards { grid-template-columns: 1fr; }
+  .masthead nav a:not(.ghost) { display: none; }
+}
+
+@media (max-width: 520px) {
+  body { font-size: 16px; }
+  .terminal pre { font-size: .72rem; padding: 1.1rem 1rem; }
+  .receipt-wrap { transform: none; margin-inline: auto; }
+  .honest { padding: 2rem 1.3rem 1.5rem; }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,259 @@
+<!doctype html>
+<html lang="en-GB">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Meals: a meal planner your own AI can drive</title>
+<meta name="description" content="Self-hosted recipe library, meal planner and aisle-sorted shopping list, with no LLM inside. It ships a REST API, an MCP server, and a playbook that teaches your assistant to use them.">
+<meta name="theme-color" content="#f2ede3">
+<meta property="og:title" content="Meals: a meal planner your own AI can drive">
+<meta property="og:description" content="Self-hosted. No built-in LLM. A REST API, an MCP server, and a playbook the server publishes about itself.">
+<meta property="og:type" content="website">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,800;1,9..144,400&family=Instrument+Sans:wght@400;500;600&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="assets/site.css">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🥬</text></svg>">
+</head>
+<body>
+<div class="grain" aria-hidden="true"></div>
+
+<header class="masthead">
+  <a class="wordmark" href="#top">Meals<span class="dot">.</span></a>
+  <nav>
+    <a href="#different">Why it's different</a>
+    <a href="#ai">The AI layer</a>
+    <a href="#run">Run it</a>
+    <a class="ghost" href="https://github.com/marco308/meals">GitHub&nbsp;↗</a>
+  </nav>
+</header>
+
+<main id="top">
+
+<!-- ───────────────────────────── hero ───────────────────────────── -->
+<section class="hero">
+  <div class="hero-copy">
+    <p class="eyebrow"><span>Self-hosted</span><span>AGPL</span><span>No LLM inside</span></p>
+    <h1>Plan the week's meals by&nbsp;talking to <em>your own</em> AI.</h1>
+    <p class="lede">
+      A recipe library, a meal planner and an aisle-sorted shopping list that
+      you run yourself. It has no AI in it. Instead it ships a documented REST
+      API, an MCP server, and a playbook that teaches <em>your</em> assistant
+      how to drive the whole thing.
+    </p>
+    <div class="cta">
+      <a class="btn" href="#run">Run it in two commands</a>
+      <a class="btn ghost" href="https://github.com/marco308/meals">Read the source</a>
+    </div>
+    <p class="footnote">
+      One command starts the whole stack. There is nothing to sign up for, and
+      no account of mine in the middle.
+    </p>
+  </div>
+
+  <!-- The receipt: aisle order, provenance, unit convention, check-off, all in one object. -->
+  <div class="receipt-wrap" aria-label="Example shopping list">
+    <div class="receipt">
+      <p class="r-head">Meals · Shopping list</p>
+      <p class="r-sub">This week's options · 5 dinners, 2 lunches</p>
+      <hr>
+      <p class="r-aisle">🥬 &nbsp;Produce</p>
+      <p class="r-line done"><span class="tick">✓</span> Carrots <b>500 g</b></p>
+      <p class="r-why">cottage pie · katsu curry</p>
+      <p class="r-line"><span class="tick"></span> Garlic <b>4 cloves</b></p>
+      <p class="r-aisle">🥩 &nbsp;Meat</p>
+      <p class="r-line done"><span class="tick">✓</span> Beef mince <b>750 g</b></p>
+      <p class="r-why">cottage pie</p>
+      <p class="r-aisle">🥫 &nbsp;Tins &amp; jars</p>
+      <p class="r-line"><span class="tick"></span> Chopped tomatoes <b>2 tins</b></p>
+      <p class="r-why">ragù · shakshuka</p>
+      <p class="r-aisle">🍞 &nbsp;Bakery</p>
+      <p class="r-line"><span class="tick"></span> Sourdough <b>1 loaf</b></p>
+      <p class="r-line"><span class="tick"></span> Bin bags <b>1</b></p>
+      <p class="r-why">added in the shop</p>
+      <hr>
+      <p class="r-foot">14 items · 4 in the trolley · sorted the way you walk the shop</p>
+    </div>
+  </div>
+</section>
+
+<!-- ─────────────────────────── differences ─────────────────────────── -->
+<section id="different" class="band">
+  <p class="section-kicker">Four decisions everything else follows from</p>
+  <h2 class="section-title">Not another Monday-to-Sunday grid.</h2>
+
+  <div class="cards">
+    <article class="card">
+      <span class="num">01</span>
+      <h3>A plan is a pool, not a calendar</h3>
+      <p>
+        A week is a <em>set of options</em> grouped by slot: five dinners you'd
+        be happy to cook, in no particular order. No days, no dates. A takeaway
+        on Tuesday or an unexpected trip breaks precisely nothing, because
+        nothing was ever pinned to Tuesday.
+      </p>
+    </article>
+
+    <article class="card">
+      <span class="num">02</span>
+      <h3>The shopping list knows <em>why</em></h3>
+      <p>
+        Every line remembers which meals put it there. Add a second recipe that
+        needs carrots and the quantities merge; drop one meal and only its share
+        disappears, leaving the rest of the line intact, and leaving what's
+        already ticked, ticked. Units merge only on an exact match, so 500&nbsp;g
+        never silently becomes half a bag.
+      </p>
+    </article>
+
+    <article class="card">
+      <span class="num">03</span>
+      <h3>It works with no signal at all</h3>
+      <p>
+        Supermarkets eat phone reception. Check-offs and quick adds render
+        instantly from a cached list, queue to disk, survive a relaunch, and
+        replay in order when you're back outside, with idempotent client ids so
+        a replayed action is never a double. The queue always drains.
+      </p>
+    </article>
+
+    <article class="card">
+      <span class="num">04</span>
+      <h3>It remembers what you actually cooked</h3>
+      <p>
+        Marking a meal cooked is recorded permanently, per recipe as well as
+        per meal, and survives deleting the plan it came from. The library
+        shows <span class="mono">cooked 12× · last May</span> and sorts by
+        <em>most cooked</em> or <em>not had in a while</em>, which is the
+        question you're actually asking on a Sunday.
+      </p>
+    </article>
+  </div>
+</section>
+
+<!-- ──────────────────────────── the AI layer ──────────────────────────── -->
+<section id="ai" class="band dark">
+  <p class="section-kicker">The headline</p>
+  <h2 class="section-title">There is no AI in this app.<br>That's the feature.</h2>
+  <p class="band-lede">
+    Every meal-planning app is busy bolting on a chatbot you didn't choose,
+    billed by a company that isn't you. This one ships the other half: a
+    complete API and the instructions for using it. Point whatever assistant you
+    already pay for at your own server, and it plans, ingests and shops on your
+    behalf.
+  </p>
+
+  <div class="split">
+    <div class="chat">
+      <p class="chat-turn you"><span>you</span>Add the recipe on this page for Friday, then tell me what I still need to buy.</p>
+      <p class="chat-turn ai"><span>assistant</span>
+        <span class="tools">
+          <b>ingest_recipe</b> <b>add_meal_to_plan</b> <b>get_shopping_list</b>
+        </span>
+        Added it to Friday's dinner options. You already have the flour and
+        eggs. You need 250&nbsp;g butter, 2 tins of chopped tomatoes and a
+        bunch of coriander. Everything's in produce except the butter.
+      </p>
+    </div>
+
+    <div class="ai-points">
+      <div class="pt">
+        <h4>21 task-level MCP tools</h4>
+        <p>Not a thin CRUD wrapper. Tools shaped like the job: <span class="mono">ingest_recipe</span>, <span class="mono">check_off</span>, <span class="mono">get_shopping_list</span>.</p>
+      </div>
+      <div class="pt">
+        <h4>The server publishes its own manual</h4>
+        <p><span class="mono">/skill</span> and <span class="mono">/prompt-pack</span> are served live, with your server's own URL already filled in.</p>
+      </div>
+      <div class="pt">
+        <h4>A stale copy knows it's stale</h4>
+        <p>The playbook carries a version stamp pinned to a content digest, so guidance can't change without the number moving, and an assistant holding an old copy can tell.</p>
+      </div>
+      <div class="pt">
+        <h4>Parse once, keep forever</h4>
+        <p>A recipe URL is read from the page's own structured data (free, no model call) and cached. Re-posting it returns the stored copy instead of a duplicate.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="terminal" role="img" aria-label="Command to connect an MCP client">
+    <p class="t-bar"><i></i><i></i><i></i><span>connect your assistant</span></p>
+<pre><code><span class="c">$</span> claude mcp add --transport http meals https://your-server/mcp \
+      --header <span class="s">"Authorization: Bearer meals_…"</span>
+
+<span class="ok">✓</span> connected · 21 tools · playbook v6</code></pre>
+  </div>
+  <p class="band-foot">
+    The remote MCP server holds no credentials of its own: it forwards each
+    caller's own token to the API, so everyone connecting acts as themselves.
+    Prefer no MCP at all? <span class="mono">/prompt-pack</span> plus a token is
+    enough for any assistant that can make an HTTP request.
+  </p>
+</section>
+
+<!-- ───────────────────────────── run it ───────────────────────────── -->
+<section id="run" class="band">
+  <p class="section-kicker">Your kitchen, your server</p>
+  <h2 class="section-title">Two commands and a cup of tea.</h2>
+
+  <div class="terminal light">
+    <p class="t-bar"><i></i><i></i><i></i><span>quickstart</span></p>
+<pre><code><span class="c">$</span> make dev     <span class="cm"># Postgres + API on :8000, MCP on :8100</span>
+<span class="c">$</span> make seed    <span class="cm"># demo recipes, a plan, a ready-made list</span></code></pre>
+  </div>
+  <p class="run-note">
+    No Docker? <span class="mono">make run</span> starts the API on SQLite with
+    no services at all. The seed prints working credentials and an API token you
+    can hand straight to an assistant. There's an iPhone app in the repo too:
+    offline-first, built from source.
+  </p>
+
+  <div class="honest">
+    <p class="stamp">Read this bit</p>
+    <p>
+      <b>meals.marcuslab.uk is my household's private instance, not a free
+      public service.</b> Registration on it is closed, and it's someone's
+      actual dinner in there. Self-hosting is the supported way to use this.
+      It's AGPL, it costs nothing, and the two commands above get you the whole
+      stack. If you'd rather I hosted it for you, that's a paid arrangement:
+      open an issue and ask.
+    </p>
+    <p class="thin">
+      The <a href="https://meals.marcuslab.uk/skill">/skill</a> and
+      <a href="https://meals.marcuslab.uk/prompt-pack">/prompt-pack</a>
+      endpoints stay open to everyone, because they're documentation. Read mine
+      to see the shape of them.
+    </p>
+  </div>
+</section>
+
+<!-- ───────────────────────────── closing ───────────────────────────── -->
+<section class="band close">
+  <h2 class="section-title big">Built for one household.<br>Written so it works for yours.</h2>
+  <p class="band-lede centred">
+    Every decision has a number and a reason written down: why plans have no
+    days, why every quantity is metric or a count of a natural unit, why the
+    offline queue is exempt from the version gate. The decisions log is in the
+    repo, and the code cites it.
+  </p>
+  <div class="cta centred">
+    <a class="btn" href="https://github.com/marco308/meals">Read the source</a>
+    <a class="btn ghost" href="https://github.com/marco308/meals/blob/main/planning/04-open-questions.md">The decisions log</a>
+  </div>
+</section>
+
+</main>
+
+<footer>
+  <p><b>Meals</b> · © 2026 Marcus Williams.</p>
+  <p>
+    Backend, MCP server and skill under
+    <a href="https://github.com/marco308/meals/blob/main/LICENSE">AGPL-3.0</a>.
+    The iOS app is source-available: read it, build it, run it on your own
+    devices.
+  </p>
+  <p class="thin">Issues and pull requests welcome. Vulnerabilities go through SECURITY.md, not a public issue.</p>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
**Draft, and knowingly unfinished.** The page is real and deployable, but it needs a proper pass before it should go anywhere near a Show HN. Opening it so the work isn't lost.

A single static page under `docs/`, hand-written, no build step and no Jekyll. Point Settings to Pages from `main` and `/docs` and it serves at `marco308.github.io/meals`.

## What it says

The README has to serve contributors and strangers at once, so it hedges. A landing page only has to sell, which is what lets the README stay technical. The pitch here leads with the differentiator rather than the feature list:

- **"There is no AI in this app. That's the feature."** No built-in LLM, 21 task-level MCP tools, `/skill` and `/prompt-pack` served live, and the version stamp pinned to a content digest so a stale copy knows it's stale.
- **Four product decisions** as a 2x2: plans are pools not calendars, the list knows why each item is on it, the offline queue always drains, and cooked history survives the plan it came from.
- **Two-command quickstart**, and the private-instance disclaimer kept prominent rather than buried, since arriving expecting a hosted service is the main way a visitor bounces.

Visually it commits to a kitchen-paper look: warm stock, Fraunces headlines, one tomato accent, and a printed receipt as the hero object. The receipt carries aisle order, the provenance line under each item, ticked state and the metric/natural-unit convention in one glance.

Checked at 1440 and 375: no horizontal overflow, cards form a clean 2x2, long commands scroll inside the terminal block rather than the page. `21 tools · playbook v6` is read from the real `PLAYBOOK_VERSION`, not invented.

## What it still needs

- **Screenshots of the iPhone app.** The receipt is a CSS mock and reads as one. There is currently no picture of the actual app anywhere, and for a self-hosted project that is the single biggest gap.
- **A demo recording.** The AI layer is the whole pitch and the page only describes it. A short clip of "add this recipe URL, build a plan, what do I need to buy" would sell it far better than the prose does.
- **`og:image`**, so links unfurl as something other than plain text.
- **A domain decision.** It is on the default Pages URL. A `CNAME` file and a DNS record if it should live under `marcuslab.uk`.
- **Copy review.** Written in one pass; the four cards in particular could be tighter.

## Not in this PR

- [#8](https://github.com/marco308/meals/issues/8) MCP OAuth and [#9](https://github.com/marco308/meals/issues/9) Postgres backups were filed alongside this. Both are prerequisites for pointing real traffic at the project: without OAuth the claude.ai audience bounces at the connect screen, and without backups the first thing a new self-hoster asks has no answer.
- The repo-wide em dash sweep. `docs/` is clean, and so are the two issues above, but roughly 500 remain across the rest of the repo. Note that `skill/SKILL.md` and `skill/prompt-pack.md` can't be edited without bumping the playbook version and the pinned digest, so that one is a real decision rather than a formatting change.
