### PR TITLE
Fold duplicate ingredient names to one identity (Q21)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -27,6 +27,8 @@ tail plus engineering debt worth naming.
 - [ ] **Servings scaling** — scale a recipe's quantities when adding to a meal ("×2 for batch cooking"); skill/prompt pack tells AIs to confirm scaling, the API has no first-class support
 - [ ] **Archived shopping lists in iOS** — API has `GET /shopping-list/archived`; no screen for "what did we buy last week"
 - [ ] **Re-parse endpoint** — refresh a cached recipe from its URL on demand (edits win; needs an explicit force flag)
+- [ ] **Duplicate ingredients in iOS** — `GET /ingredients/duplicates` and the merge endpoint clean the catalogue up (Q21), and the MCP exposes both, but the app has no screen for it: today the tidy-up only happens if you ask an AI
+- [ ] **One ingredient, two units on the list** — folding names (Q21) makes "mint" one ingredient, but "1 bunch" and "10 g" are still two lines, because merging is exact-unit-only by design (Q2). Converting bunches to grams means guessing at densities, which is the wrong fix; grouping an ingredient's lines together in the iOS list is the right one
 - [ ] **Premium/budget browse screen in iOS** — `GET /ingredients?value_tier=premium` and the MCP `list_ingredients_by_value` read the tagged set back (Q17); the app only shows a tier on ingredients you happen to open
 - [ ] **iOS offline breadth** — plan and recipe library are online-only by design (Q11); cache read-only copies so the whole app opens signal-less
 - [x] ~~**Remote MCP multi-user auth**~~ — ✅ shipped (issue #6): the stack serves streamable HTTP at `https://meals.marcuslab.uk/mcp` and forwards each caller's own bearer PAT per request; stdio stays for local dev
@@ -47,5 +49,6 @@ tail plus engineering debt worth naming.
 - [ ] **CD** — deploys are still `make deploy` from a laptop. GitHub-hosted runners can't reach the homelab, so this needs either a self-hosted runner on the swarm or a Tailscale OAuth step in the workflow
 - [ ] **Image pipeline** — images are built on the swarm node by hand; a registry (or at least a pinned tag scheme) would make rollbacks sane
 - [ ] **Rate limiting is per-process in-memory** — fine for one replica; revisit if the API ever scales out
-- [ ] **Ingredient-line parser tail** — "1 garlic clove crushed" style lines parse with the container word in the name; the AI-cleanup path covers it, but the regex could learn the `<n> <food> <unit>` shape
+- [x] ~~**Ingredient-line parser tail**~~ — ✅ the regex learned the `<n> <food> <unit>` shape (Q21): "3 garlic cloves" is now 3 cloves of garlic rather than ×3 of an ingredient called "garlic cloves", except where the last word is load-bearing ("2 bay leaves")
+- [ ] **Flaky provision password test** — `test_generated_passwords_are_typeable_and_not_guessable` asserts no `8` in the password while `_generate_password`'s alphabet contains one, so it fails roughly one run in four. Either drop `8` from the alphabet or from the ambiguous set; predates Q21 and is unrelated to it
 - [ ] **Demo/test data hygiene in prod** — if a smoke-test account was used during deploy verification, remove it (single shared household means it sees real data)

--- a/backend/app/routers/ingredients.py
+++ b/backend/app/routers/ingredients.py
@@ -6,10 +6,20 @@ from sqlalchemy import select
 
 from app.deps import CurrentUser, DbSession
 from app.models import Ingredient
-from app.schemas.catalog import IngredientOut, IngredientUpdate
+from app.schemas.catalog import (
+    DuplicateGroup,
+    DuplicatesOut,
+    IngredientOut,
+    IngredientUpdate,
+    MergeIn,
+    MergeOut,
+    UnfoldedIngredient,
+)
 from app.serializers import ingredient_out
 from app.services.aisles import AISLES, is_valid_aisle
 from app.services.catalog import get_or_create_ingredient
+from app.services.ingredient_merge import MergeError, find_duplicate_groups, find_unfolded, merge_ingredients
+from app.services.ingredient_names import canonical_ingredient_name
 from app.services.values import VALUE_TIER_HINT, is_valid_value_tier
 
 router = APIRouter(tags=["ingredients"])
@@ -40,17 +50,30 @@ async def list_ingredients(
     user: CurrentUser,
     db: DbSession,
     search: str | None = Query(default=None, max_length=200),
+    name: str | None = Query(
+        default=None,
+        max_length=200,
+        description="exact lookup, folded the same way a write is: name=fresh mint finds 'mint'",
+    ),
     staples_only: bool = Query(default=False),
     value_tier: str | None = Query(default=None, description=f"filter by buying advice; {VALUE_TIER_HINT}"),
 ) -> list[IngredientOut]:
     """Filter by `value_tier=premium` for the shopping list of things the
     household has decided are worth paying up for (and `budget` for the
-    own-brand-is-fine ones)."""
+    own-brand-is-fine ones).
+
+    `search` matches anywhere in the name. `name` is an exact lookup that
+    folds what you send the same way a write would, so `name=mint leaves`
+    finds the "mint" it was filed under — use it to resolve a name a user
+    said into the ingredient it belongs to, rather than guessing from a
+    substring hit."""
     if value_tier is not None and not is_valid_value_tier(value_tier):
         raise HTTPException(status_code=422, detail=f"unknown value tier '{value_tier}'; {VALUE_TIER_HINT}")
     query = select(Ingredient).where(Ingredient.household_id == user.household_id).order_by(Ingredient.name)
     if search:
         query = query.where(Ingredient.name.ilike(f"%{search.lower()}%"))
+    if name is not None:
+        query = query.where(Ingredient.name == canonical_ingredient_name(name))
     if staples_only:
         query = query.where(Ingredient.is_staple == True)  # noqa: E712
     if value_tier is not None:
@@ -82,6 +105,81 @@ async def create_ingredient(payload: IngredientCreate, user: CurrentUser, db: Db
         ingredient.value_note = payload.value_note.strip() or None
     await db.commit()
     return ingredient_out(ingredient)
+
+
+@router.get("/ingredients/duplicates", response_model=DuplicatesOut)
+async def list_duplicate_ingredients(user: CurrentUser, db: DbSession) -> DuplicatesOut:
+    """Ingredients in this household that are the same food under two names —
+    "mint" and "mint leaves", "garlic" and "garlic cloves".
+
+    New writes are folded to one name automatically, so what shows up here is
+    the catalogue as it was written before, plus anything an older client added.
+    Each group's first entry is the suggested keeper; collapse a group with
+    `POST /ingredients/{keeper_id}/merge`.
+
+    `unfolded` is the related single-row case: an ingredient whose name would
+    now be stored differently but that has no twin to merge with. To tidy one,
+    `POST /ingredients` with its `canonical_name` and merge the old row into
+    the ingredient that comes back.
+
+    Reported groups are name-folding facts, not guesses — two ingredients that
+    are really the same but share no wording ("beef mince" and "minced beef")
+    won't appear. Merge those directly if you know they match."""
+    groups = await find_duplicate_groups(db, user.household_id)
+    unfolded = await find_unfolded(db, user.household_id)
+    return DuplicatesOut(
+        groups=[
+            DuplicateGroup(
+                canonical_name=canonical_ingredient_name(group[0].name) or group[0].name,
+                keeper=ingredient_out(group[0]),
+                duplicates=[ingredient_out(other) for other in group[1:]],
+            )
+            for group in groups
+        ],
+        unfolded=[
+            UnfoldedIngredient(ingredient=ingredient_out(ingredient), canonical_name=canonical)
+            for ingredient, canonical in unfolded
+        ],
+    )
+
+
+@router.post("/ingredients/{ingredient_id}/merge", response_model=MergeOut)
+async def merge_into_ingredient(
+    ingredient_id: uuid.UUID, payload: MergeIn, user: CurrentUser, db: DbSession
+) -> MergeOut:
+    """Fold duplicate ingredients into this one, which survives.
+
+    Everything pointing at a duplicate — recipe lines, a meal's loose
+    ingredients, shopping-list lines and their contributions — is repointed
+    here, so nothing loses track of why it is on the list. List lines that end
+    up on the same (ingredient, unit) are combined, and a combined line is
+    only still ticked off if both halves were.
+
+    The keeper's aisle, staple flag and value tier are untouched: that
+    curation is the household's, not the merge's. This is not reversible —
+    the duplicate rows are deleted, not archived — so merge things that are
+    genuinely the same food, not things bought together."""
+    keeper = await db.get(Ingredient, ingredient_id)
+    if keeper is None or keeper.household_id != user.household_id:
+        raise HTTPException(status_code=404, detail="ingredient not found; list ingredients via GET /ingredients")
+    duplicates = []
+    for duplicate_id in payload.duplicate_ids:
+        duplicate = await db.get(Ingredient, duplicate_id)
+        if duplicate is None or duplicate.household_id != user.household_id:
+            raise HTTPException(
+                status_code=404,
+                detail=(
+                    f"ingredient {duplicate_id} not found; merge only folds ingredients this household "
+                    "owns — list them via GET /ingredients or GET /ingredients/duplicates"
+                ),
+            )
+        duplicates.append(duplicate)
+    try:
+        absorbed = await merge_ingredients(db, user.household_id, keeper, duplicates)
+    except MergeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    await db.commit()
+    return MergeOut(ingredient=ingredient_out(keeper), merged=absorbed)
 
 
 @router.patch("/ingredients/{ingredient_id}", response_model=IngredientOut)

--- a/backend/app/schemas/catalog.py
+++ b/backend/app/schemas/catalog.py
@@ -46,6 +46,34 @@ class IngredientUpdate(BaseModel):
         return _check_value_tier(value)
 
 
+class MergeIn(BaseModel):
+    duplicate_ids: list[uuid.UUID] = Field(min_length=1, max_length=50)
+
+
+class MergeOut(BaseModel):
+    ingredient: IngredientOut  # the survivor
+    merged: int  # how many duplicates were folded into it
+
+
+class DuplicateGroup(BaseModel):
+    canonical_name: str
+    keeper: IngredientOut  # the suggested survivor — merge the rest into this one
+    duplicates: list[IngredientOut]
+
+
+class UnfoldedIngredient(BaseModel):
+    """One ingredient whose stored name is not its canonical form, with no
+    twin to merge it with."""
+
+    ingredient: IngredientOut
+    canonical_name: str
+
+
+class DuplicatesOut(BaseModel):
+    groups: list[DuplicateGroup]
+    unfolded: list[UnfoldedIngredient]
+
+
 class RecipeLineOut(BaseModel):
     ingredient_id: uuid.UUID
     name: str

