### PR TITLE
Refuse non-public recipe URLs and de-fang the bracket regex

### DIFF
--- a/backend/app/routers/recipes.py
+++ b/backend/app/routers/recipes.py
@@ -36,10 +36,12 @@ def _sort_order(sort: str) -> tuple:
 async def ingest_recipe_url(payload: IngestIn, user: CurrentUser, db: DbSession) -> IngestOut:
     """Submit a recipe URL. A URL already in the library returns the cached
     recipe instantly (parse once, reuse forever). New URLs are fetched and
-    parsed from their schema.org/Recipe JSON-LD — no LLM involved. Failure is
-    a 422 either way — the page has no usable JSON-LD, or this server couldn't
-    fetch it (bot-blocked, unreachable) — and the detail tells the calling AI
-    to read the page itself and submit the structured recipe via POST /recipes."""
+    parsed from their schema.org/Recipe JSON-LD — no LLM involved. Only public
+    http(s) pages are fetched: a private, loopback or link-local address is
+    refused rather than reached. Failure is a 422 either way — the page has no
+    usable JSON-LD, or this server couldn't fetch it (bot-blocked, unreachable,
+    not public) — and the detail tells the calling AI to read the page itself
+    and submit the structured recipe via POST /recipes."""
     url = payload.url.strip()
     cached = await _find_by_url(db, user.household_id, url)
     if cached is not None:

--- a/backend/app/services/ingredient_names.py
+++ b/backend/app/services/ingredient_names.py
@@ -187,7 +187,12 @@ def canonical_ingredient_name(name: str) -> str:
     # Prep notes after a comma ("onions, finely chopped") — the JSON-LD parser
     # already drops these, AI- and user-submitted names may not.
     cleaned = cleaned.split(",")[0].strip()
-    cleaned = re.sub(r"\s*\(.*?\)\s*", " ", cleaned)
+    # `[^()]*` rather than `.*?`: an unbalanced "(" makes a lazy dot restart
+    # its scan at every following character, so a long name of nothing but
+    # brackets costs quadratic time on a name a caller chose (CWE-1333). The
+    # whitespace around the brackets is collapsed on the next line instead of
+    # being matched here, for the same reason.
+    cleaned = re.sub(r"\([^()]*\)", " ", cleaned)
     cleaned = " ".join(cleaned.split()).strip(" .")
     if not cleaned:
         return cleaned

--- a/backend/app/services/recipe_parser.py
+++ b/backend/app/services/recipe_parser.py
@@ -6,9 +6,13 @@ message instructing the caller's AI to read the page and submit the structured
 recipe via POST /recipes instead.
 """
 
+import asyncio
+import ipaddress
 import json
 import re
+import socket
 from dataclasses import dataclass, field
+from urllib.parse import urlsplit
 
 import httpx
 from bs4 import BeautifulSoup
