### PR TITLE
Pin recipe fetches to the addresses the SSRF guard checked

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -51,5 +51,6 @@ tail plus engineering debt worth naming.
 - [ ] **Image pipeline** — images are built on the swarm node by hand; a registry (or at least a pinned tag scheme) would make rollbacks sane
 - [ ] **Rate limiting is per-process in-memory** — fine for one replica; revisit if the API ever scales out
 - [x] ~~**Ingredient-line parser tail**~~ — ✅ the regex learned the `<n> <food> <unit>` shape (Q21): "3 garlic cloves" is now 3 cloves of garlic rather than ×3 of an ingredient called "garlic cloves", except where the last word is load-bearing ("2 bay leaves")
+- [ ] **Ingestion has no response-size cap** — `fetch_page` reads the whole body into memory with only the 15s timeout as a bound; a pathological page is a memory spike. Wants a streamed read with a byte ceiling (a few MB covers any real recipe page)
 - [ ] **Flaky provision password test** — `test_generated_passwords_are_typeable_and_not_guessable` asserts no `8` in the password while `_generate_password`'s alphabet contains one, so it fails roughly one run in four. Either drop `8` from the alphabet or from the ambiguous set; predates Q21 and is unrelated to it
 - [ ] **Demo/test data hygiene in prod** — if a smoke-test account was used during deploy verification, remove it (single shared household means it sees real data)

--- a/backend/app/routers/recipes.py
+++ b/backend/app/routers/recipes.py
@@ -37,8 +37,9 @@ async def ingest_recipe_url(payload: IngestIn, user: CurrentUser, db: DbSession)
     """Submit a recipe URL. A URL already in the library returns the cached
     recipe instantly (parse once, reuse forever). New URLs are fetched and
     parsed from their schema.org/Recipe JSON-LD — no LLM involved. Only public
-    http(s) pages are fetched: a private, loopback or link-local address is
-    refused rather than reached. Failure is a 422 either way — the page has no
+    http(s) pages are fetched: an address that isn't publicly routed (private,
+    loopback, link-local, carrier-grade NAT) is refused rather than reached.
+    Failure is a 422 either way — the page has no
     usable JSON-LD, or this server couldn't fetch it (bot-blocked, unreachable,
     not public) — and the detail tells the calling AI to read the page itself
     and submit the structured recipe via POST /recipes."""

--- a/backend/app/services/recipe_parser.py
+++ b/backend/app/services/recipe_parser.py
@@ -14,6 +14,7 @@ import socket
 from dataclasses import dataclass, field
 from urllib.parse import urlsplit
 
+import httpcore
 import httpx
 from bs4 import BeautifulSoup
 
@@ -70,22 +71,33 @@ async def _resolve_host(host: str) -> list[str]:
     return [str(info[4][0]) for info in infos]
 
 
+# NAT64 (RFC 6052): the well-known prefix embeds an IPv4 address that a
+# translator on the network would deliver the connection to.
+_NAT64_PREFIX = ipaddress.ip_network("64:ff9b::/96")
+
+
 def _is_public_address(raw: str) -> bool:
     try:
         # A link-local IPv6 literal can carry a zone id ("fe80::1%eth0").
         ip = ipaddress.ip_address(raw.partition("%")[0])
     except ValueError:
         return False
-    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
-        # ::ffff:127.0.0.1 reaches loopback, so judge it as the v4 address.
-        ip = ip.ipv4_mapped
-    return not (
-        ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_reserved or ip.is_unspecified
-    )
+    if isinstance(ip, ipaddress.IPv6Address):
+        if ip.ipv4_mapped is not None:
+            # ::ffff:127.0.0.1 reaches loopback, so judge it as the v4 address.
+            ip = ip.ipv4_mapped
+        elif ip in _NAT64_PREFIX:
+            ip = ipaddress.ip_address(int(ip) & 0xFFFF_FFFF)
+    # is_global follows the IANA special-purpose registries, which also rule
+    # out ranges is_private misses — above all 100.64.0.0/10, carrier-grade
+    # NAT, which is where a tailnet lives. IPv6 multicast can be global scope,
+    # so it is excluded on its own.
+    return ip.is_global and not ip.is_multicast
 
 
-async def _assert_public_url(url: str) -> None:
-    """Refuse to fetch anything but a plain http(s) page on a public host.
+async def _assert_public_url(url: str) -> list[str]:
+    """Refuse anything but a plain http(s) URL on a publicly routed host, and
+    return the addresses that judgement was made on.
 
     Ingestion fetches a URL the caller supplied, so without this the endpoint
     is a request-forgery proxy (CWE-918): `POST /recipes/ingest` with
