### PR TITLE
Start a plan when a recipe is added and there isn't one

### DIFF
--- a/ios/Meals/Meals/Services/PlanStore.swift
+++ b/ios/Meals/Meals/Services/PlanStore.swift
@@ -101,12 +101,63 @@ final class PlanStore {
         }
     }
 
-    func addMeal(_ meal: Meal) async {
-        guard let plan else { return }
+    /// The label a plan gets when one is started implicitly. Same default
+    /// `NewPlanSheet` offers, so both routes into a first plan agree.
+    nonisolated static let implicitPlanLabel = "This week's options"
+
+    /// Add a meal to the plan, starting a plan first if the household hasn't
+    /// got one. Returns false when nothing landed, with `errorMessage` set:
+    /// this used to `guard let plan else { return }`, which let the recipe
+    /// screen announce "Added to plan" after doing precisely nothing.
+    @discardableResult
+    func addMeal(_ meal: Meal) async -> Bool {
         do {
-            self.plan = try await api().addMeal(planId: plan.id, mealId: meal.id)
+            let target = try await planForWriting()
+            try await put(meal, on: target)
+            return true
         } catch {
             errorMessage = error.localizedDescription
+            return false
+        }
+    }
+
+    /// One recipe onto the plan as a meal of its own: the one-tap path from the
+    /// recipe library. The plan is resolved *before* the meal is created, so a
+    /// failure can't leave an unattached meal behind in the library.
+    func addRecipe(_ recipe: Recipe) async -> Meal? {
+        do {
+            let target = try await planForWriting()
+            guard let meal = await createMeal(name: recipe.title, slot: "dinner", recipeIds: [recipe.id]) else {
+                return nil
+            }
+            try await put(meal, on: target)
+            return meal
+        } catch {
+            errorMessage = error.localizedDescription
+            return nil
+        }
+    }
+
+    private func put(_ meal: Meal, on target: Plan) async throws {
+        let updated = try await api().addMeal(planId: target.id, mealId: meal.id)
+        plan = updated
+        isOffline = false
+        planCache.save(updated)
+    }
+
+    /// The plan a write should land on. `plan` can't answer this on its own:
+    /// nil means both "no active plan" and "not fetched yet", and a cached copy
+    /// may have been archived from another device. So the server decides, and
+    /// only a real 404 starts a new plan.
+    private func planForWriting() async throws -> Plan {
+        do {
+            return try await api().currentPlan()
+        } catch APIError.server(404, _) {
+            let created = try await api().createPlan(label: Self.implicitPlanLabel)
+            plan = created
+            isOffline = false
+            planCache.save(created)
+            return created
         }
     }
 

--- a/ios/Meals/Meals/Views/RecipesView.swift
+++ b/ios/Meals/Meals/Views/RecipesView.swift
@@ -166,6 +166,7 @@ struct RecipeDetailView: View {
     @State private var recipe: Recipe?
     @State private var errorMessage: String?
     @State private var addedMealName: String?
+    @State private var addError: String?
     @State private var reloadKey = 0
     @State private var showDeleteConfirm = false
     @State private var deleteError: String?
@@ -280,15 +281,23 @@ struct RecipeDetailView: View {
                 Section {
                     Button {
                         Task {
-                            if let meal = await planStore.createMeal(name: recipe.title, slot: "dinner", recipeIds: [recipe.id]) {
-                                await planStore.addMeal(meal)
+                            // No active plan? One is started, rather than the
+                            // tap quietly doing nothing. And if anything fails
+                            // the user hears about it, instead of being told
+                            // the meal is on a plan that doesn't exist.
+                            if let meal = await planStore.addRecipe(recipe) {
                                 addedMealName = meal.name
+                            } else {
+                                addError = planStore.errorMessage ?? "Couldn't reach the server."
+                                planStore.errorMessage = nil
                             }
                         }
                     } label: {
                         Label("Add to this week's plan", systemImage: "plus.circle.fill")
                             .fontWeight(.medium)
                     }
+                } footer: {
+                    Text("Starts a plan for you if there isn't one yet.")
                 }
             }
         }
@@ -327,7 +336,16 @@ struct RecipeDetailView: View {
         .alert("Added to plan", isPresented: .init(get: { addedMealName != nil }, set: { if !$0 { addedMealName = nil } })) {
             Button("OK") { addedMealName = nil }
         } message: {
-            Text("\(addedMealName ?? "") is on the plan and its ingredients are on the shopping list.")
+            // Naming the plan is what tells you a new one was just started.
+            Text("\(addedMealName ?? "") is on '\(planStore.plan?.label ?? "the plan")' and its ingredients are on the shopping list.")
+        }
+        .alert(
+            "Couldn't add to the plan",
+            isPresented: .init(get: { addError != nil }, set: { if !$0 { addError = nil } })
+        ) {
+            Button("OK") { addError = nil }
+        } message: {
+            Text(addError ?? "")
         }
         .confirmationDialog(
             "Delete '\(recipe.title)'? This can't be undone.",

--- a/ios/Meals/MealsTests/AddToPlanTests.swift
+++ b/ios/Meals/MealsTests/AddToPlanTests.swift
@@ -1,0 +1,201 @@
+import XCTest
+@testable import Meals
+
+/// Canned server responses. Deliberately outside the (main-actor) test case so
+/// the `StubProtocol` handler, which runs on URLSession's thread, can reach them.
+private enum Canned {
+    static let planId = UUID(uuidString: "1E4E9C1E-0A8E-4C60-9C2A-8E4E2B7D9C31")!
+    static let mealId = UUID(uuidString: "61931D47-4154-418A-A43F-F734A0E3D888")!
+    static let planMealsPath = "/plans/\(planId.uuidString.lowercased())/meals"
+    static let noActivePlan = Data(#"{"detail": "no active plan; create one via POST /plans"}"#.utf8)
+    static let unexpected = Data(#"{"detail": "unexpected request"}"#.utf8)
+
+    static let mealBody =
+        #"{"id": "\#(mealId.uuidString.lowercased())", "name": "Cottage Pie", "slot": "dinner", "recipes": [], "loose_ingredients": []}"#
+
+    static var mealJSON: Data { Data(mealBody.utf8) }
+
+    static func planJSON(label: String, meals: String = "[]") -> Data {
+        Data(
+            #"{"id": "\#(planId.uuidString.lowercased())", "label": "\#(label)", "status": "active", "meals": \#(meals)}"#
+            .utf8
+        )
+    }
+
+    /// The plan as `POST /plans/{id}/meals` returns it: one meal on board.
+    static var plannedPlanJSON: Data {
+        let planMeal = #"{"id": "d2b1a9c4-1e2f-4a3b-8c5d-6e7f8a9b0c1d", "cooked_at": null, "meal": \#(mealBody)}"#
+        return planJSON(label: PlanStore.implicitPlanLabel, meals: "[\(planMeal)]")
+    }
+
+    static var recipe: Recipe {
+        Recipe(
+            id: UUID(), title: "Cottage Pie", sourceUrl: nil, servings: 4, prepMinutes: nil,
+            cookMinutes: nil, imageUrl: nil, instructions: nil, tags: [],
+            parseSource: "jsonld", edited: false, ingredients: []
+        )
+    }
+
+    static var meal: Meal {
+        Meal(id: mealId, name: "Cottage Pie", slot: "dinner", recipes: [], looseIngredients: [])
+    }
+}
+
+/// Every request the store made, so a test can assert what the server was (and
+/// wasn't) asked to do.
+private final class Calls: @unchecked Sendable {
+    private let lock = NSLock()
+    private var paths: [String] = []
+
+    func record(_ request: URLRequest) {
+        lock.lock()
+        paths.append("\(request.httpMethod ?? "?") \(request.url?.path ?? "")")
+        lock.unlock()
+    }
+
+    var seen: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return paths
+    }
+}
+
+/// "Add to this week's plan" on a recipe used to report success and do nothing
+/// whenever the household had no active plan: `PlanStore.addMeal` bailed out on
+/// `guard let plan`, and the recipe screen showed "Added to plan" regardless.
+/// A tap that says it worked has to have worked.
+@MainActor
+final class AddToPlanTests: XCTestCase {
+    private var directory: URL!
+
+    override func setUp() {
+        super.setUp()
+        directory = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+    }
+
+    override func tearDown() {
+        StubProtocol.handler = nil
+        try? FileManager.default.removeItem(at: directory)
+        super.tearDown()
+    }
+
+    private func store(protocolClass: AnyClass = StubProtocol.self) -> PlanStore {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [protocolClass]
+        let api = APIClient(
+            baseURL: URL(string: "http://testserver")!,
+            token: "meals_test-token",
+            session: URLSession(configuration: config)
+        )
+        return PlanStore(api: { api }, directory: directory)
+    }
+
+    /// The bug: no active plan, so one gets started and the meal lands on it.
+    func testAddingARecipeWithNoActivePlanStartsOneAndAddsTheMeal() async {
+        let calls = Calls()
+        StubProtocol.handler = { request in
+            calls.record(request)
+            switch (request.httpMethod ?? "", request.url?.path ?? "") {
+            case ("GET", "/plans/current"):
+                return (404, Canned.noActivePlan)
+            case ("POST", "/plans"):
+                return (201, Canned.planJSON(label: PlanStore.implicitPlanLabel))
+            case ("POST", "/meals"):
+                return (201, Canned.mealJSON)
+            case ("POST", Canned.planMealsPath):
+                return (201, Canned.plannedPlanJSON)
+            default:
+                return (500, Canned.unexpected)
+            }
+        }
+
+        let store = self.store()
+        let added = await store.addRecipe(Canned.recipe)
+
+        XCTAssertEqual(added?.name, "Cottage Pie")
+        XCTAssertNil(store.errorMessage)
+        XCTAssertEqual(store.plan?.meals.count, 1, "the meal has to be on the plan the store now holds")
+        XCTAssertEqual(store.plan?.label, PlanStore.implicitPlanLabel)
+        XCTAssertTrue(calls.seen.contains("POST /plans"), "a missing plan is started, not silently skipped")
+        XCTAssertTrue(calls.seen.contains("POST \(Canned.planMealsPath)"))
+    }
+
+    /// A plan already on the server is used as-is: a nil `plan` also means
+    /// "Recipes was opened before Plan", and starting a second active plan
+    /// there would split the week across two plans.
+    func testAddingDoesNotStartASecondPlanWhenTheServerHasOne() async {
+        let calls = Calls()
+        StubProtocol.handler = { request in
+            calls.record(request)
+            switch (request.httpMethod ?? "", request.url?.path ?? "") {
+            case ("GET", "/plans/current"):
+                return (200, Canned.planJSON(label: "w/c 27 July"))
+            case ("POST", "/meals"):
+                return (201, Canned.mealJSON)
+            case ("POST", Canned.planMealsPath):
+                return (201, Canned.plannedPlanJSON)
+            default:
+                return (500, Canned.unexpected)
+            }
+        }
+
+        let store = self.store()
+        XCTAssertNil(store.plan, "nothing cached and nothing fetched: the ambiguous case")
+        let added = await store.addRecipe(Canned.recipe)
+
+        XCTAssertNotNil(added)
+        XCTAssertFalse(calls.seen.contains("POST /plans"), "the household's existing plan is the one to add to")
+    }
+
+    /// `addMeal`, the plan tab's own route, gets the same treatment and says
+    /// whether it worked.
+    func testAddMealStartsAPlanAndReportsSuccess() async {
+        StubProtocol.handler = { request in
+            switch (request.httpMethod ?? "", request.url?.path ?? "") {
+            case ("GET", "/plans/current"):
+                return (404, Canned.noActivePlan)
+            case ("POST", "/plans"):
+                return (201, Canned.planJSON(label: PlanStore.implicitPlanLabel))
+            case ("POST", Canned.planMealsPath):
+                return (201, Canned.plannedPlanJSON)
+            default:
+                return (500, Canned.unexpected)
+            }
+        }
+
+        let store = self.store()
+        let added = await store.addMeal(Canned.meal)
+
+        XCTAssertTrue(added)
+        XCTAssertEqual(store.plan?.meals.count, 1)
+    }
+
+    /// Offline, nothing lands, and the caller is told rather than left to
+    /// announce a phantom add.
+    func testAddingOfflineFailsLoudly() async {
+        let store = self.store(protocolClass: AlwaysOfflineProtocol.self)
+
+        let added = await store.addMeal(Canned.meal)
+        XCTAssertFalse(added)
+        XCTAssertNotNil(store.errorMessage)
+
+        let recipeAdd = await store.addRecipe(Canned.recipe)
+        XCTAssertNil(recipeAdd)
+    }
+
+    /// The plan is resolved before the meal is created, so a failure can't
+    /// leave an orphan meal in the library.
+    func testARecipeIsNotTurnedIntoAMealWhenNoPlanCanBeResolved() async {
+        let calls = Calls()
+        StubProtocol.handler = { request in
+            calls.record(request)
+            return (500, Data(#"{"detail": "boom"}"#.utf8))
+        }
+
+        let store = self.store()
+        let added = await store.addRecipe(Canned.recipe)
+        XCTAssertNil(added)
+        XCTAssertFalse(calls.seen.contains("POST /meals"), "no plan to add to means no meal to strand")
+        XCTAssertNotNil(store.errorMessage)
+    }
+}


### PR DESCRIPTION
## The bug

Marcus hit this in the app: with no active plan, "Add to this week's plan" on a recipe says "Added to plan" and does nothing.

`PlanStore.addMeal` opened with `guard let plan else { return }`, so it returned silently. The recipe screen had already created the meal and showed its success alert unconditionally. What you were left with: an orphan meal in the library, nothing on any plan, nothing on the shopping list, and an alert claiming otherwise.

There was a second route to the same dead tap even with a plan on the server. `plan` is also nil when the Plan tab hasn't been opened yet that session, so Recipes first then add did nothing.

## The fix

- The write resolves its own target rather than trusting the in-memory copy. `GET /plans/current` decides, and only a real 404 starts a plan, labelled "This week's options" (the same default `NewPlanSheet` offers). That covers both readings of a nil `plan`, and it also stops a write landing on a cached plan somebody archived from another device.
- `addMeal` returns whether anything landed, so no caller can claim success it didn't get.
- The library's one-tap path is now `addRecipe`, which resolves the plan **before** creating the meal: if it can't, there is no half-done state to explain.
- The recipe screen shows "Added to plan" only on success, names the plan in the message (which is how you can tell a new one was just started), gains a "Couldn't add to the plan" alert for the failure it used to swallow, and a footer reading "Starts a plan for you if there isn't one yet."

## Compatibility

iOS only. No API, MCP or skill change: the endpoints already did the right thing and the app was not calling them. Nothing removed or renamed, so the additive-only contract is untouched. No build bump in this PR.

## Testing

5 new tests in `ios/Meals/MealsTests/AddToPlanTests.swift`:

- no plan starts one and the meal lands on it
- an existing server plan is reused, never duplicated (the "Recipes opened before Plan" case, which would otherwise split the week across two active plans)
- `addMeal` reports success
- offline fails loudly with `errorMessage` set
- no meal is created when no plan can be resolved, so nothing is stranded

`make ios-test`: 115 tests, 0 failures.

Also driven through the real app in the simulator against a throwaway API with its own SQLite file and a fresh household holding one recipe and no plan. The tap produced "Cottage Pie is on 'This week's options'...", the server showed exactly one active plan with the meal on it, and potato 1kg plus minced beef 500g on the shopping list attributed "for Cottage Pie". Plan and Shopping tabs matched. The throwaway API, database and simulator build were removed afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)