--- a/backend/app/services/aisles.py
+++ b/backend/app/services/aisles.py
@@ -5,6 +5,8 @@ get ❓ and the user's AI (or the user) assigns a tag via PATCH /ingredients.
 The emoji vocabulary is part of the published skill, so AIs use the same tags.
 """
 
+from app.services.wordforms import singularize_food
+
 # Store-walking order — the shopping list sorts by this.
 AISLES: list[tuple[str, str]] = [
     ("🥬", "Fruit & veg"),
@@ -360,16 +362,32 @@ _KEYWORDS: dict[str, str] = {
 }
 
 
+def _fold(text: str) -> str:
+    return " ".join(singularize_food(word) for word in text.lower().split())
+
+
+# Every keyword in its canonical word-form as well as as written, so a name
+# that has been through `canonical_ingredient_name` ("chopped tomato",
+# "bay leaf", "mixed berry") still finds the aisle its plural spelling would.
+_FOLDED_KEYWORDS: dict[str, str] = {_fold(keyword): emoji for keyword, emoji in _KEYWORDS.items()}
+
+
 def guess_aisle(ingredient_name: str) -> str:
     """Best-effort aisle for an ingredient name; ❓ when we don't know."""
     name = ingredient_name.lower().strip()
     if name in _KEYWORDS:
         return _KEYWORDS[name]
-    words = set(name.split())
+    folded = _fold(name)
+    if folded in _FOLDED_KEYWORDS:
+        return _FOLDED_KEYWORDS[folded]
+    words = set(name.split()) | set(folded.split())
     best: tuple[int, str] | None = None
     for keyword, emoji in _KEYWORDS.items():
         # multi-word keywords match as substrings, single words whole-word only
-        matched = keyword in name if " " in keyword else (keyword in words or singular_match(keyword, words))
+        if " " in keyword:
+            matched = keyword in name or _fold(keyword) in folded
+        else:
+            matched = keyword in words or singular_match(keyword, words) or singularize_food(keyword) in words
         if matched and (best is None or len(keyword) > best[0]):
             best = (len(keyword), emoji)
     return best[1] if best else UNKNOWN_AISLE

--- a/backend/app/services/catalog.py
+++ b/backend/app/services/catalog.py
@@ -9,14 +9,22 @@ from app.models import Ingredient, Recipe, RecipeIngredient
 from app.schemas.catalog import RecipeCreate
 from app.schemas.common import IngredientLineIn
 from app.services.aisles import guess_aisle