@@ -94,10 +106,10 @@ async def _assert_public_url(url: str) -> None:
     deployed on and hand the result back. Every redirect hop is checked
     separately, because a public page is free to redirect to loopback.
 
-    Names are resolved and the addresses judged, which closes the interesting
-    cases; it does not close DNS rebinding (a record whose value changes
-    between this lookup and the connection), which would need the connection
-    pinned to the address checked here.
+    The caller must connect to exactly the addresses returned here (see
+    _PinnedDialBackend): resolving the name a second time at connect time
+    would let a record that changed between the two lookups — DNS rebinding —
+    point the fetch at a private address after all.
     """
     parts = urlsplit(url)
     if parts.scheme.lower() not in _ALLOWED_SCHEMES:
@@ -124,20 +136,105 @@ async def _assert_public_url(url: str) -> None:
     if not addresses or not all(_is_public_address(address) for address in addresses):
         raise RecipeFetchError(
             f"{host} is not a public address, and this server only fetches recipes from the public "
-            f"internet — private, loopback and link-local addresses are refused. If the page is on your "
-            f"own network, {_READ_IT_YOURSELF}"
+            f"internet — private, loopback, link-local and carrier-grade NAT addresses are refused. "
+            f"If the page is on your own network, {_READ_IT_YOURSELF}"
         )
+    return addresses
+
+
+async def _validate_and_pin(pins: dict[str, list[str]], url: str) -> None:
+    """Judge a URL public and record its addresses under every spelling of the
+    host the HTTP stack might dial: urlsplit's (the one resolved) and httpx's
+    raw_host (an internationalised name becomes punycode there)."""
+    addresses = await _assert_public_url(url)
+    keys = {(urlsplit(url).hostname or "").lower()}
+    try:
+        raw_host = httpx.URL(url).raw_host.decode("ascii")
+    except httpx.InvalidURL as exc:
+        raise RecipeFetchError(f"{url} is not a fetchable URL ({exc}); check it, or {_READ_IT_YOURSELF}") from exc
+    keys.add(raw_host.lower())
+    for key in keys:
+        if key:
+            pins[key] = addresses
+
+
+class _PinnedDialBackend(httpcore.AsyncNetworkBackend):
+    """Network backend that only dials addresses _assert_public_url returned.
+
+    httpcore resolves a hostname again when it opens the socket; this replaces
+    that second lookup with the answer already judged (closing the rebinding
+    window above) and fails closed for any host that was never judged at all.
+    TLS is unaffected: httpcore wraps the socket with server_hostname taken
+    from the URL, so certificates are still verified against the site's name.
+    """
+
+    def __init__(self, inner: httpcore.AsyncNetworkBackend, pins: dict[str, list[str]]) -> None:
+        self._inner = inner
+        self._pins = pins
+
+    async def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options=None,
+    ) -> httpcore.AsyncNetworkStream:
+        addresses = self._pins.get(host.strip("[]").lower(), [])
+        if not addresses:
+            raise httpcore.ConnectError(f"{host!r} was never checked against the public-address policy")
+        error: httpcore.ConnectError | None = None
+        for address in addresses:
+            try:
+                return await self._inner.connect_tcp(
+                    address, port, timeout=timeout, local_address=local_address, socket_options=socket_options
+                )
+            except httpcore.ConnectError as exc:  # try the next resolved address, as a plain dial would
+                error = exc
+        assert error is not None
+        raise error
+
+    async def connect_unix_socket(self, path: str, timeout: float | None = None, socket_options=None):
+        raise httpcore.ConnectError("recipe fetching never uses unix sockets")
+
+    async def sleep(self, seconds: float) -> None:
+        await self._inner.sleep(seconds)
+
+
+def _fetch_transport() -> httpx.AsyncHTTPTransport:
+    """Its own function so tests can substitute a transport whose network
+    backend serves canned bytes instead of touching a socket."""
+    return httpx.AsyncHTTPTransport()
+
+
+def _pin_transport_dial(transport: httpx.AsyncHTTPTransport, pins: dict[str, list[str]]) -> None:
+    """Make the transport dial only pinned addresses.
+
+    Reaches into httpx internals — there is no supported hook for the dial
+    step. If an upgrade moves them, refuse to fetch at all rather than quietly
+    fetch unpinned; the ingestion tests fail loudly on that day.
+    """
+    pool = getattr(transport, "_pool", None)
+    inner = getattr(pool, "_network_backend", None)
+    if inner is None:
+        raise RuntimeError("httpx internals changed: recipe fetches can no longer be pinned to checked addresses")
+    pool._network_backend = _PinnedDialBackend(inner, pins)
 
 
 async def fetch_page(url: str) -> str:
     settings = get_settings()
     headers = {"User-Agent": "MealsBot/0.1 (+recipe ingestion; JSON-LD only)"}
-    await _assert_public_url(url)
+    # host → the addresses judged public for it; the transport refuses to dial
+    # anything else, so the address checked is the address connected.
+    pins: dict[str, list[str]] = {}
+    await _validate_and_pin(pins, url)
+    transport = _fetch_transport()
+    _pin_transport_dial(transport, pins)
     try:
         # Redirects are followed by hand so each hop goes through the same
         # public-address check as the URL the caller gave us.
         async with httpx.AsyncClient(
-            follow_redirects=False, timeout=settings.recipe_fetch_timeout_seconds, headers=headers
+            transport=transport, follow_redirects=False, timeout=settings.recipe_fetch_timeout_seconds, headers=headers
         ) as client:
             target = url
             for _ in range(_MAX_REDIRECTS + 1):
@@ -147,7 +244,7 @@ async def fetch_page(url: str) -> str:
                     return response.text
                 # next_request resolves a relative Location against the hop.
                 target = str(response.next_request.url)
-                await _assert_public_url(target)
+                await _validate_and_pin(pins, target)
             raise RecipeFetchError(
                 f"fetching {url} gave up after {_MAX_REDIRECTS} redirects; check the URL, or {_READ_IT_YOURSELF}"
             )

--- a/backend/tests/unit/test_fetch_page.py
+++ b/backend/tests/unit/test_fetch_page.py
@@ -1,3 +1,4 @@
+import httpcore
 import httpx
 import pytest
 import respx
@@ -48,6 +49,8 @@ async def test_network_error_becomes_actionable_message():
         "http://[::1]/",
         "http://[::ffff:127.0.0.1]/",  # loopback wearing an IPv6 hat
         "http://0.0.0.0/",
+        "http://100.100.1.1/",  # carrier-grade NAT — where a tailnet lives
+        "http://[64:ff9b::7f00:1]/",  # loopback wearing NAT64's well-known prefix
     ],
 )
 async def test_private_addresses_are_refused(url, monkeypatch):
@@ -131,3 +134,81 @@ async def test_unresolvable_host_is_actionable(monkeypatch):
     with pytest.raises(RecipeFetchError, match="could not resolve") as exc_info:
         await fetch_page("https://no-such-host.example/recipe")
     assert "POST /recipes" in str(exc_info.value)
+
+
+# ------------------------------------------------------------------ DNS pinning
+# The guard above judges the *resolved addresses*, so the connection must go to
+# exactly those addresses — a second lookup at connect time would let a DNS
+# record that changed between the two (rebinding) point the fetch somewhere
+# private after all. These tests run without respx: they exercise the real
+# httpx/httpcore plumbing down to the (canned) socket.
+
+
+class _RecordingBackend(httpcore.AsyncMockBackend):
+    """Serves canned HTTP bytes and records every address dialed."""
+
+    def __init__(self, buffer: list[bytes]) -> None:
+        super().__init__(buffer)
+        self.dialed: list[tuple[str, int]] = []
+
+    async def connect_tcp(self, host, port, timeout=None, local_address=None, socket_options=None):
+        self.dialed.append((host, port))
+        return await super().connect_tcp(
+            host, port, timeout=timeout, local_address=local_address, socket_options=socket_options
+        )
+
+
+async def test_connection_dials_the_checked_address_not_the_name(monkeypatch):
+    """The address judged public is the address connected; the hostname is
+    never resolved a second time at connect time."""
+
+    async def resolve(host: str) -> list[str]:
+        return ["93.184.216.34"]
+
+    monkeypatch.setattr(recipe_parser, "_resolve_host", resolve)
+    backend = _RecordingBackend([b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello"])
+
+    def canned_transport() -> httpx.AsyncHTTPTransport:
+        transport = httpx.AsyncHTTPTransport()
+        transport._pool._network_backend = backend
+        return transport
+
+    monkeypatch.setattr(recipe_parser, "_fetch_transport", canned_transport)
+    assert await fetch_page("http://example.com/chilli") == "hello"
+    assert backend.dialed == [("93.184.216.34", 80)]
+
+
+async def test_a_host_that_was_never_checked_is_refused_at_dial_time():
+    """Whatever path a hostname arrives by, dialing it without a prior
+    public-address judgement fails closed."""
+    backend = recipe_parser._PinnedDialBackend(httpcore.AsyncMockBackend([]), {})
+    with pytest.raises(httpcore.ConnectError, match="public-address policy"):
+        await backend.connect_tcp("unchecked.example", 80)
+
+
+class _FlakyBackend(httpcore.AsyncNetworkBackend):
+    def __init__(self) -> None:
+        self.dialed: list[str] = []
+
+    async def connect_tcp(self, host, port, timeout=None, local_address=None, socket_options=None):
+        self.dialed.append(host)
+        if host == "203.0.113.1":
+            raise httpcore.ConnectError("host down")
+        return httpcore.AsyncMockStream([])
+
+
+async def test_dial_falls_through_to_the_next_checked_address():
+    """Pinning must not lose multi-address fallback: a dual-stack host with
+    one dead address still loads."""
+    inner = _FlakyBackend()
+    backend = recipe_parser._PinnedDialBackend(inner, {"example.com": ["203.0.113.1", "203.0.113.2"]})
+    await backend.connect_tcp("example.com", 443)
+    assert inner.dialed == ["203.0.113.1", "203.0.113.2"]
+
+
+def test_pinning_surgery_holds_on_this_httpx():
+    """_pin_transport_dial reaches into httpx internals; if an upgrade moves
+    them it must raise rather than quietly fetch unpinned."""
+    transport = httpx.AsyncHTTPTransport()
+    recipe_parser._pin_transport_dial(transport, {})
+    assert isinstance(transport._pool._network_backend, recipe_parser._PinnedDialBackend)


### PR DESCRIPTION
## Summary

[Code-scanning alert #4](https://github.com/marco308/meals/security/code-scanning/4) (`py/full-ssrf`, critical) re-flagged `fetch_page` after the cc7c29a guard: CodeQL's taint analysis can't recognise a validate-don't-transform check, and since fetching a caller-supplied URL *is* recipe ingestion, the rule fires on any correct implementation. Looking into it surfaced two genuine gaps, though — one the guard's own docstring admitted.

**DNS rebinding is now closed.** The guard resolved the hostname and judged the addresses, then httpx resolved the name a second time to connect — a record that changed between the two lookups reached the private network after all. `_assert_public_url` now returns the addresses it judged, and a `httpcore` network-backend wrapper makes the transport dial exactly those, failing closed for any host that was never judged. TLS still verifies certificates against the URL's hostname (httpcore takes `server_hostname` from the origin, not the dial target), dual-stack fallback is preserved, and every redirect hop pins the same way. This is the "verify the IP, then make the connection use it" remedy CodeQL's help text prescribes.

**Address judgement moved from an `is_private` flag pile to `is_global`.** The old flags passed `100.64.0.0/10` (carrier-grade NAT — where a tailnet lives) as public. `is_global` refuses it, along with TEST-NET and benchmarking ranges; NAT64 `64:ff9b::/96` is unwrapped and judged as the embedded IPv4, the way `::ffff:` v4-mapped already was. IPv6 multicast can be "global" scope, so it stays excluded on its own.

The missing response-size cap noticed on the way is deferred to `BACKLOG.md` rather than snuck in here.

## Testing

- New: a canned-socket end-to-end test proving the connection dials the checked address (not the name), fail-closed and multi-address-fallback tests on the pinned backend, an internals canary so an httpx upgrade that moves `_pool._network_backend` fails loudly rather than fetching unpinned, and CGNAT + NAT64 refusal cases.
- `make test` (499 backend + 47 mcp) and `make lint` pass; no existing test needed changing — respx intercepts above the dial layer, which is also why the pin needed real-plumbing tests of its own.

## After merging

The alert itself will **not** auto-close: CodeQL still sees user input reaching the request, and always will. Dismiss #4 as "won't fix" with a note that ingestion is guarded by the scheme allow-list, per-hop public-address checks, and connections pinned to the checked addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)