### PR TITLE
Drop 8 from the provision password alphabet and stop testing by chance

### DIFF
--- a/backend/app/provision.py
+++ b/backend/app/provision.py
@@ -33,12 +33,18 @@ from app.database import SessionLocal
 from app.models import Household, User
 from app.services.security import hash_password
 
+# Look-alikes off a screen, dropped in whole pairs so neither half can turn up:
+# i/l/1, o/O/0, B/8. Keeping one half of a pair is no better than keeping both,
+# because the reader still can't tell which character they are looking at.
+AMBIGUOUS_CHARACTERS = "Il1O0oB8"
+
+# Long enough to be safe, typeable enough to go in App Review notes and be
+# retyped on a phone by someone who did not choose to be here.
+PASSWORD_ALPHABET = "abcdefghjkmnpqrstuvwxyzACDEFGHJKLMNPQRSTUVWXYZ2345679"
+
 
 def _generate_password() -> str:
-    # Long enough to be safe, typeable enough to go in App Review notes and be
-    # retyped on a phone by someone who did not choose to be here.
-    alphabet = "abcdefghjkmnpqrstuvwxyzACDEFGHJKLMNPQRSTUVWXYZ23456789"
-    return "-".join("".join(secrets.choice(alphabet) for _ in range(5)) for _ in range(3))
+    return "-".join("".join(secrets.choice(PASSWORD_ALPHABET) for _ in range(5)) for _ in range(3))
 
 
 async def provision(

--- a/backend/tests/integration/test_provision.py
+++ b/backend/tests/integration/test_provision.py
@@ -9,7 +9,12 @@ shopping list.
 import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
-from app.provision import _generate_password, provision
+from app.provision import (
+    AMBIGUOUS_CHARACTERS,
+    PASSWORD_ALPHABET,
+    _generate_password,
+    provision,
+)
 from tests.conftest import create_recipe
 
 
@@ -86,5 +91,8 @@ class TestProvision:
         password = _generate_password()
         assert len(password) >= 16
         assert password != _generate_password()
-        # No characters that are ambiguous read off a screen.
-        assert not set(password) & set("Il1O0oB8")
+        # Assert on the alphabet, not on a sample of it: a password only *usually*
+        # contains any given character, so checking one draw fails a fraction of
+        # runs and lets a re-introduced look-alike through the rest of the time.
+        assert not set(PASSWORD_ALPHABET) & set(AMBIGUOUS_CHARACTERS)
+        assert all(set(_generate_password()) <= set(PASSWORD_ALPHABET + "-") for _ in range(50))


### PR DESCRIPTION
`test_generated_passwords_are_typeable_and_not_guessable` was flaky and turned `main` red on 77fbe57 (CI run 30489513729) for no real reason.

`_generate_password()` built its alphabet by removing ambiguous look-alike pairs, and dropped `B` but kept `8`. The test forbade both, so with 15 characters drawn from 54 it only passed when the draw happened to miss `8`, roughly (53/54)^15 ≈ 76% of the time.

The generator was the side that was wrong: every other pair (i/l/1, o/O/0) was removed whole, and the comment above it asks for a password "typeable enough to go in App Review notes and be retyped on a phone by someone who did not choose to be here".

- Remove `8` from the alphabet. It is now 53 characters with no duplicates, missing exactly `i l o`, `B I O`, `0 1 8`. No other ambiguous character had crept in; `L` survives correctly because both of its look-alikes are already gone.
- Hoist the alphabet and the ambiguous set to `PASSWORD_ALPHABET` / `AMBIGUOUS_CHARACTERS` so the test asserts the two don't intersect. That is deterministic: a look-alike added back to the alphabet fails every run rather than one in four while passing the rest of the time and hiding the problem.
- Keep a sampled loop over 50 generated passwords, which catches the generator drifting away from the alphabet it publishes.

Entropy goes from log2(54)x15 ≈ 86 bits to log2(53)x15 ≈ 85.9 bits.

## Testing

- `pytest tests/integration/test_provision.py` run 15 times, 6 passed every time
- `make test-fast`: 443 backend + 44 mcp passed
- `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)