@@ -47,16 +51,99 @@ class ParsedRecipe:
     ingredients: list[ParsedIngredient] = field(default_factory=list)
 
 
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+_MAX_REDIRECTS = 5
+_READ_IT_YOURSELF = "read the page yourself and submit the structured recipe via POST /recipes"
+
+
+async def _resolve_host(host: str) -> list[str]:
+    """A/AAAA lookup for a hostname. Its own function so the test suite can
+    stub it — tests never touch the network, DNS included."""
+    infos = await asyncio.get_running_loop().getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    return [str(info[4][0]) for info in infos]
+
+
+def _is_public_address(raw: str) -> bool:
+    try:
+        # A link-local IPv6 literal can carry a zone id ("fe80::1%eth0").
+        ip = ipaddress.ip_address(raw.partition("%")[0])
+    except ValueError:
+        return False
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        # ::ffff:127.0.0.1 reaches loopback, so judge it as the v4 address.
+        ip = ip.ipv4_mapped
+    return not (
+        ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_reserved or ip.is_unspecified
+    )
+
+
+async def _assert_public_url(url: str) -> None:
+    """Refuse to fetch anything but a plain http(s) page on a public host.
+
+    Ingestion fetches a URL the caller supplied, so without this the endpoint
+    is a request-forgery proxy (CWE-918): `POST /recipes/ingest` with
+    `http://192.168.1.1/`, `http://169.254.169.254/latest/meta-data/` or
+    `file:///etc/passwd` would have this server read the network it is
+    deployed on and hand the result back. Every redirect hop is checked
+    separately, because a public page is free to redirect to loopback.
+
+    Names are resolved and the addresses judged, which closes the interesting
+    cases; it does not close DNS rebinding (a record whose value changes
+    between this lookup and the connection), which would need the connection
+    pinned to the address checked here.
+    """
+    parts = urlsplit(url)
+    if parts.scheme.lower() not in _ALLOWED_SCHEMES:
+        raise RecipeFetchError(
+            f"{parts.scheme or url!r} is not a scheme this server will fetch — recipe URLs must be "
+            f"http:// or https://; if the recipe is somewhere this server can't reach, {_READ_IT_YOURSELF}"
+        )
+    host = parts.hostname
+    if not host:
+        raise RecipeFetchError(f"{url} has no hostname; pass the full page URL, or {_READ_IT_YOURSELF}")
+
+    try:
+        ipaddress.ip_address(host)
+    except ValueError:
+        try:
+            addresses = await _resolve_host(host)
+        except OSError as exc:
+            raise RecipeFetchError(
+                f"could not resolve {host} (DNS lookup failed); check the URL, or {_READ_IT_YOURSELF}"
+            ) from exc
+    else:
+        addresses = [host]
+
+    if not addresses or not all(_is_public_address(address) for address in addresses):
+        raise RecipeFetchError(
+            f"{host} is not a public address, and this server only fetches recipes from the public "
+            f"internet — private, loopback and link-local addresses are refused. If the page is on your "
+            f"own network, {_READ_IT_YOURSELF}"
+        )
+
+
 async def fetch_page(url: str) -> str:
     settings = get_settings()
     headers = {"User-Agent": "MealsBot/0.1 (+recipe ingestion; JSON-LD only)"}
+    await _assert_public_url(url)
     try:
+        # Redirects are followed by hand so each hop goes through the same
+        # public-address check as the URL the caller gave us.
         async with httpx.AsyncClient(
-            follow_redirects=True, timeout=settings.recipe_fetch_timeout_seconds, headers=headers
+            follow_redirects=False, timeout=settings.recipe_fetch_timeout_seconds, headers=headers
         ) as client:
-            response = await client.get(url)
-            response.raise_for_status()
-            return response.text
+            target = url
+            for _ in range(_MAX_REDIRECTS + 1):
+                response = await client.get(target)
+                if response.next_request is None:
+                    response.raise_for_status()
+                    return response.text
+                # next_request resolves a relative Location against the hop.
+                target = str(response.next_request.url)
+                await _assert_public_url(target)
+            raise RecipeFetchError(
+                f"fetching {url} gave up after {_MAX_REDIRECTS} redirects; check the URL, or {_READ_IT_YOURSELF}"
+            )
     except httpx.HTTPStatusError as exc:
         raise RecipeFetchError(
             f"fetching {url} failed with HTTP {exc.response.status_code}; "
@@ -401,5 +488,6 @@ def _clean_name(name: str) -> str:
     name = re.sub(r"^(of|de)\s+", "", name, flags=re.IGNORECASE)
     # Drop trailing prep notes: "onions, finely chopped" → "onions"
     name = name.split(",")[0]
-    name = re.sub(r"\s*\((.*?)\)\s*", " ", name).strip()
-    return name.lower().strip(" .")
+    # Bracket-matching kept non-backtracking, as in canonical_ingredient_name.
+    name = re.sub(r"\([^()]*\)", " ", name)
+    return " ".join(name.split()).lower().strip(" .")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -17,6 +17,7 @@ from sqlalchemy.pool import StaticPool  # noqa: E402
 from app.config import get_settings  # noqa: E402
 from app.database import Base, enforce_sqlite_foreign_keys, get_db  # noqa: E402
 from app.main import app  # noqa: E402
+from app.services import recipe_parser  # noqa: E402
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -70,6 +71,20 @@ async def auth_client(client: AsyncClient) -> AsyncClient:
     auth = await register(client)
     client.headers["Authorization"] = f"Bearer {auth['token']}"
     return client
+
+
+@pytest.fixture(autouse=True)
+def stub_dns(monkeypatch):
+    """No test resolves a real name. Ingestion checks that a URL points at a
+    public address before fetching it, so every hostname the suite hands to
+    `fetch_page` would otherwise be a live DNS lookup; here they all answer
+    with the same public address. Tests that care about the answer patch
+    `recipe_parser._resolve_host` themselves."""
+
+    async def resolve(host: str) -> list[str]:
+        return ["93.184.216.34"]
+
+    monkeypatch.setattr(recipe_parser, "_resolve_host", resolve)
 
 
 @pytest.fixture

--- a/backend/tests/integration/test_misc.py
+++ b/backend/tests/integration/test_misc.py
@@ -136,8 +136,8 @@ class TestPublicPages:
 # Without this, guidance can ship under an unchanged number — which is exactly
 # what happened when the premium/budget tools landed on v1: a stale v1 copy
 # compared v1 to v1, found no drift, and never learned the tools existed.
-PINNED_PLAYBOOK_VERSION = 8
-PINNED_PLAYBOOK_DIGEST = "36f6dd72ab5025558df78cb043cd11b2e6159672244c101baea9b3e14423559d"
+PINNED_PLAYBOOK_VERSION = 9
+PINNED_PLAYBOOK_DIGEST = "cb42e7d16392d16daaab98e8bd58bec45c8056cc3b254a9f2464fa13c2756f6d"
 
 _VERSION_STAMP = re.compile(r"<!--\s*playbook-version:\s*\d+\s*-->\n?")
 _VERSION_PROSE = re.compile(r"playbook v\d+", re.IGNORECASE)

--- a/backend/tests/unit/test_fetch_page.py
+++ b/backend/tests/unit/test_fetch_page.py
@@ -2,6 +2,7 @@ import httpx
 import pytest
 import respx
 
+from app.services import recipe_parser
 from app.services.recipe_parser import RecipeFetchError, fetch_page
 
 
@@ -27,4 +28,106 @@ async def test_network_error_becomes_actionable_message():
     respx.get("https://example.com/gone").mock(side_effect=httpx.ConnectError("boom"))
     with pytest.raises(RecipeFetchError, match="could not fetch") as exc_info:
         await fetch_page("https://example.com/gone")
+    assert "POST /recipes" in str(exc_info.value)
+
+
+# ------------------------------------------------------------------ SSRF guard
+# Ingestion fetches a URL the caller chose, so the endpoint would otherwise
+# read the network the server is deployed on and hand back the result.
+
+
+@respx.mock
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:8000/healthz",
+        "http://localhost/healthz",  # via the stubbed resolver below
+        "http://192.168.1.1/",
+        "http://10.0.0.5/admin",
+        "http://169.254.169.254/latest/meta-data/",  # cloud instance metadata
+        "http://[::1]/",
+        "http://[::ffff:127.0.0.1]/",  # loopback wearing an IPv6 hat
+        "http://0.0.0.0/",
+    ],
+)
+async def test_private_addresses_are_refused(url, monkeypatch):
+    async def resolve(host: str) -> list[str]:
+        return ["127.0.0.1"]
+
+    monkeypatch.setattr(recipe_parser, "_resolve_host", resolve)
+    route = respx.get(url).mock(return_value=httpx.Response(200, text="secret"))
+    with pytest.raises(RecipeFetchError, match="not a public address") as exc_info:
+        await fetch_page(url)
+    assert "POST /recipes" in str(exc_info.value)
+    assert not route.called
+
+
+@respx.mock
+async def test_public_name_resolving_to_a_private_address_is_refused(monkeypatch):
+    """The DNS answer decides, not the name: a hostname a household member
+    controls can point wherever they like."""
+
+    async def resolve(host: str) -> list[str]:
+        return ["93.184.216.34", "10.1.2.3"]
+
+    monkeypatch.setattr(recipe_parser, "_resolve_host", resolve)
+    route = respx.get("https://rebind.example/recipe").mock(return_value=httpx.Response(200, text="secret"))
+    with pytest.raises(RecipeFetchError, match="not a public address"):
+        await fetch_page("https://rebind.example/recipe")
+    assert not route.called
+
+
+@respx.mock
+async def test_redirect_to_a_private_address_is_refused():
+    """A public page is free to redirect to loopback, so every hop is checked."""
+    respx.get("https://example.com/chilli").mock(
+        return_value=httpx.Response(302, headers={"location": "http://169.254.169.254/latest/meta-data/"})
+    )
+    route = respx.get("http://169.254.169.254/latest/meta-data/").mock(return_value=httpx.Response(200, text="creds"))
+    with pytest.raises(RecipeFetchError, match="not a public address"):
+        await fetch_page("https://example.com/chilli")
+    assert not route.called
+
+
+@respx.mock
+async def test_redirect_loop_gives_up_with_guidance():
+    respx.get("https://example.com/loop").mock(
+        return_value=httpx.Response(302, headers={"location": "https://example.com/loop"})
+    )
+    with pytest.raises(RecipeFetchError, match="gave up after") as exc_info:
+        await fetch_page("https://example.com/loop")
+    assert "POST /recipes" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("url", ["file:///etc/passwd", "gopher://example.com/", "ftp://example.com/x"])
+async def test_non_http_schemes_are_refused(url):
+    with pytest.raises(RecipeFetchError, match="not a scheme this server will fetch") as exc_info:
+        await fetch_page(url)
+    assert "POST /recipes" in str(exc_info.value)
+
+
+async def test_url_without_a_hostname_is_refused():
+    with pytest.raises(RecipeFetchError, match="no hostname"):
+        await fetch_page("https:///recipes/chilli")
+
+
+async def test_an_answer_that_is_not_an_address_fails_closed(monkeypatch):
+    """Whatever the resolver hands back has to be judged public, not merely
+    not-judged-private."""
+
+    async def resolve(host: str) -> list[str]:
+        return ["not-an-address"]
+
+    monkeypatch.setattr(recipe_parser, "_resolve_host", resolve)
+    with pytest.raises(RecipeFetchError, match="not a public address"):
+        await fetch_page("https://example.com/chilli")
+
+
+async def test_unresolvable_host_is_actionable(monkeypatch):
+    async def resolve(host: str) -> list[str]:
+        raise OSError("nodename nor servname provided")
+
+    monkeypatch.setattr(recipe_parser, "_resolve_host", resolve)
+    with pytest.raises(RecipeFetchError, match="could not resolve") as exc_info:
+        await fetch_page("https://no-such-host.example/recipe")
     assert "POST /recipes" in str(exc_info.value)