+from app.services.ingredient_names import canonical_ingredient_name
 from app.services.recipe_parser import ParsedRecipe
 
 
 async def get_or_create_ingredient(db: AsyncSession, household_id: uuid.UUID, name: str) -> Ingredient:
     """Ingredient names are the canonical key: 'chopped tomatoes' from two
     recipes resolves to one ingredient. New ingredients get a best-effort
-    aisle from the built-in lookup table."""
-    canonical = " ".join(name.lower().split())
+    aisle from the built-in lookup table.
+
+    Every write path — JSON-LD ingest, an AI's POST /recipes, a loose meal
+    ingredient, an ad-hoc list add — lands here, which is why the name folding
+    (Q21) belongs here and nowhere else: 'mint leaves' and 'mint' resolve to
+    one ingredient however they arrived."""
+    # The fallback matters for names that fold to nothing (","): a punctuation
+    # ingredient is bad data, an unnamed one breaks every client that shows it.
+    canonical = canonical_ingredient_name(name) or " ".join(name.lower().split())
     result = await db.execute(
         select(Ingredient).where(Ingredient.household_id == household_id, Ingredient.name == canonical)
     )

--- a/backend/app/services/ingredient_merge.py
+++ b/backend/app/services/ingredient_merge.py
@@ -1,0 +1,140 @@
+"""Folding duplicate ingredient rows together (decision Q21).
+
+`ingredient_names.canonical_ingredient_name` stops *new* duplicates arriving.
+This is the other half: finding the ones already in the household's catalogue
+and collapsing them, because an ingredient row is an identity that recipes,
+meals and shopping-list lines all point at — it cannot simply be renamed away.
+
+Detection is deliberately narrow. It reports only ingredients whose names fold
+to the same canonical form, which is a fact rather than a guess. Anything
+looser ("garlic" ⊂ "garlic bread") would propose merges that silently change
+what someone buys, so the judgement calls stay with the household's AI, which
+can call `merge_ingredients` on anything the table was too cautious to claim.
+"""
+
+import uuid
+from collections import defaultdict
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Ingredient, ListItem, ListItemSource, MealIngredient, RecipeIngredient
+from app.services.ingredient_names import canonical_ingredient_name
+
+
+class MergeError(ValueError):
+    """The merge was refused; the message says what to do instead."""
+
+
+async def find_duplicate_groups(db: AsyncSession, household_id: uuid.UUID) -> list[list[Ingredient]]:
+    """Groups of two or more ingredients that fold to the same canonical name,
+    keeper first. The keeper is the row already stored under the canonical
+    name if there is one, else the oldest — merging into the oldest keeps the
+    aisle and value tier somebody has most likely already curated."""
+    result = await db.execute(
+        select(Ingredient).where(Ingredient.household_id == household_id).order_by(Ingredient.created_at)
+    )
+    by_canonical: dict[str, list[Ingredient]] = defaultdict(list)
+    for ingredient in result.scalars():
+        by_canonical[canonical_ingredient_name(ingredient.name) or ingredient.name].append(ingredient)
+
+    groups = []
+    for canonical, members in by_canonical.items():
+        if len(members) < 2:
+            continue
+        members.sort(key=lambda i: (i.name != canonical, i.created_at))
+        groups.append(members)
+    groups.sort(key=lambda group: group[0].name)
+    return groups
+
+
+async def find_unfolded(db: AsyncSession, household_id: uuid.UUID) -> list[tuple[Ingredient, str]]:
+    """Ingredients stored under a name that predates the folding rules and has
+    no duplicate to merge with — "garlic cloves" when there is no "garlic".
+    Reported as `(ingredient, canonical name)` so a client can offer the
+    rename, which it performs as a merge into the canonical name."""
+    result = await db.execute(
+        select(Ingredient).where(Ingredient.household_id == household_id).order_by(Ingredient.name)
+    )
+    ingredients = list(result.scalars())
+    names = {ingredient.name for ingredient in ingredients}
+    unfolded = []
+    for ingredient in ingredients:
+        canonical = canonical_ingredient_name(ingredient.name)
+        if canonical and canonical != ingredient.name and canonical not in names:
+            unfolded.append((ingredient, canonical))
+    return unfolded
+
+
+async def merge_ingredients(
+    db: AsyncSession, household_id: uuid.UUID, keeper: Ingredient, duplicates: list[Ingredient]
+) -> int:
+    """Repoint every reference from `duplicates` onto `keeper` and delete them.
+
+    Returns the number of ingredients absorbed. The keeper's own aisle, staple
+    flag and value tier are left exactly as they are — those are the
+    household's curation (Q17) and the merge has no opinion about them.
+    """
+    absorbed = 0
+    for duplicate in duplicates:
+        if duplicate.household_id != household_id:
+            raise MergeError("ingredient not found in this household")
+        if duplicate.id == keeper.id:
+            continue
+        await _repoint(db, RecipeIngredient, duplicate.id, keeper.id)
+        await _repoint(db, MealIngredient, duplicate.id, keeper.id)
+        await _merge_list_items(db, duplicate.id, keeper.id)
+        await db.delete(duplicate)
+        absorbed += 1
+    await db.flush()
+    return absorbed
+
+
+async def _repoint(db: AsyncSession, model: type, from_id: uuid.UUID, to_id: uuid.UUID) -> None:
+    result = await db.execute(select(model).where(model.ingredient_id == from_id))
+    for row in result.scalars():
+        row.ingredient_id = to_id
+    await db.flush()
+
+
+async def _merge_list_items(db: AsyncSession, from_id: uuid.UUID, to_id: uuid.UUID) -> None:
+    """Move the duplicate's list lines onto the keeper, collapsing the ones
+    that now collide on (list, ingredient, unit) — the same identity the rest
+    of the shopping code merges on.
+
+    Contributions move rather than being recomputed, so the line still knows
+    *why* it is there (guiding principle 3) and its quantity stays the sum of
+    its sources. Shop state is combined pessimistically: a line is only still
+    ticked off if both halves were, so a need that was outstanding on either
+    side comes back to the top of the list rather than being quietly bought.
+    """
+    moving = await db.execute(
+        select(ListItem).where(ListItem.ingredient_id == from_id).execution_options(populate_existing=True)
+    )
+    for item in moving.scalars().all():
+        existing = await db.execute(
+            select(ListItem)
+            .where(
+                ListItem.list_id == item.list_id,
+                ListItem.ingredient_id == to_id,
+                ListItem.unit == item.unit,
+                ListItem.id != item.id,
+            )
+            .execution_options(populate_existing=True)
+        )
+        target = existing.scalars().first()
+        if target is None:
+            item.ingredient_id = to_id
+            continue
+        target.checked = target.checked and item.checked
+        target.excluded = target.excluded and item.excluded
+        target.staple_needed = target.staple_needed or item.staple_needed
+        sources = await db.execute(select(ListItemSource).where(ListItemSource.item_id == item.id))
+        for source in sources.scalars().all():
+            source.item_id = target.id
+        await db.flush()
+        # The collection was loaded before its rows moved away; without this
+        # the delete cascades them straight back out again.
+        await db.refresh(item, ["sources"])
+        await db.delete(item)
+    await db.flush()

--- a/backend/app/services/ingredient_names.py
+++ b/backend/app/services/ingredient_names.py
@@ -1,0 +1,215 @@
+"""Ingredient-name canonicalisation (decision Q21).
+
+The ingredient *name* is the identity key (one row per household per name), so
+two recipes describing the same food differently produce two ingredients and
+two shopping-list lines: "mint" and "mint leaves", "garlic" and "garlic
+cloves", "onion" and "onions".
+
+This module folds the mechanical differences away before the name is used as a
+key. It is deliberately in the same spirit as `aisles.py` (decision Q13): a
+table gets the easy cases for free, and the tail is handed to the household's
+AI — here via `GET /ingredients/duplicates` and `POST
+/ingredients/{id}/merge`. Unlike a value tier (Q17) a plural is not a matter of
+taste, so folding it automatically is safe.
+
+Three classes of difference are folded, and only three:
+
+1. **Prep and size adjectives** that don't change what you put in the trolley:
+   "fresh", "grated", "finely chopped", "large".
+2. **Form nouns** describing how much of the plant you were told to use:
+   "mint *leaves*", "garlic *cloves*", "*root* ginger".
+3. **Plurals**: "onions" → "onion".
+
+Everything that changes *which product you buy* is left alone: "ground"
+coriander is a different jar from coriander, "dried" oregano a different one
+from the growing pot, "smoked" paprika, "minced" beef, "red" onion, "whole"
+milk, "unsalted" butter. When in doubt a word stays — a missed merge is a
+cosmetic annoyance, a wrong merge silently changes someone's shopping.
+
+`_PROTECTED` is the backstop for names whose modifier *is* load-bearing even
+though the word appears in the strip list: "chopped tomatoes" is a tin, not a
+tomato. It is seeded from the multi-word entries in the aisle table — an
+ingredient specific enough to have earned its own aisle is by definition its
+own product — plus the extras below.
+
+The original wording is never lost: `RecipeIngredient.raw_text` keeps the line
+exactly as the recipe wrote it, which is what the recipe view shows.
+"""
+
+import re
+
+from app.services.aisles import _KEYWORDS
+from app.services.wordforms import singularize_food
+
+# Prep state and size. Stripped wherever they appear, unless frozen by a
+# protected phrase. See the module docstring for what is deliberately absent.
+_MODIFIERS: frozenset[str] = frozenset(
+    {
+        "fresh",
+        "freshly",
+        "finely",
+        "roughly",
+        "thinly",
+        "coarsely",
+        "chopped",
+        "diced",
+        "sliced",
+        "grated",
+        "crushed",
+        "peeled",
+        "trimmed",
+        "washed",
+        "rinsed",
+        "drained",
+        "halved",
+        "quartered",
+        "cubed",
+        "shredded",
+        "torn",
+        "beaten",
+        "melted",
+        "softened",
+        "large",
+        "small",
+        "medium",
+        "ripe",
+        "quality",
+        "good-quality",
+        "best-quality",
+        "room-temperature",
+    }
+)
+
+# "how much of the plant" words. Stripped only at the ends of the name, so
+# "cloves" (the spice) and "bay leaf" survive as names in their own right.
+_FORM_NOUNS: frozenset[str] = frozenset(
+    {
+        "leaf",
+        "clove",
+        "sprig",
+        "stalk",
+        "stick",
+        "bunch",
+        "head",
+        "bulb",
+        "fillet",
+        "root",
+    }
+)
+
+# Compounds whose modifier changes the product, beyond those the aisle table
+# already names. Write them the way a recipe would — a protected phrase is
+# stored under its own spelling, not folded to the singular.
+_EXTRA_PROTECTED: frozenset[str] = frozenset(
+    {
+        # Listing a phrase here also overrides the aisle table's spelling of
+        # it, because the longer spelling wins — which is how a product the
+        # aisle table happens to name in the singular still reaches the
+        # shopping list written the way it is bought.
+        "green beans",
+        "cherry tomatoes",
+        "stock cubes",
+        "sliced bread",
+        "crushed ice",
+        "grated cheese",
+        "grated parmesan",
+        "curry leaves",
+        "vine leaves",
+        "lime leaves",
+        "kaffir lime leaves",
+        "chopped nuts",
+        "large eggs",
+        "medium eggs",
+        "small eggs",
+        "spring greens",
+        "root vegetables",
+        "fresh yeast",
+        "fresh pasta",
+        "melted butter",
+    }
+)
+
+
+def _normalize_phrase(phrase: str) -> list[str]:
+    """Lowercase, split, and singularise every word — the form protected
+    phrases are stored in and candidate names are matched against."""
+    return [singularize_food(word) for word in phrase.lower().split()]
+
+
+def _build_protected() -> dict[tuple[str, ...], str]:
+    """Normalised phrase → the spelling it is stored under. "chopped tomato"
+    and "chopped tomatoes" both key to the tin, and both come back as
+    "chopped tomatoes" — folding a compound product to the singular would fix
+    the duplicate and ruin the shopping list ("2 tins chopped tomato")."""
+    phrases = {keyword for keyword in _KEYWORDS if " " in keyword} | set(_EXTRA_PROTECTED)
+    table: dict[tuple[str, ...], str] = {}
+    for phrase in sorted(phrases):
+        key = tuple(_normalize_phrase(phrase))
+        # Two spellings can normalise together ("bay leaf" and "bay leaves");
+        # the longer is the one recipes actually write.
+        if key not in table or len(phrase) > len(table[key]):
+            table[key] = phrase
+    return table
+
+
+_PROTECTED: dict[tuple[str, ...], str] = _build_protected()
+
+
+def is_protected_name(name: str) -> bool:
+    """True when the whole name is a compound whose modifier is load-bearing —
+    "bay leaves", "chopped tomatoes", "stock cubes". Callers use it to leave
+    such names alone."""
+    return tuple(_normalize_phrase(name)) in _PROTECTED
+
+
+def _protected_span(words: list[str]) -> tuple[int, int] | None:
+    """The longest protected phrase appearing as a run of words, as a
+    [start, end) span. Words inside it are frozen; only words outside may be
+    stripped, so "fresh chopped tomatoes" loses "fresh" and keeps the tin."""
+    best: tuple[int, int] | None = None
+    for start in range(len(words)):
+        for end in range(len(words), start, -1):
+            span = tuple(words[start:end])
+            if span in _PROTECTED and (best is None or end - start > best[1] - best[0]):
+                best = (start, end)
+                break
+    return best
+
+
+def canonical_ingredient_name(name: str) -> str:
+    """Fold an ingredient name to the key form used for identity.
+
+    "3 garlic cloves" has already become "garlic cloves" by the time it gets
+    here; this turns it into "garlic". Returns the cleaned-but-unfolded name
+    when folding would leave nothing behind — "cloves" on its own is the spice.
+    """
+    cleaned = " ".join(name.lower().split()).strip(" .")
+    # Prep notes after a comma ("onions, finely chopped") — the JSON-LD parser
+    # already drops these, AI- and user-submitted names may not.
+    cleaned = cleaned.split(",")[0].strip()
+    cleaned = re.sub(r"\s*\(.*?\)\s*", " ", cleaned)
+    cleaned = " ".join(cleaned.split()).strip(" .")
+    if not cleaned:
+        return cleaned
+
+    words = [singularize_food(word) for word in cleaned.split()]
+    frozen = _protected_span(words)
+    if frozen == (0, len(words)):
+        return _PROTECTED[tuple(words)]
+
+    keep_from, keep_to = frozen if frozen is not None else (len(words), 0)
+
+    def is_frozen(index: int) -> bool:
+        return keep_from <= index < keep_to
+
+    # Carry the original index so the frozen span keeps its meaning after the
+    # modifiers have been dropped.
+    kept = [(i, word) for i, word in enumerate(words) if word not in _MODIFIERS or is_frozen(i)]
+    # Form nouns only at the ends, and never all of them: "clove" alone stays.
+    while len(kept) > 1 and kept[-1][1] in _FORM_NOUNS and not is_frozen(kept[-1][0]):
+        kept.pop()
+    while len(kept) > 1 and kept[0][1] in _FORM_NOUNS and not is_frozen(kept[0][0]):
+        kept.pop(0)
+
+    folded = tuple(word for _, word in kept) or tuple(words)
+    return _PROTECTED.get(folded, " ".join(folded))

--- a/backend/app/services/recipe_parser.py
+++ b/backend/app/services/recipe_parser.py
@@ -14,6 +14,7 @@ import httpx
 from bs4 import BeautifulSoup
 
 from app.config import get_settings
+from app.services.ingredient_names import is_protected_name
 from app.services.units import _UNIT_SYNONYMS, INGEST_CONVERSIONS, METRIC_UNITS, parse_number, singularize
 
 
@@ -235,60 +236,58 @@ def parse_iso8601_duration(value: str | None) -> int | None:
 # ---------------------------------------------------------------- ingredient lines
 
 _NUMBER_TOKEN = r"\d+(?:[./]\d+)?|[½⅓⅔¼¾⅕⅛]|\d+\s*[½⅓⅔¼¾⅕⅛]|\d+\s+\d/\d|\d+(?:\.\d+)?\s*[-–]\s*\d+(?:\.\d+)?"
+_NATURAL_UNIT_WORDS = {
+    "tin",
+    "tins",
+    "clove",
+    "cloves",
+    "bunch",
+    "bunches",
+    "sprig",
+    "sprigs",
+    "stick",
+    "sticks",
+    "slice",
+    "slices",
+    "rasher",
+    "rashers",
+    "fillet",
+    "fillets",
+    "leaf",
+    "leaves",
+    "pinch",
+    "pinches",
+    "dash",
+    "handful",
+    "handfuls",
+    "knob",
+    "sheet",
+    "sheets",
+    "ball",
+    "balls",
+    "sachet",
+    "sachets",
+    "jar",
+    "jars",
+    "pack",
+    "packs",
+    "packet",
+    "packets",
+    "block",
+    "blocks",
+    "head",
+    "heads",
+    "stalk",
+    "stalks",
+    "wedge",
+    "wedges",
+    "nest",
+    "nests",
+    "cube",
+    "cubes",
+}
 _UNIT_WORDS = sorted(
-    set(METRIC_UNITS)
-    | set(INGEST_CONVERSIONS)
-    | set(_UNIT_SYNONYMS)
-    | {
-        "tin",
-        "tins",
-        "clove",
-        "cloves",
-        "bunch",
-        "bunches",
-        "sprig",
-        "sprigs",
-        "stick",
-        "sticks",
-        "slice",
-        "slices",
-        "rasher",
-        "rashers",
-        "fillet",
-        "fillets",
-        "leaf",
-        "leaves",
-        "pinch",
-        "pinches",
-        "dash",
-        "handful",
-        "handfuls",
-        "knob",
-        "sheet",
-        "sheets",
-        "ball",
-        "balls",
-        "sachet",
-        "sachets",
-        "jar",
-        "jars",
-        "pack",
-        "packs",
-        "packet",
-        "packets",
-        "block",
-        "blocks",
-        "head",
-        "heads",
-        "stalk",
-        "stalks",
-        "wedge",
-        "wedges",
-        "nest",
-        "nests",
-        "cube",
-        "cubes",
-    },
+    set(METRIC_UNITS) | set(INGEST_CONVERSIONS) | set(_UNIT_SYNONYMS) | _NATURAL_UNIT_WORDS,
     key=len,
     reverse=True,
 )
@@ -345,11 +344,13 @@ def parse_ingredient_line(raw: str) -> ParsedIngredient:
         unit_token = (match.group("unit") or "").lower()
         rest = match.group("rest")
         if quantity is not None:
+            name = _clean_name(rest)
             if unit_token:
                 quantity, unit = _convert_unit(quantity, unit_token)
             else:
-                unit = "item"
-            return ParsedIngredient(raw=raw, name=_clean_name(rest), quantity=quantity, unit=unit)
+                name, lifted = _lift_trailing_unit(name)
+                unit = lifted or "item"
+            return ParsedIngredient(raw=raw, name=name, quantity=quantity, unit=unit)
 
     # Glued metric quantities: "500g beef" with no space
     glued = re.match(r"^\s*(\d+(?:\.\d+)?)\s*(g|kg|ml|l)\b\.?\s*(?:of\s+)?(?P<rest>.+)$", cleaned, re.IGNORECASE)
@@ -370,6 +371,29 @@ def _convert_unit(quantity: float, unit_token: str) -> tuple[float, str]:
         return round(quantity * factor, 3), canonical
     folded = _UNIT_SYNONYMS.get(unit_token, unit_token)
     return quantity, singularize(folded)
+
+
+def _lift_trailing_unit(name: str) -> tuple[str, str | None]:
+    """'garlic cloves' → ('garlic', 'clove'); returns (name, None) when there
+    is nothing to lift.
+
+    Recipe lines write the unit on either side of the food — "2 cloves garlic"
+    and "3 garlic cloves" mean the same shop. Only the first shape was
+    recognised, so the second stranded the container word in the *name* and
+    counted the food as `×3 items`. That is how one household ends up with
+    both "garlic" and "garlic cloves" on the same list, in units that can
+    never merge (decision Q2).
+
+    Never applied to a name whose last word is load-bearing: "2 bay leaves"
+    is two bay leaves, not two leaves of bay.
+    """
+    words = name.split()
+    if len(words) < 2:
+        return name, None
+    token = words[-1].lower()
+    if token not in _NATURAL_UNIT_WORDS or is_protected_name(name):
+        return name, None
+    return " ".join(words[:-1]), singularize(_UNIT_SYNONYMS.get(token, token))
 
 
 def _clean_name(name: str) -> str:

--- a/backend/app/services/wordforms.py
+++ b/backend/app/services/wordforms.py
@@ -1,0 +1,65 @@
+"""Word-form folding for food words (decision Q21).
+
+Shared by `ingredient_names` (which uses it to build the canonical identity
+key) and `aisles` (which must recognise a keyword in its canonical form —
+"chopped tomato" is still a tin). Kept apart from `units.singularize`, which
+only ever sees unit words and so mangles "tomatoes" into "tomatoe", and kept
+in its own module so the two importers don't form a cycle.
+"""
+
+# Words that merely look plural: singularising them produces nonsense
+# ("molasse") or a different food ("green" for spring greens). The -us/-ss/-is
+# endings are handled by rule, so this only needs the exceptions to the rules.
+_NEVER_SINGULAR: frozenset[str] = frozenset({"molasses", "greens", "grits"})
+
+# Foods English only ever names in the plural. Canonicalising *to* the plural
+# rather than away from it keeps "green beans" reading like food, and keeps
+# both spellings landing on one key — which is the whole point.
+_ALWAYS_PLURAL: dict[str, str] = {
+    "bean": "beans",
+    "chickpea": "chickpeas",
+    "pea": "peas",
+    "lentil": "lentils",
+    "noodle": "noodles",
+    "oat": "oats",
+    "chip": "chips",
+    "crisp": "crisps",
+}
+
+_IRREGULAR_PLURALS: dict[str, str] = {
+    "leaves": "leaf",
+    "loaves": "loaf",
+    "halves": "half",
+    "potatoes": "potato",
+    "tomatoes": "tomato",
+    "mangoes": "mango",
+    "avocadoes": "avocado",
+    "chillies": "chilli",
+}
+
+
+def singularize_food(word: str) -> str:
+    """Fold a food word to its canonical number — singular, except for the
+    foods in `_ALWAYS_PLURAL`.
+
+    Distinct from `units.singularize`, which only ever sees unit words and so
+    mangles "tomatoes" into "tomatoe"."""
+    word = word.lower().strip()
+    folded = _singular(word)
+    return _ALWAYS_PLURAL.get(folded, folded)
+
+
+def _singular(word: str) -> str:
+    if word in _IRREGULAR_PLURALS:
+        return _IRREGULAR_PLURALS[word]
+    if word in _NEVER_SINGULAR or len(word) <= 3:
+        return word
+    if word.endswith(("ss", "us", "is", "sh", "ch")) or not word.endswith("s"):
+        return word
+    if word.endswith("ies"):
+        return word[:-3] + "y"
+    if word.endswith("oes"):
+        return word[:-2]
+    if word.endswith("es") and word[:-2].endswith(("ch", "sh", "ss", "x", "z")):
+        return word[:-2]
+    return word[:-1]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -129,3 +129,30 @@ def item_by_name(shopping_list: dict, name: str, unit: str | None = "any") -> di
         if item["name"] == name and (unit == "any" or item["unit"] == unit):
             return item
     return None
+
+
+@pytest.fixture
+async def legacy_ingredient(engine, auth_client):
+    """Insert an ingredient under a name the folding rules would no longer
+    produce (decision Q21).
+
+    The API canonicalises on the way in, so a pre-folding catalogue can only be
+    reproduced by writing the row directly — which is exactly what
+    `GET /ingredients/duplicates` exists to clean up.
+    """
+    from sqlalchemy import select
+
+    from app.models import Ingredient, User
+    from app.services.aisles import guess_aisle
+
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def insert(name: str) -> Ingredient:
+        async with maker() as session:
+            user = (await session.execute(select(User))).scalars().first()
+            ingredient = Ingredient(household_id=user.household_id, name=name, aisle=guess_aisle(name))
+            session.add(ingredient)
+            await session.commit()
+            return ingredient
+
+    return insert

--- a/backend/tests/integration/test_ingredients.py
+++ b/backend/tests/integration/test_ingredients.py
@@ -52,11 +52,11 @@ class TestIngredients:
 
     async def test_search_and_staples_filter(self, auth_client):
         await auth_client.post("/ingredients", json={"name": "salt", "is_staple": True})
-        await auth_client.post("/ingredients", json={"name": "saltimbocca herbs"})
+        await auth_client.post("/ingredients", json={"name": "salted butter"})
         await auth_client.post("/ingredients", json={"name": "milk"})
 
         search = await auth_client.get("/ingredients", params={"search": "salt"})
-        assert {i["name"] for i in search.json()} == {"salt", "saltimbocca herbs"}
+        assert {i["name"] for i in search.json()} == {"salt", "salted butter"}
 
         staples = await auth_client.get("/ingredients", params={"staples_only": "true"})
         assert [i["name"] for i in staples.json()] == ["salt"]
@@ -164,3 +164,203 @@ class TestValueTier:
         assert item["value_tier"] == "budget"
         assert item["value_tier_label"] == "Own-brand is fine"
         assert item["value_note"] == "own-brand cook down the same"
+
+
+class TestNameFolding:
+    """Names fold to one identity on the way in, whichever client writes them
+    (decision Q21)."""
+
+    async def test_variants_resolve_to_one_ingredient(self, auth_client):
+        first = await auth_client.post("/ingredients", json={"name": "garlic cloves"})
+        second = await auth_client.post("/ingredients", json={"name": "Fresh Garlic"})
+        assert first.json()["name"] == "garlic"
+        assert first.json()["id"] == second.json()["id"]
+
+    async def test_recipe_and_adhoc_paths_agree(self, auth_client):
+        """A recipe line and an ad-hoc add of the same food land on one row —
+        the whole point of folding at the single write choke point."""
+        recipe = await create_recipe(
+            auth_client, title="Summer rolls", ingredients=[{"name": "mint leaves", "quantity": 10, "unit": "g"}]
+        )
+        response = await auth_client.post(
+            "/shopping-list/items", json={"name": "fresh mint", "quantity": 1, "unit": "bunch"}
+        )
+        assert response.status_code == 201
+        assert recipe["ingredients"][0]["name"] == "mint"
+        assert response.json()["name"] == "mint"
+        assert response.json()["ingredient_id"] == recipe["ingredients"][0]["ingredient_id"]
+
+    async def test_recipe_line_keeps_what_the_recipe_wrote(self, auth_client):
+        """Folding is an identity decision, not an edit: the line still shows
+        the wording the recipe used."""
+        recipe = await create_recipe(
+            auth_client,
+            title="Summer rolls",
+            ingredients=[{"name": "mint leaves", "quantity": 10, "unit": "g", "raw": "10g mint leaves, torn"}],
+        )
+        assert recipe["ingredients"][0]["name"] == "mint"
+        assert recipe["ingredients"][0]["raw"] == "10g mint leaves, torn"
+
+
+class TestDuplicates:
+    """Finding and folding the rows that predate the naming rules (Q21)."""
+
+    async def test_finds_a_pre_folding_pair_and_names_the_keeper(self, auth_client, legacy_ingredient):
+        """The catalogue as it was written before folding: "garlic" and
+        "garlic cloves" as separate rows. The one already under the canonical
+        name is the suggested keeper."""
+        await auth_client.post("/ingredients", json={"name": "garlic"})
+        await legacy_ingredient("garlic cloves")
+        await legacy_ingredient("fresh garlic")
+
+        body = (await auth_client.get("/ingredients/duplicates")).json()
+        assert len(body["groups"]) == 1
+        group = body["groups"][0]
+        assert group["canonical_name"] == "garlic"
+        assert group["keeper"]["name"] == "garlic"
+        assert {d["name"] for d in group["duplicates"]} == {"garlic cloves", "fresh garlic"}
+
+    async def test_reports_a_lone_misnamed_row_as_unfolded(self, auth_client, legacy_ingredient):
+        """No twin to merge with, but the name is not the one it would get
+        today — a client can offer the tidy-up."""
+        await legacy_ingredient("mint leaves")
+
+        body = (await auth_client.get("/ingredients/duplicates")).json()
+        assert body["groups"] == []
+        assert len(body["unfolded"]) == 1
+        assert body["unfolded"][0]["ingredient"]["name"] == "mint leaves"
+        assert body["unfolded"][0]["canonical_name"] == "mint"
+
+    async def test_a_duplicate_group_is_not_also_reported_as_unfolded(self, auth_client, legacy_ingredient):
+        await auth_client.post("/ingredients", json={"name": "mint"})
+        await legacy_ingredient("mint leaves")
+
+        body = (await auth_client.get("/ingredients/duplicates")).json()
+        assert len(body["groups"]) == 1
+        assert body["unfolded"] == []
+
+    async def test_duplicates_are_scoped_to_the_household(self, auth_client, client, legacy_ingredient):
+        from tests.conftest import register
+
+        other = await register(client, email="someone@example.com", name="Someone")
+        await client.post("/ingredients", json={"name": "mint"}, headers={"Authorization": f"Bearer {other['token']}"})
+        await legacy_ingredient("mint leaves")
+
+        body = (await auth_client.get("/ingredients/duplicates")).json()
+        assert body["groups"] == []  # the other household's "mint" is not ours to merge with
+        assert [u["ingredient"]["name"] for u in body["unfolded"]] == ["mint leaves"]
+
+    async def test_reports_nothing_for_a_clean_catalogue(self, auth_client):
+        await auth_client.post("/ingredients", json={"name": "garlic"})
+        await auth_client.post("/ingredients", json={"name": "mint"})
+        response = await auth_client.get("/ingredients/duplicates")
+        assert response.status_code == 200
+        assert response.json() == {"groups": [], "unfolded": []}
+
+    async def test_merge_folds_recipes_meals_and_the_list(self, auth_client):
+        """The full repointing: a recipe line, a meal's loose ingredient and a
+        shopping-list line all follow the merge onto the survivor."""
+        keeper = (await auth_client.post("/ingredients", json={"name": "garlic"})).json()
+        duplicate = (await auth_client.post("/ingredients", json={"name": "unobtainium"})).json()
+
+        recipe = await create_recipe(
+            auth_client, title="Garlic bread", ingredients=[{"name": "unobtainium", "quantity": 3, "unit": "clove"}]
+        )
+        meal = await create_meal(
+            auth_client,
+            name="Garlic bread",
+            loose_ingredients=[{"name": "unobtainium", "quantity": 1, "unit": "bunch"}],
+        )
+        plan = await create_plan(auth_client)
+        await auth_client.post(f"/plans/{plan['id']}/meals", json={"meal_id": meal["id"]})
+
+        response = await auth_client.post(
+            f"/ingredients/{keeper['id']}/merge", json={"duplicate_ids": [duplicate["id"]]}
+        )
+        assert response.status_code == 200
+        assert response.json()["merged"] == 1
+        assert response.json()["ingredient"]["name"] == "garlic"
+
+        assert (await auth_client.get(f"/ingredients/{duplicate['id']}")).status_code == 404
+        fresh_recipe = (await auth_client.get(f"/recipes/{recipe['id']}")).json()
+        assert fresh_recipe["ingredients"][0]["ingredient_id"] == keeper["id"]
+        assert fresh_recipe["ingredients"][0]["name"] == "garlic"
+        shopping = await get_list(auth_client)
+        assert {item["name"] for item in shopping["items"]} == {"garlic"}
+
+    async def test_merge_combines_colliding_list_lines_and_their_sources(self, auth_client):
+        """Two lines in the same unit become one whose quantity is the sum, and
+        which still knows both meals it came from (guiding principle 3)."""
+        keeper = (await auth_client.post("/ingredients", json={"name": "garlic"})).json()
+        duplicate = (await auth_client.post("/ingredients", json={"name": "unobtainium"})).json()
+        await auth_client.post("/shopping-list/items", json={"name": "garlic", "quantity": 2, "unit": "clove"})
+        await auth_client.post("/shopping-list/items", json={"name": "unobtainium", "quantity": 3, "unit": "clove"})
+
+        await auth_client.post(f"/ingredients/{keeper['id']}/merge", json={"duplicate_ids": [duplicate["id"]]})
+
+        shopping = await get_list(auth_client)
+        garlic = item_by_name(shopping, "garlic", unit="clove")
+        assert garlic["quantity"] == 5
+        assert len(garlic["sources"]) == 2
+
+    async def test_merged_line_unchecks_when_either_half_was_outstanding(self, auth_client):
+        """A need that was still outstanding must not be quietly bought by the
+        merge."""
+        keeper = (await auth_client.post("/ingredients", json={"name": "garlic"})).json()
+        duplicate = (await auth_client.post("/ingredients", json={"name": "unobtainium"})).json()
+        ticked = (
+            await auth_client.post("/shopping-list/items", json={"name": "garlic", "quantity": 2, "unit": "clove"})
+        ).json()
+        await auth_client.post("/shopping-list/items", json={"name": "unobtainium", "quantity": 3, "unit": "clove"})
+        await auth_client.patch(f"/shopping-list/items/{ticked['id']}", json={"checked": True})
+
+        await auth_client.post(f"/ingredients/{keeper['id']}/merge", json={"duplicate_ids": [duplicate["id"]]})
+
+        shopping = await get_list(auth_client)
+        assert item_by_name(shopping, "garlic", unit="clove")["checked"] is False
+
+    async def test_merge_keeps_the_survivors_curation(self, auth_client):
+        """Aisle, staple and value tier are the household's decisions (Q17) —
+        the merge has no opinion about them."""
+        keeper = (
+            await auth_client.post(
+                "/ingredients", json={"name": "olive oil", "aisle": "🍝", "is_staple": True, "value_tier": "premium"}
+            )
+        ).json()
+        duplicate = (await auth_client.post("/ingredients", json={"name": "unobtainium", "aisle": "❓"})).json()
+
+        response = await auth_client.post(
+            f"/ingredients/{keeper['id']}/merge", json={"duplicate_ids": [duplicate["id"]]}
+        )
+        assert response.json()["ingredient"]["aisle"] == "🍝"
+        assert response.json()["ingredient"]["is_staple"] is True
+        assert response.json()["ingredient"]["value_tier"] == "premium"
+
+    async def test_merge_refuses_another_households_ingredient(self, auth_client, client):
+        """household_id is the only thing between two families' data."""
+        from tests.conftest import register
+
+        keeper = (await auth_client.post("/ingredients", json={"name": "garlic"})).json()
+        other = await register(client, email="someone@example.com", name="Someone")
+        outsider = await client.post(
+            "/ingredients", json={"name": "saffron"}, headers={"Authorization": f"Bearer {other['token']}"}
+        )
+        response = await auth_client.post(
+            f"/ingredients/{keeper['id']}/merge", json={"duplicate_ids": [outsider.json()["id"]]}
+        )
+        assert response.status_code == 404
+        assert "GET /ingredients" in response.json()["detail"]
+
+    async def test_merging_an_ingredient_into_itself_is_a_no_op(self, auth_client):
+        keeper = (await auth_client.post("/ingredients", json={"name": "garlic"})).json()
+        response = await auth_client.post(f"/ingredients/{keeper['id']}/merge", json={"duplicate_ids": [keeper["id"]]})
+        assert response.status_code == 200
+        assert response.json()["merged"] == 0
+        assert (await auth_client.get(f"/ingredients/{keeper['id']}")).status_code == 200
+
+    async def test_merge_unknown_keeper_404(self, auth_client):
+        response = await auth_client.post(
+            "/ingredients/00000000-0000-0000-0000-000000000000/merge",
+            json={"duplicate_ids": ["00000000-0000-0000-0000-000000000001"]},
+        )
+        assert response.status_code == 404

