### PR TITLE
Send browsers at / to the marketing site when configured

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -18,6 +18,13 @@ class Settings(BaseSettings):
     registration_enabled: bool = True
     session_token_ttl_days: int = 30
 
+    # Where a *browser* hitting the API root lands. Unset, it falls back to
+    # the interactive docs, which is the right default for a self-hosted
+    # instance; the reference deployment sets the YAMP marketing site so the
+    # bare domain has a public face. Machine clients never see this — the
+    # JSON landing at `/` is unaffected.
+    marketing_url: str | None = None
+
     # Requests per minute per IP on the auth endpoints (public API hardening).
     auth_rate_limit_per_minute: int = 10
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -73,27 +73,29 @@ app.include_router(pages.router)
 
 @app.get("/", include_in_schema=False)
 async def root(request: Request) -> Response:
-    # Browsers get the interactive docs; assistants and curl get a JSON landing
+    # Browsers get the marketing site when this deployment has one, the
+    # interactive docs otherwise; assistants and curl get a JSON landing
     # advertising every machine-readable surface (issue #5).
     if "text/html" in request.headers.get("accept", ""):
-        return RedirectResponse("/docs")
+        return RedirectResponse(settings.marketing_url or "/docs")
     base = base_url(request)
-    return JSONResponse(
-        {
-            "name": settings.app_name,
-            "version": app.version,
-            "description": "Meal options planner with an AI-first API — fetch the skill for the workflow guide.",
-            "openapi": f"{base}/openapi.json",
-            "docs": f"{base}/docs",
-            "skill": f"{base}/skill",
-            "prompt_pack": f"{base}/prompt-pack",
-            # Lets an assistant spot a stale installed copy without a second request.
-            "playbook_version": playbook_version(),
-            "health": f"{base}/healthz",
-            "privacy": f"{base}/privacy",
-            "support": f"{base}/support",
-        }
-    )
+    landing = {
+        "name": settings.app_name,
+        "version": app.version,
+        "description": "Meal options planner with an AI-first API — fetch the skill for the workflow guide.",
+        "openapi": f"{base}/openapi.json",
+        "docs": f"{base}/docs",
+        "skill": f"{base}/skill",
+        "prompt_pack": f"{base}/prompt-pack",
+        # Lets an assistant spot a stale installed copy without a second request.
+        "playbook_version": playbook_version(),
+        "health": f"{base}/healthz",
+        "privacy": f"{base}/privacy",
+        "support": f"{base}/support",
+    }
+    if settings.marketing_url:
+        landing["website"] = settings.marketing_url
+    return JSONResponse(landing)
 
 
 @app.get("/healthz", tags=["meta"])

--- a/backend/tests/integration/test_misc.py
+++ b/backend/tests/integration/test_misc.py
@@ -24,6 +24,28 @@ class TestMeta:
         assert response.status_code == 307
         assert response.headers["location"] == "/docs"
 
+    async def test_root_redirects_browsers_to_the_marketing_site_when_set(self, client, monkeypatch):
+        """A deployment with a public face sends browsers there instead of the docs."""
+        # Patch the instance the route actually reads: `app.main` binds the
+        # settings object at import, and other tests clear the lru_cache, so
+        # get_settings() here can be a different object entirely.
+        from app import main as app_main
+
+        monkeypatch.setattr(app_main.settings, "marketing_url", "https://example.test/yamp/")
+
+        response = await client.get("/", headers={"accept": "text/html,application/xhtml+xml"})
+        assert response.status_code == 307
+        assert response.headers["location"] == "https://example.test/yamp/"
+
+        # The JSON landing is a machine surface: unchanged shape, plus an
+        # additive pointer so assistants can cite the website too.
+        landing = (await client.get("/")).json()
+        assert landing["website"] == "https://example.test/yamp/"
+        assert landing["skill"] == "http://test/skill"
+
+    async def test_root_landing_has_no_website_field_by_default(self, client):
+        assert "website" not in (await client.get("/")).json()
+
     async def test_root_landing_advertises_the_ai_surfaces(self, client):
         """Assistants pointed at the server discover the skill from the root (issue #5)."""
         response = await client.get("/")  # httpx sends Accept: */* — the non-browser path


### PR DESCRIPTION
Optional `MARKETING_URL` setting. Unset (self-hosting default): browsers at `/` still land on `/docs`. Set: they are redirected to the marketing site; the deployment will point at the GitHub Pages YAMP page so `meals.marcuslab.uk` gets people there.

The JSON landing for assistants keeps its exact shape, plus an additive `website` field when configured. Covered by tests either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)