--- a/backend/tests/unit/test_ingredient_names.py
+++ b/backend/tests/unit/test_ingredient_names.py
@@ -4,6 +4,8 @@ The cases that matter are the ones this must *not* fold: a wrong merge changes
 what someone buys, a missed one only leaves two tidy lines next to each other.
 """
 
+import time
+
 import pytest
 
 from app.services.aisles import guess_aisle
@@ -124,6 +126,26 @@ class TestSingularizeFood:
     def test_plural_only_foods_stay_plural_from_either_spelling(self, word):
         assert singularize_food(word) == word
         assert singularize_food(word.rstrip("s")) == word
+
+
+class TestCleaning:
+    @pytest.mark.parametrize(
+        ("written", "folded"),
+        [
+            ("chicken (skinless)", "chicken"),
+            ("chicken (skinless) thighs", "chicken thigh"),
+            ("onions, finely chopped", "onion"),
+        ],
+    )
+    def test_notes_are_stripped_without_gluing_words_together(self, written, folded):
+        assert canonical_ingredient_name(written) == folded
+
+    def test_bracket_heavy_name_is_not_quadratic(self):
+        """The folding regex used to be a lazy dot, which an unbalanced bracket
+        made quadratic (CWE-1333)."""
+        started = time.perf_counter()
+        canonical_ingredient_name("beef " + "(" * 40_000)
+        assert time.perf_counter() - started < 1.0
 
 
 class TestAisleStillFound:

--- a/backend/tests/unit/test_recipe_parser.py
+++ b/backend/tests/unit/test_recipe_parser.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 from app.services.recipe_parser import (
@@ -130,6 +132,19 @@ class TestParseIngredientLine:
         parsed = parse_ingredient_line("2 eggs (free range)")
         assert parsed.name == "eggs"
         assert parsed.quantity == 2
+
+    def test_note_inside_a_name_leaves_one_space(self):
+        parsed = parse_ingredient_line("2 chicken (skinless) thighs")
+        assert parsed.name == "chicken thighs"
+
+    def test_bracket_heavy_line_is_not_quadratic(self):
+        """A fetched page chooses this string, and its ingredient lines have no
+        length limit. The lazy-dot version of the bracket-stripping regex took
+        seven seconds on this input (CWE-1333)."""
+        line = "500g beef " + "(" * 40_000
+        started = time.perf_counter()
+        parse_ingredient_line(line)
+        assert time.perf_counter() - started < 1.0
 
 
 class TestTrailingUnitWord:

--- a/mcp/meals_mcp/server.py
+++ b/mcp/meals_mcp/server.py
@@ -32,7 +32,7 @@ from starlette.responses import PlainTextResponse, Response
 # they drift, and the backend suite fails if the guidance changes without a bump).
 # Instructions ship fresh on every connection, so this is the one channel that can
 # tell an assistant its installed skill snapshot has gone stale.
-PLAYBOOK_VERSION = 8
+PLAYBOOK_VERSION = 9
 
 mcp = FastMCP(
     "meals",
@@ -173,9 +173,10 @@ async def _resolve_recipes(terms: list[str]) -> list[dict]:
 @mcp.tool()
 async def ingest_recipe(url: str) -> str:
     """Add a recipe from a URL. Cached recipes return instantly; new pages are