--- a/backend/tests/integration/test_misc.py
+++ b/backend/tests/integration/test_misc.py
@@ -136,8 +136,8 @@ class TestPublicPages:
 # Without this, guidance can ship under an unchanged number — which is exactly
 # what happened when the premium/budget tools landed on v1: a stale v1 copy
 # compared v1 to v1, found no drift, and never learned the tools existed.
-PINNED_PLAYBOOK_VERSION = 6
-PINNED_PLAYBOOK_DIGEST = "7db55983268bf26305753654beaebfdd5054060f7440374a8cb07cdf908a5fb4"
+PINNED_PLAYBOOK_VERSION = 7
+PINNED_PLAYBOOK_DIGEST = "908f38c4ffba53eb3ecb36ccb53cb3e7f022e180151fa1ada33e6c2717842298"
 
 _VERSION_STAMP = re.compile(r"<!--\s*playbook-version:\s*\d+\s*-->\n?")
 _VERSION_PROSE = re.compile(r"playbook v\d+", re.IGNORECASE)

--- a/backend/tests/unit/test_ingredient_names.py
+++ b/backend/tests/unit/test_ingredient_names.py
@@ -1,0 +1,150 @@
+"""Ingredient-name canonicalisation (decision Q21).
+
+The cases that matter are the ones this must *not* fold: a wrong merge changes
+what someone buys, a missed one only leaves two tidy lines next to each other.
+"""
+
+import pytest
+
+from app.services.aisles import guess_aisle
+from app.services.ingredient_names import canonical_ingredient_name, is_protected_name
+from app.services.wordforms import singularize_food
+
+
+class TestFolding:
+    @pytest.mark.parametrize(
+        ("written", "canonical"),
+        [
+            # The duplicates from the screenshot that started this
+            ("garlic cloves", "garlic"),
+            ("mint leaves", "mint"),
+            ("fresh coriander leaves", "coriander"),
+            ("grated ginger", "ginger"),
+            ("fresh root ginger", "ginger"),
+            ("ginger root", "ginger"),
+            # Prep and size adjectives
+            ("finely chopped parsley", "parsley"),
+            ("large onions", "onion"),
+            ("ripe avocados", "avocado"),
+            ("peeled king prawns", "king prawn"),
+            ("   Fresh   Mint  ", "mint"),
+            # Plurals
+            ("onions", "onion"),
+            ("tomatoes", "tomato"),
+            ("potatoes", "potato"),
+            ("chicken breasts", "chicken breast"),
+            ("red chillies", "red chilli"),
+            # Prep notes the parser would have stripped, from clients that don't
+            ("basil leaves, torn", "basil"),
+            ("olive oil (extra virgin)", "olive oil"),
+        ],
+    )
+    def test_folds(self, written, canonical):
+        assert canonical_ingredient_name(written) == canonical
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            # The modifier is the product: a different jar, tin or packet
+            "ground coriander",
+            "dried oregano",
+            "smoked paprika",
+            "minced beef",
+            "whole milk",
+            "unsalted butter",
+            "red onion",
+            "spring onion",
+            "coconut milk",
+            "baby spinach",
+            "extra virgin olive oil",
+            # Foods English only names in the plural
+            "hummus",
+            "asparagus",
+            "porridge oats",
+            "black beans",
+            "chickpeas",
+            "lentils",
+        ],
+    )
+    def test_leaves_alone(self, name):
+        assert canonical_ingredient_name(name) == name
+
+    @pytest.mark.parametrize(
+        ("written", "canonical"),
+        [
+            # A protected phrase keeps the spelling it is bought under, and
+            # both spellings land on it — that is the point of protecting it
+            ("chopped tomato", "chopped tomatoes"),
+            ("chopped tomatoes", "chopped tomatoes"),
+            ("fresh chopped tomatoes", "chopped tomatoes"),
+            ("bay leaf", "bay leaves"),
+            ("bay leaves", "bay leaves"),
+            ("green bean", "green beans"),
+            ("green beans", "green beans"),
+            ("large egg", "large eggs"),
+        ],
+    )
+    def test_protected_compounds_keep_their_own_name(self, written, canonical):
+        assert canonical_ingredient_name(written) == canonical
+        assert is_protected_name(canonical)
+
+    def test_a_name_is_never_folded_away_to_nothing(self):
+        # "cloves" the spice, not a count of garlic
+        assert canonical_ingredient_name("cloves") == "clove"
+        assert canonical_ingredient_name("fresh") == "fresh"
+        assert canonical_ingredient_name("") == ""
+
+    def test_folding_is_idempotent(self):
+        for name in ["garlic cloves", "chopped tomatoes", "large onions", "bay leaf", "fresh root ginger"]:
+            once = canonical_ingredient_name(name)
+            assert canonical_ingredient_name(once) == once
+
+
+class TestSingularizeFood:
+    @pytest.mark.parametrize(
+        ("plural", "singular"),
+        [
+            ("tomatoes", "tomato"),
+            ("potatoes", "potato"),
+            ("leaves", "leaf"),
+            ("chillies", "chilli"),
+            ("berries", "berry"),
+            ("cloves", "clove"),
+            ("breasts", "breast"),
+            ("hummus", "hummus"),
+            ("asparagus", "asparagus"),
+            ("watercress", "watercress"),
+            ("molasses", "molasses"),
+        ],
+    )
+    def test_singularizes(self, plural, singular):
+        assert singularize_food(plural) == singular
+
+    @pytest.mark.parametrize("word", ["beans", "peas", "lentils", "oats", "chips", "crisps", "chickpeas"])
+    def test_plural_only_foods_stay_plural_from_either_spelling(self, word):
+        assert singularize_food(word) == word
+        assert singularize_food(word.rstrip("s")) == word
+
+
+class TestAisleStillFound:
+    """Canonicalisation runs before `guess_aisle`, so every folded name must
+    still find the aisle its written form would have."""
+
+    @pytest.mark.parametrize(
+        ("written", "aisle"),
+        [
+            ("chopped tomatoes", "🥫"),
+            ("stock cubes", "🥫"),
+            ("bay leaves", "🌶️"),
+            ("mixed berries", "🥬"),
+            ("large onions", "🥬"),
+            ("garlic cloves", "🥬"),
+            ("chicken breasts", "🥩"),
+            ("frozen peas", "🧊"),
+            ("bin bags", "🧴"),
+            ("red chillies", "🥬"),
+        ],
+    )
+    def test_aisle_survives_folding(self, written, aisle):
+        assert guess_aisle(canonical_ingredient_name(written)) == aisle
+        assert guess_aisle(written) == aisle

