### PR TITLE
Make `make deploy` work from a git worktree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,11 @@ backed up under `~/meals-local-deploy/`. Don't re-add it to git; if the deploy
 needs changing, change it in place. `docker-compose.yml` is the public reference
 deployment and the one CI boots.
 
+Because it is untracked, `deploy/` is absent from every git worktree. `make
+deploy` falls back to the main worktree's script and hands it the current tree
+via `MEALS_REPO_ROOT` — so a deploy from a worktree ships *that* branch, not
+main. Keep those two in step if either moves.
+
 `deploy/deploy.sh` syncs sources to the swarm manager, builds images on the node
 that will run them (no registry, so a task only starts where its image already
 exists), forces a service update (locally built `:latest` tags don't roll out

--- a/Makefile
+++ b/Makefile
@@ -170,11 +170,21 @@ seed: ## Load demo data (into the Docker stack's API by default)
 # deploy/ is gitignored: a swarm stack file describes one specific set of
 # machines, which isn't much use to anyone else and tells the internet more about
 # them than it needs to know. docker-compose.yml is the reference deployment.
+#
+# Untracked also means it exists only in the checkout it was created in: a
+# `git worktree` tree gets a clean copy of tracked files and no deploy/ at all,
+# so `make deploy` from a worktree used to fail. Fall back to the main
+# worktree's copy, and hand the script *this* tree as the sources to sync
+# (MEALS_REPO_ROOT) — otherwise deploying from a worktree would quietly ship
+# main's code while claiming success.
+MAIN_WORKTREE := $(patsubst %/.git,%,$(shell git rev-parse --path-format=absolute --git-common-dir 2>/dev/null))
+DEPLOY_SH := $(firstword $(wildcard deploy/deploy.sh $(MAIN_WORKTREE)/deploy/deploy.sh))
+
 .PHONY: deploy
 deploy: ## Deploy to your swarm (needs an untracked deploy/deploy.sh)
-	@test -x ./deploy/deploy.sh || \
+	@test -n "$(DEPLOY_SH)" && test -x "$(DEPLOY_SH)" || \
 		{ echo "no deploy/deploy.sh — it's gitignored and environment-specific; see 'Deployment notes' in README.md"; exit 1; }
-	./deploy/deploy.sh
+	MEALS_REPO_ROOT="$(CURDIR)" "$(DEPLOY_SH)"
 
 # ------------------------------------------------------------------ cleanup
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,12 @@ labels, host aliases, which box has the free disk), so it's kept out and
 gitignored. [`docker-compose.yml`](docker-compose.yml) is the honest reference
 for the shape of the deployment, and it's what CI boots and smoke-tests.
 
+Being untracked, `deploy/` only exists in the checkout you put it in, so from a
+`git worktree` there is nothing to run. `make deploy` therefore falls back to
+the main worktree's copy of the script and passes the *current* tree as
+`MEALS_REPO_ROOT`, which is the source tree that gets synced and built — the
+script prints it first, so the deploy log says which tree went live.
+
 If you're deploying this yourself, the two things worth knowing, learned the
 hard way:
 


### PR DESCRIPTION
`make deploy` from any git worktree failed with `no deploy/deploy.sh`. Not a broken script: `deploy/` is gitignored, so it only exists in the checkout it was created in, and a worktree gets tracked files only.

Falling back to the main worktree's script on its own would have been worse than the error, because `deploy.sh` derives `REPO_ROOT` from its own location, so the deploy would have synced and shipped `main`'s code while printing success. So the Makefile also passes the current tree as `MEALS_REPO_ROOT`, which the (untracked, edited in place) script honours and echoes before syncing.

No environment detail enters the repo: the script path is resolved at runtime via `git rev-parse --git-common-dir`, and a clone with no `deploy/` still gets the same "gitignored and environment-specific" message.

Verified: from a worktree, `make -n deploy` resolves to the main worktree's script with the worktree as `MEALS_REPO_ROOT`; from the main checkout it still prefers the local `deploy/deploy.sh`; outside a repo the guard prints the same message and exits 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)