-    parsed from their JSON-LD. If the page has no structured data, or the site
-    blocks the server's fetch, this tool tells you to read the page yourself
-    and call submit_recipe instead."""
+    parsed from their JSON-LD. Only public http(s) pages are fetched — a URL on
+    a private network is refused. If the page has no structured data, or the
+    site blocks the server's fetch, this tool tells you to read the page
+    yourself and call submit_recipe instead."""
     try:
         result = await _call("POST", "/recipes/ingest", json={"url": url})
     except ApiError as exc:

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -3,7 +3,7 @@ name: meal-planner
 description: Plan meals and manage the shopping list through the Meals API/MCP. Use when the user shares recipe links, asks what to cook, wants to plan the week's meals, needs the shopping list, or says they're out of something. Covers recipe ingestion (including parsing pages the backend can't), building meal options, and shopping-mode check-offs.
 ---
 
-<!-- playbook-version: 8 -->
+<!-- playbook-version: 9 -->
 
 # Being a great meal-planning assistant
 
@@ -12,7 +12,7 @@ calendar), a recipe library, and an aisle-sorted shopping list that knows why
 every item is on it. Prefer the MCP tools when connected; otherwise use the
 REST API (OpenAPI at `/openapi.json`, auth via `Authorization: Bearer <PAT>`).
 
-**This is playbook v8, and this file is a snapshot** — once installed it never
+**This is playbook v9, and this file is a snapshot** — once installed it never
 updates itself. If a connected Meals MCP server names a higher playbook version
 in its instructions, or `GET {{API_URL}}/skill/version` reports one, this copy
 is stale: fetch `{{API_URL}}/skill`, follow the fresh copy for the rest of the
@@ -37,9 +37,10 @@ conversation, and tell the user to replace their installed copy.
 
 1. `ingest_recipe(url)` for each link.
 2. If it succeeds — confirm the parse briefly (title, servings, anything odd).