--- a/backend/tests/unit/test_recipe_parser.py
+++ b/backend/tests/unit/test_recipe_parser.py
@@ -130,3 +130,43 @@ class TestParseIngredientLine:
         parsed = parse_ingredient_line("2 eggs (free range)")
         assert parsed.name == "eggs"
         assert parsed.quantity == 2
+
+
+class TestTrailingUnitWord:
+    """'<n> <food> <unit>' lines — the shape that used to leave the container
+    word in the name and count the food as items (decision Q21)."""
+
+    def test_lifts_the_unit_out_of_the_name(self):
+        parsed = parse_ingredient_line("3 garlic cloves, crushed")
+        assert (parsed.name, parsed.quantity, parsed.unit) == ("garlic", 3, "clove")
+
+    def test_both_orderings_now_agree(self):
+        """'2 cloves garlic' and '3 garlic cloves' are the same shop, so they
+        have to reach the list in the same unit or they can never merge (Q2)."""
+        before = parse_ingredient_line("2 cloves garlic")
+        after = parse_ingredient_line("3 garlic cloves")
+        assert (before.name, before.unit) == (after.name, after.unit) == ("garlic", "clove")
+
+    @pytest.mark.parametrize(
+        ("line", "name", "unit"),
+        [
+            ("6 basil leaves", "basil", "leaf"),
+            ("2 celery sticks", "celery", "stick"),
+            ("2 lemon wedges", "lemon", "wedge"),
+            ("1 large garlic clove", "large garlic", "clove"),
+        ],
+    )
+    def test_lifts_other_container_words(self, line, name, unit):
+        parsed = parse_ingredient_line(line)
+        assert (parsed.name, parsed.unit) == (name, unit)
+
+    @pytest.mark.parametrize("line", ["2 bay leaves", "4 lasagne sheets", "2 stock cubes"])
+    def test_never_lifts_a_load_bearing_last_word(self, line):
+        """Two bay leaves, not two leaves of bay."""
+        parsed = parse_ingredient_line(line)
+        assert parsed.unit == "item"
+        assert parsed.name == line.split(" ", 1)[1]
+
+    def test_leaves_a_stated_unit_alone(self):
+        parsed = parse_ingredient_line("10g mint leaves")
+        assert (parsed.quantity, parsed.unit) == (10, "g")

