### PR TITLE
Make swarm rollouts zero-downtime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,4 +215,40 @@ otherwise), and verifies `/healthz`, `/skill`, `/prompt-pack` and an MCP
 initialize handshake through Traefik. In that script, keep every check a bare
 command — `curl … && echo` is exempt from `set -e`.
 
+**Rollouts are zero-downtime and it takes two settings, not one** (both in the
+gitignored stack file, which is why they're restated here). api and mcp run one
+replica each, and `make deploy` used to drop every request for a few seconds.
+It needed:
+
+1. `order: start-first` on api and mcp. Swarm's stop-first default killed the
+   only task before starting its replacement.
+2. `traefik.docker.lbswarm=true` on both. With start-first alone the deploy
+   still failed requests for ~9.5s, because Traefik was picking task IPs
+   itself: swarm reports a container Running the moment it starts, but api
+   waits for Postgres and runs `alembic upgrade head` before uvicorn binds, so
+   Traefik sent traffic to a port nothing was listening on (502) and to the
+   retired task's overlay address after it vanished (hangs until timeout).
+   Routing to the swarm VIP instead means ingress only reaches tasks that pass
+   their healthcheck. Traefik here is v2; v3 renames the label to
+   `traefik.swarm.lbswarm`.
+
+Verified by polling `/healthz` every 200ms through Traefik across a full
+`make deploy`: 468/468 requests 200, worst response 366ms.
+
+Two things follow from the fix and they constrain what you may deploy:
+
+- The container healthcheck is now the cutover gate *and* what admits a task
+  to the VIP, so its interval bounds the rollout. It's 5s with a generous
+  `start_period`, not the 30s Docker suggests. Don't raise it back.
+- Old and new tasks overlap for a few seconds, and the new one runs
+  `alembic upgrade head` **while the old code is still serving**. Additive
+  migrations are safe; one that drops or renames something the old code still
+  reads will break the outgoing task for that window, so split it
+  expand/contract across two deploys. This is the same additive-only
+  discipline the iOS client contract already demands, now applying to the
+  schema during a rollout.
+
+Postgres stays stop-first on purpose — one replica on one local volume can't
+have two tasks at once.
+
 Open items and deferred work live in `BACKLOG.md`.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -22,5 +22,9 @@ RUN uv sync --frozen --no-dev
 
 EXPOSE 8000
 
-# Apply migrations, then serve
-CMD ["sh", "-c", ".venv/bin/alembic upgrade head && .venv/bin/uvicorn app.main:app --host 0.0.0.0 --port 8000"]
+# Apply migrations, then serve. `exec` makes uvicorn PID 1 so it receives
+# SIGTERM directly and drains in-flight requests on shutdown; without it the
+# signal stops at `sh` and uvicorn is killed mid-response. The swarm stack
+# overrides this command (it waits for Postgres first) and execs for the same
+# reason.
+CMD ["sh", "-c", ".venv/bin/alembic upgrade head && exec .venv/bin/uvicorn app.main:app --host 0.0.0.0 --port 8000"]


### PR DESCRIPTION
## What and why

Every `make deploy` took the API down for a few seconds. Two separate causes, and the first fix alone wasn't enough:

1. **`api` and `mcp` run one replica each with no `order` in `update_config`**, so swarm's `stop-first` default stopped the only task before starting its replacement — which then waits for Postgres, runs `alembic upgrade head` and boots uvicorn before it can serve anything. Fixed with `order: start-first`.
2. **Traefik (v2, `swarmMode=true`) load balances across task IPs**, and swarm reports a container `Running` the instant it starts. So traffic went to the new api task while it was still migrating with nothing bound to 8000 (502s), and to the retired task's overlay address after that container had gone (requests hung until they timed out). Measured at ~9.5s of failures per rollout even with start-first. Fixed with `traefik.docker.lbswarm=true`, which routes to the swarm service VIP — and the VIP only contains tasks that pass their healthcheck.

Both settings live in the gitignored `deploy/` stack file (already applied and deployed), so the only committed changes are the documentation of them and one Dockerfile fix.

Also in the stack file: healthcheck interval 30s → 5s (the probe is now the cutover gate, so a 30s interval put a 30s floor under every rollout), `stop_grace_period: 30s`, `monitor` 5s → 30s so a task that goes healthy then falls over actually triggers the configured rollback, and `db` pinned *explicitly* to `stop-first` since one replica on one local volume can't have two tasks at once.

`backend/Dockerfile` now `exec`s uvicorn so it is PID 1 and receives SIGTERM directly rather than being killed mid-response. The swarm stack already did this; the compose path (dev, CI smoke) did not.

### Verified against production

Polling `/healthz` every 200ms through Traefik:

| | before | after |
|---|---|---|
| forced `api` rollout | 4 failed requests, ~9.5s window | 241/241 → 200 |
| full `make deploy` | 3 failures | 468/468 → 200, worst 366ms |

`/mcp` separately returned 240/240 across a forced `mcp` rollout.

### One constraint this introduces

Old and new tasks now overlap for a few seconds, and the new one migrates **while the old code is still serving**. Additive migrations are safe, which is all this project makes. One that drops or renames something the old code still reads would break the outgoing task for that window, so it needs splitting expand/contract across two deploys. Noted in CLAUDE.md and in the stack file.

## Checklist

- [x] **API contract stayed additive** — no API changes at all.
- [x] **Model change has a migration** — no model changes.
- [x] **New 4xx strings say what to do instead** — no new error strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)