-3. If it fails — no JSON-LD on the page, or the site blocked the server's
-   fetch (your own fetch may still work fine): read the page yourself, extract
-   the fields in **the parsing contract** below, and `submit_recipe(...)`.
+3. If it fails — no JSON-LD on the page, the site blocked the server's fetch
+   (your own fetch may still work fine), or the URL isn't a public http(s) page
+   the server will fetch: read the page yourself, extract the fields in **the
+   parsing contract** below, and `submit_recipe(...)`.
 4. Create a meal per recipe (`create_meal`) — ask about sides ("anything with
    it?") and attach them as loose ingredients, not fake recipes.
 5. Add the meals to the current plan (`add_meal_to_plan`); create the plan if

--- a/skill/prompt-pack.md
+++ b/skill/prompt-pack.md
@@ -1,6 +1,6 @@
 # Meals prompt pack (portable)
 
-<!-- playbook-version: 8 -->
+<!-- playbook-version: 9 -->
 
 Paste this into any AI assistant's custom instructions to make it a good
 meal-planning assistant for your Meals server. (Claude-family tools can use
@@ -13,7 +13,7 @@ You help me plan meals and manage shopping through my Meals API at
 `Authorization: Bearer {{YOUR_API_TOKEN}}`. The full OpenAPI spec is at
 `{{API_URL}}/openapi.json` — fetch it if unsure about an endpoint.
 
-These instructions are playbook v8 and don't update themselves. If
+These instructions are playbook v9 and don't update themselves. If
 `{{API_URL}}/skill/version` reports a higher version, tell me — re-fetching
 `{{API_URL}}/prompt-pack` gets the current guidance.
 
@@ -27,7 +27,7 @@ Quantity convention (the API rejects anything else, with a hint):
 - convert first: 1 tsp = 5 ml, 1 tbsp = 15 ml, 1 cup = 240 ml, 1 oz = 28 g, 1 lb = 454 g, 1 UK pint = 568 ml
 
 Key endpoints:
-- `POST /recipes/ingest {url}` — try this first for any recipe link; cached URLs return instantly. A 422 means the server couldn't use the page — no structured data, or the site blocked its fetch (yours may still work): read the page yourself and `POST /recipes` with `{title, servings, prep_minutes, cook_minutes, instructions, tags, source_url, parse_source: "ai", ingredients: [{name, quantity, unit}]}` (names lowercase, prep notes stripped; omit quantity+unit for "to taste").
+- `POST /recipes/ingest {url}` — try this first for any recipe link; cached URLs return instantly. A 422 means the server couldn't use the page — no structured data, the site blocked its fetch (yours may still work), or the URL isn't a public http(s) page the server will fetch: read the page yourself and `POST /recipes` with `{title, servings, prep_minutes, cook_minutes, instructions, tags, source_url, parse_source: "ai", ingredients: [{name, quantity, unit}]}` (names lowercase, prep notes stripped; omit quantity+unit for "to taste").
 - `POST /meals {name, slot, recipe_ids, loose_ingredients}` · `GET /meals`
 - `PATCH /meals/{id}` — edit an existing meal: `{name}`, `{slot}`, and the full replacement lists `{recipe_ids}` / `{loose_ingredients}` (read the meal first and send the whole list). The shopping list re-syncs itself. Prefer this over delete-and-recreate, which loses the meal's place on the plan.
 - Batch cooking: send `{recipes: [{recipe_id, scale}]}` instead of `{recipe_ids}` (same list, plus a multiplier — sending both is a 422). `scale: 2` doubles that recipe's contribution to the shopping list; the recipe and every other meal using it are unchanged, so "×2 the curry, ×1 the rice" is one meal. Each recipe in `GET /meals` carries its `scale`. Confirm the multiple with the user first. Countable units round **up** on the list (1.5 tins → "2 tins") while the stored quantity stays exact, so two meals each needing half a tin come to one tin, not two.


### PR DESCRIPTION
Closes the two open [code-scanning alerts](https://github.com/marco308/meals/security/code-scanning).

## Critical, `py/full-ssrf` in `fetch_page`

`POST /recipes/ingest` fetched whatever URL the caller passed, so any household member could have the server read the network it is deployed on and hand the result back: `http://192.168.1.1/`, `http://169.254.169.254/latest/meta-data/`, `file:///etc/passwd`.

`_assert_public_url` now gates every fetch:

- scheme must be `http` or `https`
- IP literals are judged directly; hostnames are resolved and **every** returned address judged, so a name pointing at `10.x` is refused
- private, loopback, link-local, multicast, reserved and unspecified addresses are refused, including IPv4-mapped IPv6 (`::ffff:127.0.0.1`) and zoned v6 literals
- redirects are followed by hand (max 5 hops) so a public page cannot bounce the server to loopback
- an answer that is not an address fails closed

Every refusal is a `RecipeFetchError`, so the 422 keeps carrying the read-the-page-yourself guidance that makes ingestion recoverable. DNS rebinding stays open and is documented as such: closing it needs the connection pinned to the address that was checked.

## High, `py/polynomial-redos` in `canonical_ingredient_name`

`\s*\(.*?\)\s*` is quadratic on unbalanced brackets. Replaced with `\([^()]*\)` plus the whitespace collapse that already followed. Measured on 40k brackets: **6.9s before, 0.8ms after**. The identical regex in `_clean_name` is fixed too, and it is the reachable one: API name fields cap at 200 characters, but the ingredient lines of a fetched page have no length limit.

## Supporting

- Autouse `stub_dns` fixture so the suite still never touches the network, DNS included.
- 12 new tests: private/loopback/metadata/IPv6 refusals, resolve-to-private, redirect-to-private, redirect loop, non-http schemes, missing hostname, fail-closed resolver, and two timing regressions for the ReDoS.
- The refusal is a failure mode a calling AI should know about rather than retry, so it is in the ingest docstring, the MCP tool description and the skill. That makes this **playbook v9**, bumped in all four places.

`make lint` clean, 466 backend + 44 mcp tests pass.

Note: CodeQL has no notion of a validation barrier for `py/full-ssrf`, so the alert may reappear on the next scan even though the hole is closed. If it does, the honest resolution is dismissing it with a comment pointing at `_assert_public_url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)