--- a/mcp/meals_mcp/server.py
+++ b/mcp/meals_mcp/server.py
@@ -32,7 +32,7 @@ from starlette.responses import PlainTextResponse, Response
 # they drift, and the backend suite fails if the guidance changes without a bump).
 # Instructions ship fresh on every connection, so this is the one channel that can
 # tell an assistant its installed skill snapshot has gone stale.
-PLAYBOOK_VERSION = 6
+PLAYBOOK_VERSION = 7
 
 mcp = FastMCP(
     "meals",
@@ -587,6 +587,12 @@ async def finish_shop() -> str:
 
 
 async def _find_ingredient(name: str) -> dict:
+    # Names are stored folded — "mint leaves" is filed under "mint" — so ask
+    # the API to apply the same folding to the lookup rather than guessing at
+    # a near miss here ("olive oil" must not resolve to "olive oil spray").
+    resolved = await _call("GET", "/ingredients", params={"name": name})
+    if resolved:
+        return resolved[0]
     ingredients = await _call("GET", "/ingredients", params={"search": name})
     exact = [i for i in ingredients if i["name"] == name.lower().strip()]
     if not exact:
@@ -653,6 +659,65 @@ async def list_ingredients_by_value(tier: str = "premium") -> str:
         return f"Nothing tagged '{tier}' yet — set_ingredient_value(name, '{tier}') records one."
     lines = [f"  {i['name']}" + (f" — {i['value_note']}" if i.get("value_note") else "") for i in ingredients]
     return f"Tagged '{tier}':\n" + "\n".join(lines)
+
+
+@mcp.tool()
+async def find_duplicate_ingredients() -> str:
+    """Find ingredients in the household's catalogue that are the same food
+    filed under two names — "mint" and "mint leaves", "garlic" and "garlic
+    cloves" — which is why the shopping list shows them as two lines.
+
+    New recipes and list additions are folded to one name automatically, so
+    this reports what was written before that, and anything the folding rules
+    are too cautious to claim. Fold a group with `merge_ingredients`. Worth
+    running before a big shop, or when the user says the list looks
+    repetitive."""
+    try:
+        report = await _call("GET", "/ingredients/duplicates")
+    except ApiError as exc:
+        return str(exc)
+    lines = []
+    for group in report["groups"]:
+        others = ", ".join(f"'{d['name']}'" for d in group["duplicates"])
+        lines.append(f"  '{group['keeper']['name']}' ← {others}")
+    for entry in report["unfolded"]:
+        lines.append(f"  '{entry['ingredient']['name']}' would now be filed as '{entry['canonical_name']}'")
+    if not lines:
+        return "No duplicate ingredients — every food in the catalogue is filed under one name."
+    return (
+        "Same food, more than one name:\n"
+        + "\n".join(lines)
+        + "\n\nmerge_ingredients(keep, duplicates=[...]) folds them together. Check with the "
+        "user before merging anything you are not sure is the same thing to buy."
+    )
+
+
+@mcp.tool()
+async def merge_ingredients(keep: str, duplicates: list[str]) -> str:
+    """Fold duplicate ingredients into one. `keep` is the name to keep — it
+    does not have to exist yet, which is how you also rename a lone badly-named
+    ingredient ("garlic cloves" → keep="garlic", duplicates=["garlic cloves"]).
+
+    Recipe lines, meals and shopping-list lines all follow the merge, and list
+    lines in the same unit are combined. The kept ingredient's aisle, staple
+    flag and buying advice are left alone.
+
+    This is not reversible, so only merge things that are the same thing to
+    buy. "beef mince" and "minced beef", yes. "garlic" and "garlic bread", no.
+    When the user has not asked for a specific merge, confirm it first."""
+    try:
+        keeper = await _call("POST", "/ingredients", json={"name": keep})
+        duplicate_ids = []
+        for name in duplicates:
+            found = await _find_ingredient(name)
+            if found["id"] != keeper["id"]:
+                duplicate_ids.append(found["id"])
+        if not duplicate_ids:
+            return f"Nothing to merge — '{keeper['name']}' is already the only name for it."
+        result = await _call("POST", f"/ingredients/{keeper['id']}/merge", json={"duplicate_ids": duplicate_ids})
+    except ApiError as exc:
+        return str(exc)
+    return f"Merged {result['merged']} into '{result['ingredient']['name']}' — one line on the list from now on."
 
 
 @mcp.custom_route("/healthz", methods=["GET"])

--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -1,3 +1,4 @@
+import json
 import re
 from pathlib import Path
 
@@ -217,11 +218,26 @@ class TestValueTier:
 
     @respx.mock
     async def test_unknown_ingredient_suggests_near_misses(self):
-        respx.get(f"{API}/ingredients").mock(
+        """A substring hit is not a match: 'olive oil spray' is a different
+        thing to buy, so the tool asks rather than tagging the wrong one."""
+        respx.get(f"{API}/ingredients", params={"name": "olive oil"}).mock(return_value=httpx.Response(200, json=[]))
+        respx.get(f"{API}/ingredients", params={"search": "olive oil"}).mock(
             return_value=httpx.Response(200, json=[self._ingredient(name="olive oil spray")])
         )
         result = await server.set_ingredient_value("olive oil", "premium")
         assert "olive oil spray" in result
+
+    @respx.mock
+    async def test_a_name_the_ingredient_is_filed_under_resolves(self):
+        """Names are stored folded, so 'mint leaves' has to find 'mint'."""
+        respx.get(f"{API}/ingredients", params={"name": "mint leaves"}).mock(
+            return_value=httpx.Response(200, json=[self._ingredient(name="mint")])
+        )
+        patch = respx.patch(f"{API}/ingredients/22222222-2222-2222-2222-222222222222").mock(
+            return_value=httpx.Response(200, json=self._ingredient(name="mint", value_tier="premium"))
+        )
+        await server.set_ingredient_value("mint leaves", "premium")
+        assert patch.called
 
     @respx.mock
     async def test_invalid_tier_passes_the_api_hint_through(self):
@@ -575,3 +591,71 @@ class TestPlaybookVersion:
         instructions = server.mcp.instructions or ""
         assert f"Playbook v{server.PLAYBOOK_VERSION}" in instructions
         assert "/skill" in instructions
+
+
+class TestDuplicateIngredients:
+    """Finding and folding same-food-two-names rows (decision Q21)."""
+
+    def _ingredient(self, name: str, ingredient_id: str):
+        return {
+            "id": ingredient_id,
+            "name": name,
+            "aisle": "🥬",
+            "aisle_label": "Fruit & veg",
+            "is_staple": False,
+            "value_tier": "any",
+            "value_tier_label": "No strong opinion",
+            "value_note": None,
+        }
+
+    @respx.mock
+    async def test_reports_groups_and_unfolded_names(self):
+        respx.get(f"{API}/ingredients/duplicates").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "groups": [
+                        {
+                            "canonical_name": "garlic",
+                            "keeper": self._ingredient("garlic", "1" * 32),
+                            "duplicates": [self._ingredient("garlic cloves", "2" * 32)],
+                        }
+                    ],
+                    "unfolded": [{"ingredient": self._ingredient("mint leaves", "3" * 32), "canonical_name": "mint"}],
+                },
+            )
+        )
+        result = await server.find_duplicate_ingredients()
+        assert "'garlic' ← 'garlic cloves'" in result
+        assert "'mint leaves' would now be filed as 'mint'" in result
+
+    @respx.mock
+    async def test_says_so_when_the_catalogue_is_clean(self):
+        respx.get(f"{API}/ingredients/duplicates").mock(
+            return_value=httpx.Response(200, json={"groups": [], "unfolded": []})
+        )
+        assert "No duplicate ingredients" in await server.find_duplicate_ingredients()
+
+    @respx.mock
+    async def test_merge_resolves_names_then_folds(self):
+        keeper = self._ingredient("garlic", "1" * 32)
+        respx.post(f"{API}/ingredients").mock(return_value=httpx.Response(201, json=keeper))
+        respx.get(f"{API}/ingredients", params={"name": "garlic cloves"}).mock(
+            return_value=httpx.Response(200, json=[self._ingredient("garlic cloves", "2" * 32)])
+        )
+        merge = respx.post(f"{API}/ingredients/{'1' * 32}/merge").mock(
+            return_value=httpx.Response(200, json={"ingredient": keeper, "merged": 1})
+        )
+        result = await server.merge_ingredients("garlic", ["garlic cloves"])
+        assert json.loads(merge.calls.last.request.content) == {"duplicate_ids": ["2" * 32]}
+        assert "Merged 1 into 'garlic'" in result
+
+    @respx.mock
+    async def test_merging_a_name_into_itself_says_so_without_calling_merge(self):
+        keeper = self._ingredient("garlic", "1" * 32)
+        respx.post(f"{API}/ingredients").mock(return_value=httpx.Response(201, json=keeper))
+        respx.get(f"{API}/ingredients", params={"name": "garlic cloves"}).mock(
+            return_value=httpx.Response(200, json=[keeper])
+        )
+        result = await server.merge_ingredients("garlic", ["garlic cloves"])
+        assert "Nothing to merge" in result

