### PR TITLE
Return 422 for ingest fetch failures so the guidance survives proxies

### DIFF
--- a/backend/app/routers/recipes.py
+++ b/backend/app/routers/recipes.py
@@ -36,9 +36,10 @@ def _sort_order(sort: str) -> tuple:
 async def ingest_recipe_url(payload: IngestIn, user: CurrentUser, db: DbSession) -> IngestOut:
     """Submit a recipe URL. A URL already in the library returns the cached
     recipe instantly (parse once, reuse forever). New URLs are fetched and
-    parsed from their schema.org/Recipe JSON-LD — no LLM involved. Pages
-    without usable JSON-LD return 422 telling the calling AI to read the page
-    itself and submit the structured recipe via POST /recipes."""
+    parsed from their schema.org/Recipe JSON-LD — no LLM involved. Failure is
+    a 422 either way — the page has no usable JSON-LD, or this server couldn't
+    fetch it (bot-blocked, unreachable) — and the detail tells the calling AI
+    to read the page itself and submit the structured recipe via POST /recipes."""
     url = payload.url.strip()
     cached = await _find_by_url(db, user.household_id, url)
     if cached is not None:
@@ -47,7 +48,10 @@ async def ingest_recipe_url(payload: IngestIn, user: CurrentUser, db: DbSession)
     try:
         html = await recipe_parser.fetch_page(url)
     except RecipeFetchError as exc:
-        raise HTTPException(status_code=502, detail=str(exc)) from exc
+        # 422, not 502: proxies in front of a deployment (Cloudflare) replace
+        # origin 5xx bodies with their own error page, which would strip the
+        # read-the-page-yourself guidance — and that guidance is the product.
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
     try:
         parsed = recipe_parser.extract_recipe(html, url)
     except NoRecipeFound as exc:

--- a/backend/tests/integration/test_misc.py
+++ b/backend/tests/integration/test_misc.py
@@ -136,8 +136,8 @@ class TestPublicPages:
 # Without this, guidance can ship under an unchanged number — which is exactly
 # what happened when the premium/budget tools landed on v1: a stale v1 copy
 # compared v1 to v1, found no drift, and never learned the tools existed.
-PINNED_PLAYBOOK_VERSION = 7
-PINNED_PLAYBOOK_DIGEST = "908f38c4ffba53eb3ecb36ccb53cb3e7f022e180151fa1ada33e6c2717842298"
+PINNED_PLAYBOOK_VERSION = 8
+PINNED_PLAYBOOK_DIGEST = "36f6dd72ab5025558df78cb043cd11b2e6159672244c101baea9b3e14423559d"
 
 _VERSION_STAMP = re.compile(r"<!--\s*playbook-version:\s*\d+\s*-->\n?")
 _VERSION_PROSE = re.compile(r"playbook v\d+", re.IGNORECASE)

--- a/backend/tests/integration/test_recipes.py
+++ b/backend/tests/integration/test_recipes.py
@@ -104,7 +104,10 @@ class TestIngest:
         assert response.status_code == 422
         assert "POST /recipes" in response.json()["detail"]
 
-    async def test_fetch_failure_502_with_hint(self, auth_client, monkeypatch):
+    async def test_fetch_failure_422_keeps_the_hint(self, auth_client, monkeypatch):
+        """A 4xx, never a 5xx: proxies (Cloudflare) replace origin 5xx bodies
+        with their own page, so a 502's read-it-yourself hint never arrives."""
+
         async def failing_fetch(url: str) -> str:
             raise recipe_parser.RecipeFetchError(
                 f"fetching {url} failed with HTTP 403; if you can read the page yourself, "
@@ -113,7 +116,7 @@ class TestIngest:
 
         monkeypatch.setattr(recipe_parser, "fetch_page", failing_fetch)
         response = await auth_client.post("/recipes/ingest", json={"url": "https://example.com/blocked"})
-        assert response.status_code == 502
+        assert response.status_code == 422
         assert "POST /recipes" in response.json()["detail"]
 
     async def test_non_http_url_rejected(self, auth_client):

--- a/mcp/meals_mcp/server.py
+++ b/mcp/meals_mcp/server.py
@@ -32,7 +32,7 @@ from starlette.responses import PlainTextResponse, Response
 # they drift, and the backend suite fails if the guidance changes without a bump).
 # Instructions ship fresh on every connection, so this is the one channel that can
 # tell an assistant its installed skill snapshot has gone stale.
-PLAYBOOK_VERSION = 7
+PLAYBOOK_VERSION = 8
 
 mcp = FastMCP(
     "meals",
@@ -173,8 +173,9 @@ async def _resolve_recipes(terms: list[str]) -> list[dict]:
 @mcp.tool()
 async def ingest_recipe(url: str) -> str:
     """Add a recipe from a URL. Cached recipes return instantly; new pages are
-    parsed from their JSON-LD. If the page has no structured data, this tool
-    tells you to read the page yourself and call submit_recipe instead."""
+    parsed from their JSON-LD. If the page has no structured data, or the site
+    blocks the server's fetch, this tool tells you to read the page yourself
+    and call submit_recipe instead."""
     try:
         result = await _call("POST", "/recipes/ingest", json={"url": url})
     except ApiError as exc:

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -3,7 +3,7 @@ name: meal-planner
 description: Plan meals and manage the shopping list through the Meals API/MCP. Use when the user shares recipe links, asks what to cook, wants to plan the week's meals, needs the shopping list, or says they're out of something. Covers recipe ingestion (including parsing pages the backend can't), building meal options, and shopping-mode check-offs.
 ---
 
-<!-- playbook-version: 7 -->
+<!-- playbook-version: 8 -->
 
 # Being a great meal-planning assistant
 
@@ -12,7 +12,7 @@ calendar), a recipe library, and an aisle-sorted shopping list that knows why
 every item is on it. Prefer the MCP tools when connected; otherwise use the
 REST API (OpenAPI at `/openapi.json`, auth via `Authorization: Bearer <PAT>`).
 
-**This is playbook v7, and this file is a snapshot** — once installed it never
+**This is playbook v8, and this file is a snapshot** — once installed it never
 updates itself. If a connected Meals MCP server names a higher playbook version
 in its instructions, or `GET {{API_URL}}/skill/version` reports one, this copy
 is stale: fetch `{{API_URL}}/skill`, follow the fresh copy for the rest of the
@@ -37,8 +37,9 @@ conversation, and tell the user to replace their installed copy.
 
 1. `ingest_recipe(url)` for each link.
 2. If it succeeds — confirm the parse briefly (title, servings, anything odd).
-3. If it fails with "no JSON-LD": read the page yourself, extract the fields
-   in **the parsing contract** below, and `submit_recipe(...)`.
+3. If it fails — no JSON-LD on the page, or the site blocked the server's
+   fetch (your own fetch may still work fine): read the page yourself, extract
+   the fields in **the parsing contract** below, and `submit_recipe(...)`.
 4. Create a meal per recipe (`create_meal`) — ask about sides ("anything with
    it?") and attach them as loose ingredients, not fake recipes.
 5. Add the meals to the current plan (`add_meal_to_plan`); create the plan if

--- a/skill/prompt-pack.md
+++ b/skill/prompt-pack.md
@@ -1,6 +1,6 @@
 # Meals prompt pack (portable)
 
-<!-- playbook-version: 7 -->
+<!-- playbook-version: 8 -->
 
 Paste this into any AI assistant's custom instructions to make it a good
 meal-planning assistant for your Meals server. (Claude-family tools can use
@@ -13,7 +13,7 @@ You help me plan meals and manage shopping through my Meals API at
 `Authorization: Bearer {{YOUR_API_TOKEN}}`. The full OpenAPI spec is at
 `{{API_URL}}/openapi.json` — fetch it if unsure about an endpoint.
 
-These instructions are playbook v7 and don't update themselves. If
+These instructions are playbook v8 and don't update themselves. If
 `{{API_URL}}/skill/version` reports a higher version, tell me — re-fetching
 `{{API_URL}}/prompt-pack` gets the current guidance.
 
@@ -27,7 +27,7 @@ Quantity convention (the API rejects anything else, with a hint):
 - convert first: 1 tsp = 5 ml, 1 tbsp = 15 ml, 1 cup = 240 ml, 1 oz = 28 g, 1 lb = 454 g, 1 UK pint = 568 ml
 
 Key endpoints:
-- `POST /recipes/ingest {url}` — try this first for any recipe link; cached URLs return instantly. A 422 means the page has no structured data: read the page yourself and `POST /recipes` with `{title, servings, prep_minutes, cook_minutes, instructions, tags, source_url, parse_source: "ai", ingredients: [{name, quantity, unit}]}` (names lowercase, prep notes stripped; omit quantity+unit for "to taste").
+- `POST /recipes/ingest {url}` — try this first for any recipe link; cached URLs return instantly. A 422 means the server couldn't use the page — no structured data, or the site blocked its fetch (yours may still work): read the page yourself and `POST /recipes` with `{title, servings, prep_minutes, cook_minutes, instructions, tags, source_url, parse_source: "ai", ingredients: [{name, quantity, unit}]}` (names lowercase, prep notes stripped; omit quantity+unit for "to taste").
 - `POST /meals {name, slot, recipe_ids, loose_ingredients}` · `GET /meals`
 - `PATCH /meals/{id}` — edit an existing meal: `{name}`, `{slot}`, and the full replacement lists `{recipe_ids}` / `{loose_ingredients}` (read the meal first and send the whole list). The shopping list re-syncs itself. Prefer this over delete-and-recreate, which loses the meal's place on the plan.
 - Batch cooking: send `{recipes: [{recipe_id, scale}]}` instead of `{recipe_ids}` (same list, plus a multiplier — sending both is a 422). `scale: 2` doubles that recipe's contribution to the shopping list; the recipe and every other meal using it are unchanged, so "×2 the curry, ×1 the rice" is one meal. Each recipe in `GET /meals` carries its `scale`. Confirm the multiple with the user first. Countable units round **up** on the list (1.5 tins → "2 tins") while the stored quantity stays exact, so two meals each needing half a tin come to one tin, not two.


### PR DESCRIPTION
## Summary

`POST /recipes/ingest` raised a 502 when the server-side fetch failed (`RecipeFetchError`). In production behind Cloudflare, origin 5xx bodies are replaced with a bare "error code: 502" page, so the AI-facing guidance in the JSON `detail` never reached the calling client (verified live 2026-07-29: deliciousmagazine.co.uk 403s the server fetch and prod returned only Cloudflare's page, while 4xx JSON bodies pass through intact).

Fetch failures now return 422, same as the no-JSON-LD path. The detail already tells the calling AI to read the page itself and `POST /recipes` with `parse_source="ai"`, and a 4xx survives the proxy, so the recovery instruction actually arrives.

## Changes

- `backend/app/routers/recipes.py`: `RecipeFetchError` now raises 422, with a comment recording the proxy constraint; the endpoint docstring (OpenAPI-visible) covers both 422 causes
- `backend/tests/integration/test_recipes.py`: fetch-failure test asserts 422 and documents why it must never be a 5xx
- `skill/SKILL.md`, `skill/prompt-pack.md`, MCP `ingest_recipe` docstring: failure wording now covers blocked fetches, noting the assistant's own fetch may still work
- Playbook bumped v7 to v8 in all four pinned places (both skill stamps and prose lines, `PLAYBOOK_VERSION`, `PINNED_PLAYBOOK_VERSION` plus the new guidance digest)

## Compatibility

- The only 502 references in the repo were the raise and its test; nothing branches on it.
- iOS special-cases only 401/426 and shows generic detail otherwise; ingest is a foreground flow nowhere near the offline queue. Old builds improve: today they render "Request failed (502)" because Cloudflare's body has no `detail`; after deploy they show the real message.
- The MCP server treats every status >= 400 alike and returns errors as tool results in 200 JSON-RPC responses; remote MCP calls the API container directly and was never affected.
- No response fields or request validation changed, so the additive-only contract is untouched.
- Once deployed, the MCP server announces v8 and assistants holding v7 skill snapshots are told to re-fetch `/skill` (the designed staleness mechanism).

## Test plan

- [x] `make test` (443 backend + 44 mcp, all pass)
- [x] `make lint` (ruff check + format, clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)