--- a/planning/04-open-questions.md
+++ b/planning/04-open-questions.md
@@ -163,3 +163,55 @@ requirements for an app that creates accounts, and neither existed. Decisions:
 - **Redeeming revokes every session token and returns a fresh one**, matching
   `POST /auth/password`. API tokens survive: rotating a password shouldn't
   silently break every AI client.
+
+**Q21 — Ingredient names are folded to one identity: yes** (2026-07-29,
+prompted by a shopping list showing "garlic" and "garlic cloves", "mint" and
+"mint leaves" as separate lines). An ingredient's *name* is its identity key,
+so two recipes describing the same food differently produced two ingredients
+and two lines that could never merge. Decisions:
+
+- **Fold at `get_or_create_ingredient`, not per client.** Every write path —
+  JSON-LD ingest, an AI's `POST /recipes`, a meal's loose ingredient, an ad-hoc
+  list add — already funnels through it. One place to fold means the answer is
+  the same however the food arrived, and no client has to know the rules.
+- **Fold only what doesn't change the shop.** Prep and size adjectives
+  ("fresh", "grated", "large"), the "how much of the plant" nouns ("mint
+  *leaves*", "garlic *cloves*", "*root* ginger") and plurals. Anything that
+  changes which product you buy stays: "ground" coriander, "dried" oregano,
+  "smoked" paprika, "minced" beef, "red" onion, "whole" milk. **A missed merge
+  is a cosmetic annoyance; a wrong merge silently changes someone's
+  shopping** — so when in doubt, the word stays.
+- **This is Q13's hybrid, not Q17's abstention.** Unlike "is the posh one worth
+  it", a plural is not a matter of household taste, so a table can settle it.
+  What the table won't claim ("beef mince" vs "minced beef") goes to the AI via
+  `GET /ingredients/duplicates` and `POST /ingredients/{id}/merge`, the same
+  shape as an ❓ aisle.
+- **Protected compounds keep the spelling they are bought under.** "chopped
+  tomatoes" is a tin, not a tomato, and folding it to the singular would fix a
+  duplicate while ruining the list ("2 tins chopped tomato"). Both spellings
+  key to one row and it is stored plural. The protected list is seeded from the
+  multi-word entries in the aisle table — an ingredient specific enough to have
+  earned its own aisle is by definition its own product.
+- **Detection reports facts, not guesses.** `GET /ingredients/duplicates` only
+  groups names that fold to the same string. Looser heuristics were considered
+  and rejected: "garlic" is a subset of "garlic bread", and same-aisle
+  proximity would have proposed exactly the merges that lose someone's dinner.
+- **Merging repoints, it does not recompute.** Recipe lines, loose meal
+  ingredients and list lines all move to the survivor, carrying their
+  `ListItemSource` rows, so a merged line still knows why it is there
+  (principle 3) and its quantity is still the sum of its sources. Colliding
+  lines combine their shop state pessimistically — ticked off only if *both*
+  halves were, so an outstanding need resurfaces rather than being quietly
+  bought.
+- **The survivor's curation is untouched.** Aisle, staple flag and value tier
+  are the household's decisions (Q17); a merge has no opinion about them.
+- **No migration, and no backfill on deploy.** Existing rows keep their names
+  and ids: a rewrite would change the identity of rows that iOS may hold
+  queued offline operations against (Q11). The catalogue is cleaned up
+  deliberately, through the merge endpoint, by someone who can see what they
+  are merging.
+- **Also fixed at the source: `<n> <food> <unit>`.** "3 garlic cloves" parsed
+  as `×3` of an ingredient called "garlic cloves" while "2 cloves garlic"
+  parsed correctly, so the same food arrived under two names *and* two units.
+  The parser now lifts a trailing container word into the unit, except where
+  it is load-bearing ("2 bay leaves" is not two leaves of bay).

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -3,7 +3,7 @@ name: meal-planner
 description: Plan meals and manage the shopping list through the Meals API/MCP. Use when the user shares recipe links, asks what to cook, wants to plan the week's meals, needs the shopping list, or says they're out of something. Covers recipe ingestion (including parsing pages the backend can't), building meal options, and shopping-mode check-offs.
 ---
 
-<!-- playbook-version: 6 -->
+<!-- playbook-version: 7 -->
 
 # Being a great meal-planning assistant
 
@@ -12,7 +12,7 @@ calendar), a recipe library, and an aisle-sorted shopping list that knows why
 every item is on it. Prefer the MCP tools when connected; otherwise use the
 REST API (OpenAPI at `/openapi.json`, auth via `Authorization: Bearer <PAT>`).
 
-**This is playbook v6, and this file is a snapshot** — once installed it never
+**This is playbook v7, and this file is a snapshot** — once installed it never
 updates itself. If a connected Meals MCP server names a higher playbook version
 in its instructions, or `GET {{API_URL}}/skill/version` reports one, this copy
 is stale: fetch `{{API_URL}}/skill`, follow the fresh copy for the rest of the
@@ -65,6 +65,16 @@ Extract and submit via `submit_recipe` / `POST /recipes`:
 - Ad-hoc items ("we're out of milk") go straight on with `add_to_list` — never
   create a meal for them.
 - "Already have onions" → `mark_already_have("onion")`, don't delete the line.
+- **Ingredient names are folded to one identity.** "mint leaves", "fresh mint"
+  and "mint" are one ingredient and one line; so are "garlic cloves" and
+  "garlic", and "onions" and "onion". You don't have to match existing
+  spellings — write the bare food and the server files it correctly.
+  Distinctions that change the product are kept, so don't flatten them
+  yourself: ground coriander is not coriander, dried oregano is not oregano,
+  minced beef is not beef. If the list still looks repetitive,
+  `find_duplicate_ingredients()` reports same-food-two-names rows and
+  `merge_ingredients(keep, duplicates=[...])` folds them — irreversible, so
+  confirm anything you aren't sure is the same thing to buy.
 - Staples (olive oil, salt…) are hidden by default. Before a shop, offer a
   staples check: `get_shopping_list(include_staples=true)`, then
   `need_staple(name)` for anything the user is low on — just that staple

--- a/skill/prompt-pack.md
+++ b/skill/prompt-pack.md
@@ -1,6 +1,6 @@
 # Meals prompt pack (portable)
 
-<!-- playbook-version: 6 -->
+<!-- playbook-version: 7 -->
 
 Paste this into any AI assistant's custom instructions to make it a good
 meal-planning assistant for your Meals server. (Claude-family tools can use
@@ -13,7 +13,7 @@ You help me plan meals and manage shopping through my Meals API at
 `Authorization: Bearer {{YOUR_API_TOKEN}}`. The full OpenAPI spec is at
 `{{API_URL}}/openapi.json` — fetch it if unsure about an endpoint.
 
-These instructions are playbook v6 and don't update themselves. If
+These instructions are playbook v7 and don't update themselves. If
 `{{API_URL}}/skill/version` reports a higher version, tell me — re-fetching
 `{{API_URL}}/prompt-pack` gets the current guidance.
 
@@ -38,6 +38,7 @@ Key endpoints:
 - `POST /shopping-list/items {name, quantity, unit, id}` — ad-hoc adds ("out of milk"); send a fresh UUID as `id` so retries are safe
 - `PATCH /shopping-list/items/{id}` with `{"checked": true}` (shopping), `{"excluded": true}` ("already have it" — never delete provenance), or `{"staple_needed": true}` (staples check: "I'm low" — surfaces that staple; `false` hides it again)
 - `POST /shopping-list/archive` after the shop · `PATCH /ingredients/{id}` to fix ❓ aisles, flag staples, or record premium-vs-budget advice
+- Ingredient names are folded to one identity on the way in: "mint leaves", "fresh mint" and "mint" are one ingredient and one line, as are "garlic cloves"/"garlic" and "onions"/"onion". Write the bare food and don't try to match existing spellings — but don't flatten distinctions that change the product either (ground coriander ≠ coriander, dried oregano ≠ oregano, minced beef ≠ beef). `GET /ingredients?name=mint%20leaves` resolves a name the user said to the row it's filed under. If the list still looks repetitive, `GET /ingredients/duplicates` reports same-food-two-names rows and `POST /ingredients/{keeper_id}/merge {"duplicate_ids": [...]}` folds them into one — irreversible, so confirm anything you aren't sure is the same thing to buy.
 - Premium vs budget: every ingredient carries `value_tier` — `"premium"` (⭐ worth paying up for), `"budget"` (💷 own-brand is fine) or `"any"` (no opinion, the default) — plus a one-line `value_note` reason. Set both with `PATCH /ingredients/{id} {"value_tier": "premium", "value_note": "the cheap stuff goes bitter"}`; read the tagged set back with `GET /ingredients?value_tier=premium`. Shopping-list items and recipe lines carry the tier and note, so mention them when reading the list back — that's the moment the decision gets made. Only save a tier the household has actually agreed to; suggest, don't assume.
 
 Habits: read lists back grouped by aisle; mention which meal needs an item


### PR DESCRIPTION
## What and why

The shopping list showed "garlic" and "garlic cloves", "mint" and "mint leaves", "coriander" and "fresh coriander leaves" as separate items. The ingredient name is the identity key, so two recipes describing the same food differently produced two ingredients and two lines that could never merge.

Four mechanical causes, all reproduced against the real parser before anything was changed:

```
'3 garlic cloves, crushed'        -> name='garlic cloves'           qty=3   unit='item'
'2 cloves garlic, finely chopped' -> name='garlic'                  qty=2   unit='clove'
'10g mint leaves'                 -> name='mint leaves'             qty=10  unit='g'
'1 bunch mint'                    -> name='mint'                    qty=1   unit='bunch'
'15g fresh coriander leaves'      -> name='fresh coriander leaves'  qty=15  unit='g'
'2 large onions, diced'           -> name='large onions'            qty=2   unit='item'
```

1. **Unit word trapped in the name.** `_LINE_RE` only recognised the `2 cloves garlic` shape (quantity, unit, then food), so "3 garlic cloves" became `×3` of an ingredient called "garlic cloves" while "2 cloves garlic" parsed correctly — the same food under two names *and* two units. This was the open `BACKLOG.md` item (the regex could learn the quantity-food-unit shape), now ticked off.
2. **Prep and size adjectives** survived into the name ("fresh", "grated", "large") — `_clean_name` only dropped notes after a comma.
3. **Form nouns** — "mint **leaves**", "**root** ginger".
4. **Plurals** — `get_or_create_ingredient` canonicalised with `lower()` + whitespace only, so "onions" and "onion" were two rows.

Fixed at the source: the parser now lifts a trailing container word into the unit, and the rest is folded in `canonical_ingredient_name`, applied at `get_or_create_ingredient` — the one choke point ingest, an AI's `POST /recipes`, loose meal ingredients and ad-hoc list adds all already funnel through, so they can't disagree.

**Where folding deliberately stops.** Anything that changes which product you buy is left alone: ground coriander, dried oregano, smoked paprika, minced beef, red onion, whole milk, unsalted butter. A missed merge is a cosmetic annoyance; a wrong merge silently changes someone's shopping. Compound products are protected by a table seeded from the multi-word aisle keywords and keep the spelling they are bought under — "chopped tomatoes", not "chopped tomato". `_lift_trailing_unit` respects the same list, so "2 bay leaves" is not two leaves of bay.

**For rows that predate the rules**, `GET /ingredients/duplicates` reports names that fold together and `POST /ingredients/{id}/merge` repoints recipe lines, loose meal ingredients and list lines onto the survivor — carrying their `ListItemSource` rows, so a merged line still knows why it is there, and combining shop state pessimistically (ticked off only if *both* halves were) so an outstanding need resurfaces rather than being quietly bought. Detection reports folding facts only; looser heuristics were rejected because "garlic" is a subset of "garlic bread". Existing rows are never rewritten in place, since iOS may hold queued offline ops against their ids (Q11) — no migration, no backfill on deploy.

Full reasoning is recorded as **decision Q21** in `planning/04-open-questions.md`.

### Also in here

- `GET /ingredients?name=` — exact lookup folded the same way a write is, so a name the user said resolves to the row it is filed under. An MCP test caught that resolving a lone near-miss client-side would have tagged "olive oil spray" as premium when asked about "olive oil"; this keeps the folding rules in one place instead.
- `guess_aisle` matches keywords in their folded form as well as as written, so no ingredient loses its aisle to canonicalisation (covered by a test that asserts both forms).
- MCP: `find_duplicate_ingredients` and `merge_ingredients`.
- Playbook **v7** — the full four-place ritual (both markdown stamps, `PLAYBOOK_VERSION`, and the pinned digest).

### Two things worth knowing

- **Mint still shows two lines.** Both are now the `mint` ingredient, but "1 bunch" and "10 g" stay separate because `ListItem` identity is `(list, ingredient, unit)` and merging is exact-unit-only by design (Q2). They share a name and sort adjacently. Converting bunches to grams means guessing densities — the wrong fix; grouping an ingredient's lines in the iOS list is the right one, and it is on the backlog rather than in this PR. Garlic *does* fully merge now, since both lines are `clove`.
- **Pre-existing flaky test**, untouched by this branch and backlogged: `test_generated_passwords_are_typeable_and_not_guessable` asserts no `8` appears while `_generate_password`'s alphabet contains one, so it fails roughly one run in four.

### Testing

`make lint` clean; `make test` green — 443 backend (up from 334) + 44 MCP. New coverage: `tests/unit/test_ingredient_names.py` (folding, the cases that must *not* fold, idempotence, and aisle survival), parser cases for the lifted unit word, and integration tests for detection, merge repointing, list-line collapsing, shop-state combination and household scoping.

## Checklist

- [x] **API contract stayed additive** — two new endpoints and one new optional query param; no response field removed or renamed, no new required request field, no tightened validation. `IngredientOut` is unchanged. Ingredient *names* differ for new writes, but they are free text that iOS renders, not a vocabulary value a decoder can trip over.
- [x] **Model change has a migration** — n/a, no schema change.
- [x] **Shopping-list quantities still derive from `ListItemSource`** — the merge moves source rows between items and never touches `ListItem.quantity`.
- [x] **Every new query filters on `household_id`** — both service functions take it as a parameter, and the merge re-checks each duplicate's household before repointing anything. A test asserts another household's ingredient is a 404.
- [x] **Skill/prompt pack updated** — both, plus the playbook version bump.
- [x] **New 4xx strings say what to do instead** — the merge 404 names `GET /ingredients` and `GET /ingredients/duplicates`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXPern9LamMtHALuuzDHzC