### PR TITLE
Web app: the big-screen client, served by the API at /app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,11 @@ jobs:
           curl -fsS --max-time 10 http://localhost:8000/privacy > privacy.html
           grep -q '<h1' privacy.html
           curl -fsS --max-time 10 -o /dev/null http://localhost:8000/support
+          # The web client is COPYed into the image separately from app/ too —
+          # a build that forgets it serves a 404 where the big-screen UI was.
+          curl -fsS --max-time 10 http://localhost:8000/app/ > app.html
+          grep -qi 'yamp' app.html
+          curl -fsS --max-time 10 -o /dev/null http://localhost:8000/app/js/main.js
 
       - name: Verify the remote MCP initialize handshake
         run: |

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -15,6 +15,22 @@ tail plus engineering debt worth naming.
 - [ ] **Onboard the second household member** — no longer needs curl at either end: build 16 mints the code (Settings → Invite someone) and build 14 onwards can redeem it on the register screen. Both are on TestFlight, so this is now just a thing to do
 - [ ] **Clean the BBC misparse junk out of prod** — dual-measure lines left ingredients named "/3½oz vermicelli rice noodles", "/10½oz cooked" and friends behind (parser fixed + guarded `DELETE /ingredients/{id}` added 2026-07-29, Q22; summer_rolls_15105 is a known affected recipe). The recipe lines kept their raw text and correct metric quantities, so merging each junk row into the real food (`POST /ingredients/{keeper_id}/merge`) heals the recipes too; `DELETE /ingredients/{id}` mops up anything left unreferenced. An AI on the v9 playbook can do the whole sweep
 
+## Web app tail
+
+The web client (`web/`, served at `/app`) shipped covering the whole loop;
+what it deliberately doesn't do yet:
+
+- [ ] **Offline** — it's online-only by design (the iPhone in the supermarket
+  is the offline story; the web app is the kitchen/desk screen). If that ever
+  changes, the `PendingOp` queue semantics from iOS (Q11) are the model
+- [ ] **Servings scaling UI** — same gap as iOS; the API has no first-class
+  support yet (see "Servings scaling" below), the meal editor only exposes the
+  per-recipe `scale` factor
+- [ ] **Re-ingest from the recipe page** — blocked on the same "Re-parse
+  endpoint" item below
+- [ ] **Marketing site mention** — docs/ still sells "iPhone app + any AI";
+  the self-host pitch can now include the web app for free
+
 ## Account lifecycle
 
 - [x] ~~**Password reset**~~ — ✅ shipped (Q20): `POST /auth/password-reset` emails a typeable code, `POST /auth/password/reset-confirm` redeems it. Needs SMTP configured — `SMTP_HOST`, `SMTP_FROM`, and usually `SMTP_USERNAME`/`SMTP_PASSWORD` — or the endpoint returns 503 saying so. **Not yet set on the deployment**, so reset is unavailable in production until it is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 
 ### Added
 
+- **A web app**, served by the API itself at `/app` (`web/` in the repo) — the
+  big-screen client. Same-origin with the endpoints it calls, no build step, no
+  external requests; covers the plan, the shopping list (staples check,
+  "already have it", finish-the-shop, previous shops), recipe library with URL
+  ingest, meals, the ingredient catalogue (aisles, staples, value verdicts,
+  duplicate merge), and settings (invites, API tokens, password, account
+  deletion). Browsers at `/` on a deployment with no `marketing_url` configured
+  now land there instead of `/docs`; the JSON landing advertises it as `app`.
+  Assets are served `Cache-Control: no-cache` so a deploy shows up on the next
+  page load.
 - `GET /privacy` and `GET /support` — the App Store requires publicly reachable
   policy and support URLs, and the deployment is the only thing this project
   already hosts. Unauthenticated, exempt from the client gate, and rendered

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ is what keeps the API complete and the views consistent.
 | Path | Role |
 |---|---|
 | `backend/` | FastAPI + async SQLAlchemy 2.0 + Alembic. Postgres in Docker; SQLite for `make run` and all tests |
+| `web/` | Web app served by the backend at `/app` (StaticFiles mount in `app/main.py`). No build step: hand-written HTML/CSS + ES modules, same-origin with the API, no external requests |
 | `ios/Meals/` | SwiftUI app (Swift 6, strict concurrency). Offline-first shopping list |
 | `mcp/` | MCP server: a thin task-level wrapper over the REST API, no DB access |
 | `skill/` | `SKILL.md` + `prompt-pack.md` — served live by the backend at `/skill` and `/prompt-pack` |
@@ -111,6 +112,32 @@ from `deps.py`; every query filters on `user.household_id`.
   household's own verdict — unlike an aisle it is **never guessed**, so no
   keyword table. It rides along on list items and recipe lines so it shows up
   at the shelf; the vocabulary is published in the skill.
+
+### The web client (`web/`)
+
+Ships inside the backend image (repo-root build context, like `skill/`) and is
+mounted at `/app` with the same two-place directory lookup; browsers hitting
+`/` with no `marketing_url` configured are redirected there. Rules that keep
+it boring to operate:
+
+- **No build step, no external requests.** Hand-written CSS + ES modules the
+  browser loads directly; recipe `image_url`s are the one external fetch
+  (allowed by the CSP in `index.html`). Don't introduce npm, bundlers, or CDN
+  scripts.
+- **Assets are served `Cache-Control: no-cache`** (`_RevalidatedStaticFiles`)
+  because there are no hashed filenames — every load revalidates by ETag, so a
+  deploy shows up on the next page load. Don't "optimise" this into long-lived
+  caching without adding content hashes.
+- It identifies as `X-Meals-Client: web/1.0 (1)`; only `ios/*` is ever gated,
+  and the web app deploys *with* the server, so it can never be older than the
+  API — no gate, no version ceremony.
+- The XSS boundary is the `html` tagged template in `js/dom.js` (everything
+  interpolated is escaped unless it is itself a template). Never build DOM
+  strings outside it.
+- Dialog code must not depend on the `close` *event* — some embedded browsers
+  never deliver it; `openDialog` patches `close()` to also remove the element.
+- The 4xx `detail` strings the API writes for AI clients are shown verbatim in
+  toasts — another reason to keep them human sentences.
 
 ### Client/API compatibility
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ make dev     # full stack in Docker: Postgres + API on http://localhost:8000
 make seed    # demo user, recipes, a plan, and a ready-made shopping list
 ```
 
-Interactive API docs: <http://localhost:8000/docs>. The seed's demo account is
+The **web app** is at <http://localhost:8000/app/> (a browser at the bare
+address is redirected there). Interactive API docs: <http://localhost:8000/docs>. The seed's demo account is
 `demo@example.com` / `demo-password-123`, and it prints an API token you can
 use immediately with `curl` or the MCP server. (The password lives here rather
 than in the seed's output: `make seed` also fills real accounts on real servers
@@ -86,10 +87,23 @@ PASSWORD_RESET_TTL_MINUTES=30   # default
 | Directory | Contents |
 |---|---|
 | [`backend/`](backend/) | FastAPI + async SQLAlchemy + Alembic. Postgres in Docker, SQLite for local/tests |
+| [`web/`](web/) | Web app, served by the API itself at `/app` — the big-screen client. Plain HTML/CSS/ES modules, no build step |
 | [`ios/`](ios/) | Native SwiftUI iPhone app: plan, recipe library + URL ingest, and an **offline-first shopping list** |
 | [`mcp/`](mcp/) | MCP server wrapping the API with task-level tools (`ingest_recipe`, `get_shopping_list`, `check_off`, …) |
 | [`skill/`](skill/) | The AI playbook: `SKILL.md` (Claude-family Agent Skill) + `prompt-pack.md` (portable, any assistant) — served live at `/skill` + `/prompt-pack` |
 | [`planning/`](planning/) | Product plan and decisions log this POC implements |
+
+### Web app
+
+The big-screen client, served by the API itself at `/app` — same origin as the
+endpoints it calls, so there's no second host, no CORS, nothing extra to
+deploy: if the server is up, the web app is too. Plain HTML/CSS/ES modules
+with no build step and no external requests, in the same Sunday-market skin as
+the site (dark mode included). It covers the whole loop: the plan, the
+shopping list (staples check, "already have it", finish-the-shop), recipe
+library with URL ingest, meals, the ingredient catalogue (aisles, staples,
+⭐/💷 verdicts, duplicate merge — the tidy-up screens the phone doesn't have),
+and settings (invites, API tokens, password, account deletion).
 
 ### iOS app
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,6 +15,8 @@ COPY backend/alembic ./alembic
 COPY backend/app ./app
 # The skill + prompt pack, served at /skill and /prompt-pack
 COPY skill ./skill
+# The web client, served at /app — same-origin with the API it calls
+COPY web ./web
 # The App Store's privacy and support URLs point at /privacy and /support, which
 # render these. If they don't ship, those URLs 404 and the listing is broken.
 COPY PRIVACY.md SUPPORT.md ./

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,10 @@
 from collections.abc import Awaitable, Callable
+from pathlib import Path
 
 from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
 
 from app import client_gate
 from app.config import get_settings
@@ -70,14 +72,46 @@ app.include_router(shopping.router)
 app.include_router(skill.router)
 app.include_router(pages.router)
 
+# The web client is served by the API itself so it is always same-origin with
+# the endpoints it calls — no CORS, no second host to deploy or certify. Plain
+# static files with no build step; hash routing means only /app/ itself and its
+# assets need serving. In the Docker image web/ sits next to app/
+# (/srv/meals/web); in a repo checkout it lives at the repo root. Same
+# two-place lookup as the skill router, for the same reason.
+_WEB_DIRS = (
+    Path(__file__).resolve().parents[1] / "web",
+    Path(__file__).resolve().parents[2] / "web",
+)
+_web_dir = next((path for path in _WEB_DIRS if path.is_dir()), None)
+
+
+class _RevalidatedStaticFiles(StaticFiles):
+    """`Cache-Control: no-cache` on every asset (revalidate, don't refetch).
+
+    With no build step there are no hashed filenames, and the ES modules the
+    shell imports carry no ?v= query — heuristic caching would keep a browser
+    on weeks-stale JS after a deploy. ETag revalidation makes this cheap: the
+    steady state is 304s, and a deploy shows up on the next load.
+    """
+
+    def file_response(self, *args: object, **kwargs: object) -> Response:
+        response = super().file_response(*args, **kwargs)
+        response.headers.setdefault("Cache-Control", "no-cache")
+        return response
+
+
+if _web_dir is not None:
+    app.mount("/app", _RevalidatedStaticFiles(directory=_web_dir, html=True), name="webapp")
+
 
 @app.get("/", include_in_schema=False)
 async def root(request: Request) -> Response:
-    # Browsers get the marketing site when this deployment has one, the
-    # interactive docs otherwise; assistants and curl get a JSON landing
-    # advertising every machine-readable surface (issue #5).
+    # Browsers get the marketing site when this deployment has one, the web
+    # app otherwise (it ships in the image, so a self-hosted bare domain lands
+    # somewhere usable); assistants and curl get a JSON landing advertising
+    # every machine-readable surface (issue #5).
     if "text/html" in request.headers.get("accept", ""):
-        return RedirectResponse(settings.marketing_url or "/docs")
+        return RedirectResponse(settings.marketing_url or ("/app/" if _web_dir else "/docs"))
     base = base_url(request)
     landing = {
         "name": settings.app_name,
@@ -85,6 +119,7 @@ async def root(request: Request) -> Response:
         "description": "Meal options planner with an AI-first API — fetch the skill for the workflow guide.",
         "openapi": f"{base}/openapi.json",
         "docs": f"{base}/docs",
+        "app": f"{base}/app/",
         "skill": f"{base}/skill",
         "prompt_pack": f"{base}/prompt-pack",
         # Lets an assistant spot a stale installed copy without a second request.

--- a/backend/tests/integration/test_misc.py
+++ b/backend/tests/integration/test_misc.py
@@ -19,10 +19,13 @@ class TestMeta:
         assert response.status_code == 200
         assert response.json()["status"] == "ok"
 
-    async def test_root_redirects_browsers_to_docs(self, client):
+    async def test_root_redirects_browsers_to_the_web_app(self, client):
+        """No marketing_url set (the self-hosted default): browsers land on the
+        web app now that one ships in the image. /docs remains the fallback
+        only for a build without web/."""
         response = await client.get("/", headers={"accept": "text/html,application/xhtml+xml"})
         assert response.status_code == 307
-        assert response.headers["location"] == "/docs"
+        assert response.headers["location"] == "/app/"
 
     async def test_root_redirects_browsers_to_the_marketing_site_when_set(self, client, monkeypatch):
         """A deployment with a public face sends browsers there instead of the docs."""

--- a/backend/tests/integration/test_webapp.py
+++ b/backend/tests/integration/test_webapp.py
@@ -1,0 +1,38 @@
+"""The web client ships inside the API and is served at /app.
+
+Same-origin with the endpoints it calls, so a self-hosted deployment gets the
+big-screen UI with no second host and no CORS configuration. These tests pin
+the serving contract; whether the app *works* is exercised in a browser, not
+here.
+"""
+
+from httpx import AsyncClient
+
+
+async def test_webapp_served_unauthenticated(client: AsyncClient):
+    """The shell must load without credentials — login happens inside it."""
+    response = await client.get("/app/")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert "yamp" in response.text.lower()
+
+
+async def test_webapp_redirects_bare_path(client: AsyncClient):
+    response = await client.get("/app")
+    assert response.status_code in (301, 307)
+    assert response.headers["location"].endswith("/app/")
+
+
+async def test_webapp_serves_module_assets(client: AsyncClient):
+    """The shell loads ES modules directly; a missing mount or COPY makes the
+    page render blank rather than 404, so pin the asset paths themselves."""
+    for path, content_type in (
+        ("/app/js/main.js", "javascript"),  # text/ vs application/ varies by Python version
+        ("/app/app.css", "text/css"),
+    ):
+        response = await client.get(path)
+        assert response.status_code == 200, path
+        assert content_type in response.headers["content-type"], path
+        # No build step means no hashed filenames: every asset must revalidate
+        # (ETag 304s), or a deploy leaves browsers on heuristically-cached JS.
+        assert response.headers["cache-control"] == "no-cache", path

--- a/web/app.css
+++ b/web/app.css
@@ -1,0 +1,809 @@
+/* YAMP web client.
+   Aesthetic: the working-tool half of the marketing site's Sunday market —
+   warm cream paper, rounded friendly type, awning stripes, shelf-edge aisle
+   labels, a weekly plan that looks like the menu card on the front of the
+   site. Dark mode is the chalkboard after close: warm near-black, chalk text,
+   the same accents turned up a notch.
+   Hand-written, no build step, no external requests. */
+
+:root {
+  --cream:     #fbf5e9;
+  --cream-2:   #f5edda;
+  --card:      #fffdf6;
+  --ink:       #33261a;
+  --ink-soft:  #5f5142;
+  --ink-mute:  #8d7f6d;
+  --tomato:    #df4a2b;
+  --tomato-dk: #c23c20;
+  --leek:      #4f7d33;
+  --butter:    #e8a53a;
+  --butter-dk: #b57d20;
+  --tint-red:    #f9e2d8;
+  --tint-green:  #e6eed6;
+  --tint-butter: #f8ecca;
+  --line:      rgba(51, 38, 26, .14);
+  --line-2:    rgba(51, 38, 26, .3);
+  --shadow:    0 14px 34px rgba(51, 38, 26, .10);
+  --shadow-sm: 0 3px 12px rgba(51, 38, 26, .07);
+
+  --display: ui-rounded, "SF Pro Rounded", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --body: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+  --ease: cubic-bezier(.22, 1, .36, 1);
+  --sidebar: 236px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --cream:     #211a12;
+    --cream-2:   #1b150e;
+    --card:      #2c231a;
+    --ink:       #f1e8d9;
+    --ink-soft:  #cdbfab;
+    --ink-mute:  #9c8d7b;
+    --tomato:    #f06a47;
+    --tomato-dk: #d64f2e;
+    --leek:      #8ab364;
+    --butter:    #eebc59;
+    --butter-dk: #d9a33e;
+    --tint-red:    rgba(240, 106, 71, .16);
+    --tint-green:  rgba(138, 179, 100, .16);
+    --tint-butter: rgba(238, 188, 89, .15);
+    --line:      rgba(241, 232, 217, .14);
+    --line-2:    rgba(241, 232, 217, .32);
+    --shadow:    0 14px 34px rgba(0, 0, 0, .35);
+    --shadow-sm: 0 3px 12px rgba(0, 0, 0, .25);
+  }
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  background: var(--cream);
+  color: var(--ink);
+  font-family: var(--body);
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  min-height: 100vh;
+}
+
+h1, h2, h3 {
+  font-family: var(--display);
+  font-weight: 800;
+  letter-spacing: -.02em;
+  line-height: 1.1;
+  margin: 0;
+}
+
+a { color: inherit; }
+button { font: inherit; color: inherit; }
+::placeholder { color: var(--ink-mute); opacity: .8; }
+:focus-visible { outline: 2px solid var(--tomato); outline-offset: 2px; border-radius: 4px; }
+
+/* ── awning ─────────────────────────────────────────────────────────── */
+
+.awning {
+  position: fixed;
+  inset: 0 0 auto 0;
+  z-index: 60;
+  height: 10px;
+  background: repeating-linear-gradient(90deg,
+    var(--tomato) 0 28px, var(--card) 28px 56px);
+}
+.awning::after {
+  content: "";
+  position: absolute;
+  top: 10px; left: 0; right: 0;
+  height: 7px;
+  background:
+    radial-gradient(circle at 14px -4px, var(--tomato) 0 13px, transparent 13.5px) 0 0 / 56px 7px repeat-x,
+    radial-gradient(circle at 14px -4px, var(--card) 0 13px, transparent 13.5px) 28px 0 / 56px 7px repeat-x;
+}
+
+/* ── shell ──────────────────────────────────────────────────────────── */
+
+#shell { min-height: 100vh; }
+
+.app {
+  display: grid;
+  grid-template-columns: var(--sidebar) minmax(0, 1fr);
+  min-height: 100vh;
+}
+
+/* ── sidebar ────────────────────────────────────────────────────────── */
+
+.side {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: .4rem;
+  padding: 2.2rem 1rem 1.1rem;
+  background: var(--cream-2);
+  border-right: 1px solid var(--line);
+}
+
+.wordmark {
+  font-family: var(--display);
+  font-weight: 800;
+  font-size: 1.9rem;
+  letter-spacing: -.03em;
+  text-decoration: none;
+  padding: 0 .65rem;
+  margin-bottom: 1.1rem;
+}
+.wordmark .dot { color: var(--tomato); }
+
+.side nav { display: flex; flex-direction: column; gap: 2px; }
+
+.nav-link {
+  display: flex;
+  align-items: center;
+  gap: .65rem;
+  padding: .5rem .65rem;
+  border-radius: 12px;
+  text-decoration: none;
+  font-weight: 600;
+  color: var(--ink-soft);
+  transition: background .15s var(--ease), color .15s;
+}
+.nav-link .n-emoji { font-size: 1.15rem; width: 1.5rem; text-align: center; }
+.nav-link:hover { background: color-mix(in srgb, var(--card) 70%, transparent); color: var(--ink); }
+.nav-link.active {
+  background: var(--card);
+  color: var(--ink);
+  box-shadow: var(--shadow-sm);
+}
+.nav-link.active .n-label { color: var(--tomato); }
+
+.side .spacer { flex: 1; }
+
+.side-user {
+  border-top: 1px dashed var(--line-2);
+  padding: .85rem .65rem .2rem;
+  font-size: .85rem;
+  color: var(--ink-mute);
+  line-height: 1.4;
+}
+.side-user b { color: var(--ink-soft); display: block; }
+
+/* ── content ────────────────────────────────────────────────────────── */
+
+.content {
+  padding: 2.6rem 3rem 5rem;
+  min-width: 0;
+}
+.page { max-width: 1120px; margin: 0 auto; }
+.page.narrow { max-width: 780px; }
+
+.page-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.6rem;
+}
+.page-head h1 { font-size: 2rem; }
+.page-head .sub { color: var(--ink-mute); margin: .3rem 0 0; font-size: .95rem; }
+.page-actions { display: flex; gap: .5rem; flex-wrap: wrap; align-items: center; }
+
+/* staggered arrival */
+.page > * { animation: rise .38s var(--ease) backwards; }
+.page > *:nth-child(2) { animation-delay: .05s; }
+.page > *:nth-child(3) { animation-delay: .1s; }
+.page > *:nth-child(4) { animation-delay: .15s; }
+.page > *:nth-child(5) { animation-delay: .2s; }
+@keyframes rise { from { opacity: 0; transform: translateY(10px); } }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { animation: none !important; transition: none !important; }
+}
+
+/* ── buttons ────────────────────────────────────────────────────────── */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: .45rem;
+  padding: .5rem 1.05rem;
+  border: 1.5px solid var(--tomato);
+  border-radius: 999px;
+  background: var(--tomato);
+  color: #fff;
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: .92rem;
+  letter-spacing: -.01em;
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform .12s var(--ease), background .15s, border-color .15s, box-shadow .15s;
+}
+.btn:hover { background: var(--tomato-dk); border-color: var(--tomato-dk); transform: translateY(-1px); box-shadow: var(--shadow-sm); }
+.btn:active { transform: translateY(0); }
+.btn.ghost { background: transparent; color: var(--ink); border-color: var(--line-2); }
+.btn.ghost:hover { background: var(--card); border-color: var(--ink-soft); }
+.btn.leek { background: var(--leek); border-color: var(--leek); }
+.btn.leek:hover { background: color-mix(in srgb, var(--leek) 85%, black); }
+.btn.danger { background: transparent; color: var(--tomato); border-color: var(--tomato); }
+.btn.danger:hover { background: var(--tomato); color: #fff; }
+.btn.small { padding: .28rem .75rem; font-size: .82rem; }
+.btn[disabled] { opacity: .45; pointer-events: none; }
+
+.link-btn {
+  background: none; border: 0; padding: 0;
+  color: var(--tomato); font-weight: 600; cursor: pointer;
+  text-decoration: underline; text-underline-offset: 3px;
+  font-size: inherit;
+}
+.link-btn:hover { color: var(--tomato-dk); }
+
+/* ── forms ──────────────────────────────────────────────────────────── */
+
+label.field { display: block; margin-bottom: .9rem; }
+label.field > span, .field-label {
+  display: block;
+  font-size: .72rem;
+  font-weight: 700;
+  letter-spacing: .09em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  margin-bottom: .3rem;
+}
+
+input[type="text"], input[type="email"], input[type="password"], input[type="number"],
+input[type="url"], input[type="search"], textarea, select {
+  width: 100%;
+  padding: .55rem .8rem;
+  border: 1.5px solid var(--line);
+  border-radius: 11px;
+  background: var(--card);
+  color: var(--ink);
+  font: inherit;
+  transition: border-color .15s, box-shadow .15s;
+}
+input:focus, textarea:focus, select:focus {
+  outline: none;
+  border-color: var(--tomato);
+  box-shadow: 0 0 0 3px var(--tint-red);
+}
+textarea { resize: vertical; min-height: 7.5rem; line-height: 1.6; }
+select { cursor: pointer; }
+
+.form-row { display: flex; gap: .75rem; }
+.form-row > * { flex: 1; }
+
+.check-line { display: flex; align-items: center; gap: .5rem; font-size: .95rem; cursor: pointer; }
+.check-line input { width: auto; }
+
+/* ── cards & chips ──────────────────────────────────────────────────── */
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  box-shadow: var(--shadow-sm);
+  padding: 1.4rem 1.5rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: .3rem;
+  padding: .12rem .6rem;
+  border-radius: 999px;
+  font-size: .76rem;
+  font-weight: 700;
+  font-family: var(--display);
+  letter-spacing: 0;
+  white-space: nowrap;
+  background: var(--cream-2);
+  color: var(--ink-soft);
+  border: 1px solid var(--line);
+}
+.chip.red    { background: var(--tint-red);    color: var(--tomato-dk); border-color: transparent; }
+.chip.green  { background: var(--tint-green);  color: var(--leek);      border-color: transparent; }
+.chip.butter { background: var(--tint-butter); color: var(--butter-dk); border-color: transparent; }
+.chip.click { cursor: pointer; border: 1px solid var(--line); background: var(--card); }
+.chip.click:hover { border-color: var(--ink-soft); }
+.chip.click.on { background: var(--ink); color: var(--cream); border-color: var(--ink); }
+
+/* ── toolbar ────────────────────────────────────────────────────────── */
+
+.toolbar {
+  display: flex;
+  gap: .6rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 1.3rem;
+}
+.toolbar input[type="search"] { max-width: 300px; }
+.toolbar select { width: auto; }
+.toolbar .gap { flex: 1; }
+
+/* ── menu card (the plan) ───────────────────────────────────────────── */
+
+.menu-card {
+  position: relative;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  box-shadow: var(--shadow);
+  padding: 1.9rem 2.1rem 1.6rem;
+  overflow: hidden;
+}
+.menu-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 9px;
+  background: repeating-linear-gradient(90deg,
+    var(--tomato) 0 22px, transparent 22px 44px);
+  opacity: .9;
+}
+.menu-title-row { display: flex; align-items: baseline; justify-content: space-between; gap: 1rem; flex-wrap: wrap; }
+.menu-title { font-family: var(--display); font-weight: 800; font-size: 1.55rem; letter-spacing: -.02em; }
+.menu-sub { color: var(--ink-mute); font-size: .92rem; margin: .15rem 0 0; }
+
+.menu-list { list-style: none; margin: 1.2rem 0 0; padding: 0; }
+.menu-item {
+  display: flex;
+  align-items: center;
+  gap: .85rem;
+  padding: .8rem .35rem;
+  border-top: 1px dashed var(--line-2);
+}
+.menu-item:first-child { border-top: 0; }
+.m-emoji { font-size: 1.5rem; width: 2.1rem; text-align: center; flex: none; }
+.m-name {
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 1.08rem;
+  letter-spacing: -.01em;
+  text-decoration: none;
+}
+.m-name:hover { color: var(--tomato); }
+.menu-item .m-main { flex: 1; min-width: 0; }
+.m-meta { display: flex; gap: .4rem; margin-top: .15rem; flex-wrap: wrap; }
+.menu-item .m-actions { display: flex; gap: .4rem; opacity: 0; transition: opacity .15s; }
+.menu-item:hover .m-actions, .menu-item:focus-within .m-actions { opacity: 1; }
+.menu-item.cooked .m-name { color: var(--ink-mute); }
+.menu-item.cooked .m-emoji { filter: grayscale(.6); opacity: .7; }
+.menu-foot {
+  text-align: center;
+  color: var(--ink-mute);
+  font-size: .85rem;
+  margin: 1.3rem 0 0;
+  font-style: italic;
+}
+
+/* ── shopping list ──────────────────────────────────────────────────── */
+
+.aisle-group { margin-bottom: 1.7rem; break-inside: avoid; }
+.aisle-head {
+  display: flex;
+  align-items: center;
+  gap: .6rem;
+  padding-bottom: .45rem;
+  border-bottom: 2px solid var(--line);
+  margin-bottom: .3rem;
+}
+.aisle-head .a-emoji {
+  font-size: 1.25rem;
+  background: var(--cream-2);
+  border-radius: 10px;
+  padding: .18rem .4rem;
+}
+.aisle-head .a-label {
+  font-family: var(--display);
+  font-weight: 800;
+  font-size: .82rem;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+.aisle-head .a-count { margin-left: auto; color: var(--ink-mute); font-size: .8rem; font-variant-numeric: tabular-nums; }
+
+.shop-item {
+  display: flex;
+  align-items: center;
+  gap: .75rem;
+  padding: .55rem .3rem;
+  border-bottom: 1px dashed var(--line);
+}
+.shop-item:last-child { border-bottom: 0; }
+
+.tick {
+  flex: none;
+  width: 23px; height: 23px;
+  border: 2px solid var(--line-2);
+  border-radius: 50%;
+  background: var(--card);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition: background .18s var(--ease), border-color .18s;
+}
+.tick::after {
+  content: "✓";
+  font-size: .8rem;
+  font-weight: 900;
+  color: #fff;
+  transform: scale(0);
+  transition: transform .18s var(--ease);
+}
+.tick[aria-pressed="true"] { background: var(--leek); border-color: var(--leek); }
+.tick[aria-pressed="true"]::after { transform: scale(1); }
+
+.shop-item .qty {
+  font-family: var(--mono);
+  font-size: .82rem;
+  color: var(--ink-soft);
+  min-width: 4.2rem;
+  text-align: right;
+  flex: none;
+  font-variant-numeric: tabular-nums;
+}
+.shop-item .i-main { flex: 1; min-width: 0; }
+.i-name {
+  font-weight: 600;
+  background-image: linear-gradient(var(--ink-mute), var(--ink-mute));
+  background-size: 0% 1.5px;
+  background-position: 0 58%;
+  background-repeat: no-repeat;
+  transition: background-size .3s var(--ease), color .3s;
+}
+.shop-item.done .i-name { background-size: 100% 1.5px; color: var(--ink-mute); }
+.shop-item.done .qty { opacity: .5; }
+.i-why { font-size: .78rem; color: var(--ink-mute); margin-top: .05rem; }
+.shop-item .i-actions { display: flex; gap: .35rem; opacity: 0; transition: opacity .15s; }
+.shop-item:hover .i-actions, .shop-item:focus-within .i-actions { opacity: 1; }
+
+.icon-btn {
+  border: 1px solid var(--line);
+  background: var(--card);
+  border-radius: 9px;
+  padding: .2rem .5rem;
+  font-size: .78rem;
+  cursor: pointer;
+  color: var(--ink-soft);
+  white-space: nowrap;
+}
+.icon-btn:hover { border-color: var(--ink-soft); color: var(--ink); }
+.icon-btn.warm:hover { border-color: var(--tomato); color: var(--tomato); }
+
+.quick-add {
+  display: flex;
+  gap: .6rem;
+  margin-bottom: 1.6rem;
+}
+.quick-add input { flex: 1; font-size: 1rem; padding: .7rem 1rem; border-radius: 999px; }
+
+.staples-banner {
+  background: var(--tint-butter);
+  border: 1px dashed var(--butter-dk);
+  color: var(--butter-dk);
+  border-radius: 14px;
+  padding: .7rem 1rem;
+  font-size: .92rem;
+  margin-bottom: 1.2rem;
+}
+
+@media (min-width: 1240px) {
+  .aisle-columns { columns: 2; column-gap: 3rem; }
+}
+
+/* ── recipe grid ────────────────────────────────────────────────────── */
+
+.recipe-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1.1rem;
+}
+.recipe-card {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  overflow: hidden;
+  text-decoration: none;
+  box-shadow: var(--shadow-sm);
+  transition: transform .16s var(--ease), box-shadow .16s;
+  display: flex;
+  flex-direction: column;
+}
+.recipe-card:hover { transform: translateY(-3px); box-shadow: var(--shadow); }
+.recipe-card .r-img {
+  aspect-ratio: 5 / 3;
+  background: var(--cream-2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.4rem;
+  overflow: hidden;
+}
+.recipe-card .r-img img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.recipe-card .r-body { padding: .85rem 1rem 1rem; display: flex; flex-direction: column; gap: .4rem; flex: 1; }
+.recipe-card .r-title { font-family: var(--display); font-weight: 700; font-size: 1.05rem; letter-spacing: -.01em; line-height: 1.25; }
+.recipe-card .r-meta { display: flex; gap: .55rem; flex-wrap: wrap; color: var(--ink-mute); font-size: .8rem; margin-top: auto; }
+
+/* ── detail pages ───────────────────────────────────────────────────── */
+
+.crumb { font-size: .88rem; color: var(--ink-mute); margin-bottom: 1rem; }
+.crumb a { text-decoration: none; color: var(--ink-soft); }
+.crumb a:hover { color: var(--tomato); }
+
+.detail-cols {
+  display: grid;
+  grid-template-columns: minmax(280px, 380px) minmax(0, 1fr);
+  gap: 1.6rem;
+  align-items: start;
+}
+@media (max-width: 980px) { .detail-cols { grid-template-columns: 1fr; } }
+
+.hero-img {
+  border-radius: 18px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  box-shadow: var(--shadow-sm);
+  margin-bottom: 1.4rem;
+  max-height: 340px;
+}
+.hero-img img { width: 100%; height: 100%; max-height: 340px; object-fit: cover; display: block; }
+
+.ing-list { list-style: none; margin: 0; padding: 0; }
+.ing-list li {
+  display: flex;
+  gap: .6rem;
+  align-items: baseline;
+  padding: .45rem 0;
+  border-bottom: 1px dashed var(--line);
+}
+.ing-list li:last-child { border-bottom: 0; }
+.ing-list .qty { font-family: var(--mono); font-size: .82rem; color: var(--ink-soft); min-width: 4.5rem; text-align: right; flex: none; font-variant-numeric: tabular-nums; }
+
+.prose { line-height: 1.7; }
+.prose p { margin: 0 0 .9rem; }
+.prose ol { margin: 0; padding-left: 1.3rem; }
+.prose ol li { margin-bottom: .7rem; padding-left: .3rem; }
+.prose ol li::marker { font-family: var(--display); font-weight: 800; color: var(--tomato); }
+
+.meta-chips { display: flex; gap: .45rem; flex-wrap: wrap; margin: .6rem 0 0; }
+
+/* ── plain rows (meals, ingredients, settings tables) ───────────────── */
+
+.row-list { list-style: none; margin: 0; padding: 0; }
+.row-card {
+  display: flex;
+  align-items: center;
+  gap: .9rem;
+  padding: .85rem 1.1rem;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  margin-bottom: .55rem;
+  text-decoration: none;
+  transition: transform .14s var(--ease), box-shadow .14s;
+}
+a.row-card:hover { transform: translateY(-1px); box-shadow: var(--shadow-sm); }
+.row-card .rc-emoji { font-size: 1.4rem; flex: none; }
+.row-card .rc-main { flex: 1; min-width: 0; }
+.row-card .rc-title { font-family: var(--display); font-weight: 700; font-size: 1.02rem; }
+.row-card .rc-sub { font-size: .82rem; color: var(--ink-mute); margin-top: .1rem; }
+.row-card .rc-side { display: flex; gap: .4rem; align-items: center; flex-wrap: wrap; justify-content: flex-end; }
+
+table.plain {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: .92rem;
+}
+table.plain th {
+  text-align: left;
+  font-size: .72rem;
+  letter-spacing: .09em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  font-weight: 700;
+  padding: .4rem .6rem;
+  border-bottom: 2px solid var(--line);
+}
+table.plain td { padding: .55rem .6rem; border-bottom: 1px dashed var(--line); vertical-align: middle; }
+table.plain tr:last-child td { border-bottom: 0; }
+
+/* ── ingredient manager rows ────────────────────────────────────────── */
+
+.ing-row { display: grid; grid-template-columns: minmax(140px, 1.4fr) auto minmax(110px, 1fr) auto minmax(120px, 1fr) minmax(160px, 1.4fr) auto; gap: .6rem; align-items: center; padding: .5rem 0; border-bottom: 1px dashed var(--line); }
+.ing-row.ing-head { border-bottom: 2px solid var(--line); }
+.ing-row .name { font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ing-row select, .ing-row input { padding: .32rem .55rem; font-size: .88rem; border-radius: 9px; }
+.ing-row .flash { animation: saved .8s var(--ease); }
+@keyframes saved { 0% { background: var(--tint-green); } 100% { background: transparent; } }
+
+.scale-input { width: 4.4rem; padding: .3rem .5rem; font-size: .88rem; }
+
+/* ── editor line rows ───────────────────────────────────────────────── */
+
+.line-row { display: grid; grid-template-columns: 6.5rem 7.5rem minmax(0, 1fr) auto; gap: .55rem; margin-bottom: .5rem; }
+.line-row input { padding: .45rem .65rem; }
+
+/* ── login ──────────────────────────────────────────────────────────── */
+
+.login-wrap {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 3rem 1.2rem;
+}
+.login-card {
+  width: min(430px, 100%);
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  box-shadow: var(--shadow);
+  padding: 2.1rem 2.2rem 1.9rem;
+  position: relative;
+  overflow: hidden;
+}
+.login-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 9px;
+  background: repeating-linear-gradient(90deg, var(--tomato) 0 22px, transparent 22px 44px);
+}
+.login-card .wordmark { display: block; text-align: center; font-size: 2.3rem; padding: 0; margin: .4rem 0 .1rem; }
+.login-card .strap { text-align: center; color: var(--ink-mute); font-size: .92rem; margin: 0 0 1.5rem; }
+.login-tabs { display: flex; gap: .3rem; background: var(--cream-2); border-radius: 999px; padding: .25rem; margin-bottom: 1.4rem; }
+.login-tabs button {
+  flex: 1;
+  border: 0;
+  background: none;
+  padding: .45rem .5rem;
+  border-radius: 999px;
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: .9rem;
+  color: var(--ink-mute);
+  cursor: pointer;
+}
+.login-tabs button.on { background: var(--card); color: var(--ink); box-shadow: var(--shadow-sm); }
+.login-card .btn { width: 100%; justify-content: center; padding: .65rem 1rem; font-size: 1rem; margin-top: .4rem; }
+.login-foot { text-align: center; margin-top: 1.1rem; font-size: .85rem; color: var(--ink-mute); }
+
+.seg { display: flex; gap: .3rem; background: var(--cream-2); border-radius: 999px; padding: .22rem; margin-bottom: 1rem; }
+.seg button { flex: 1; border: 0; background: none; padding: .35rem .5rem; border-radius: 999px; font-weight: 600; font-size: .85rem; color: var(--ink-mute); cursor: pointer; }
+.seg button.on { background: var(--card); color: var(--ink); box-shadow: var(--shadow-sm); }
+
+/* ── dialogs ────────────────────────────────────────────────────────── */
+
+dialog {
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  background: var(--card);
+  color: var(--ink);
+  box-shadow: var(--shadow);
+  padding: 1.6rem 1.7rem;
+  width: min(520px, calc(100vw - 2rem));
+  max-height: min(84vh, 720px);
+  overflow: auto;
+}
+dialog::backdrop { background: rgba(30, 20, 12, .45); backdrop-filter: blur(2px); }
+dialog h2 { font-size: 1.3rem; margin-bottom: .9rem; }
+.dialog-actions { display: flex; justify-content: flex-end; gap: .6rem; margin-top: 1.3rem; }
+
+.code-reveal {
+  font-family: var(--mono);
+  font-size: 1.05rem;
+  background: var(--cream-2);
+  border: 1px dashed var(--line-2);
+  border-radius: 12px;
+  padding: .8rem 1rem;
+  text-align: center;
+  letter-spacing: .06em;
+  word-break: break-all;
+  user-select: all;
+}
+
+.picker-list { list-style: none; margin: .8rem 0 0; padding: 0; max-height: 320px; overflow: auto; }
+.picker-list li { display: flex; align-items: center; gap: .6rem; padding: .5rem .2rem; border-bottom: 1px dashed var(--line); }
+.picker-list li:last-child { border-bottom: 0; }
+.picker-list .p-main { flex: 1; min-width: 0; }
+.picker-list .p-title { font-weight: 600; }
+.picker-list .p-sub { font-size: .78rem; color: var(--ink-mute); }
+
+/* ── toast ──────────────────────────────────────────────────────────── */
+
+#toast-rack {
+  position: fixed;
+  bottom: 1.4rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: .5rem;
+  z-index: 100;
+  width: min(560px, calc(100vw - 2rem));
+  pointer-events: none;
+}
+.toast {
+  background: var(--ink);
+  color: var(--cream);
+  border-radius: 14px;
+  padding: .7rem 1.1rem;
+  font-size: .92rem;
+  box-shadow: var(--shadow);
+  animation: rise .25s var(--ease);
+  pointer-events: auto;
+  max-width: 100%;
+}
+.toast.error { background: var(--tomato-dk); color: #fff; }
+.toast.ok { background: var(--leek); color: #fff; }
+.toast.leaving { opacity: 0; transition: opacity .3s; }
+
+/* ── empty states & skeletons ───────────────────────────────────────── */
+
+.empty {
+  text-align: center;
+  padding: 3.5rem 1rem;
+  color: var(--ink-mute);
+}
+.empty .e-emoji { font-size: 2.6rem; display: block; margin-bottom: .7rem; }
+.empty h2 { color: var(--ink-soft); font-size: 1.25rem; margin-bottom: .4rem; }
+.empty p { margin: 0 0 1.2rem; }
+
+.skeleton { display: flex; flex-direction: column; gap: .7rem; padding: .5rem 0; }
+.skeleton .bone {
+  height: 1.15rem;
+  border-radius: 8px;
+  background: var(--cream-2);
+  animation: pulse 1.2s ease-in-out infinite;
+}
+.skeleton .bone:nth-child(2) { width: 82%; animation-delay: .12s; }
+.skeleton .bone:nth-child(3) { width: 64%; animation-delay: .24s; }
+@keyframes pulse { 50% { opacity: .45; } }
+
+.danger-zone { border-color: color-mix(in srgb, var(--tomato) 45%, var(--line)); }
+.danger-zone h2 { color: var(--tomato); }
+
+.section { margin-bottom: 1.9rem; }
+.section > h2 { font-size: 1.25rem; margin-bottom: .8rem; }
+
+.noscript-card { max-width: 30rem; margin: 18vh auto; text-align: center; }
+
+.value-badge { cursor: help; font-size: .85rem; }
+
+.copy-row { display: flex; gap: .5rem; align-items: center; margin-top: .8rem; }
+.copy-row .code-reveal { flex: 1; }
+
+/* ── responsive ─────────────────────────────────────────────────────── */
+
+@media (max-width: 900px) {
+  .app { grid-template-columns: 1fr; }
+  .side {
+    position: static;
+    height: auto;
+    flex-direction: row;
+    align-items: center;
+    padding: 1rem 1.2rem;
+    gap: .3rem;
+    overflow-x: auto;
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+  .wordmark { margin-bottom: 0; font-size: 1.4rem; }
+  .side nav { flex-direction: row; }
+  .nav-link { padding: .4rem .55rem; }
+  .nav-link .n-label { display: none; }
+  .side-user { display: none; }
+  .side .spacer { display: none; }
+  .content { padding: 1.6rem 1.2rem 4rem; }
+  .detail-cols { grid-template-columns: 1fr; }
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en-GB">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>YAMP</title>
+<meta name="description" content="Yet Another Meal Planner — the big-screen client. Served by your own YAMP server; talks to the same API as the iPhone app and your AI.">
+<meta name="theme-color" content="#fbf5e9">
+<!-- Same-origin only: the app calls the API that serves it, and nothing else.
+     Recipe images are the one external fetch (https images by URL). -->
+<meta http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' https: data:; connect-src 'self'; base-uri 'self'; form-action 'self'; object-src 'none'">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🍳</text></svg>">
+<!-- /app is served with Cache-Control: no-cache (see main.py), so every asset
+     revalidates by ETag and a deploy shows up on the next load — including the
+     ES modules below, which import their siblings with no version query -->
+<link rel="stylesheet" href="app.css">
+<script type="module" src="js/main.js"></script>
+</head>
+<body>
+
+<div class="awning" aria-hidden="true"></div>
+
+<div id="shell">
+  <!-- Sidebar + content are rendered by js/main.js: the shell differs for
+       signed-out (login card) and signed-in (nav + view) states. -->
+  <noscript>
+    <div class="noscript-card">
+      <h1>yamp<span class="dot">.</span></h1>
+      <p>The web app needs JavaScript — it is a client of the same API the
+      iPhone app uses. The API itself is at <a href="../docs">/docs</a>.</p>
+    </div>
+  </noscript>
+</div>
+
+<div id="toast-rack" aria-live="polite"></div>
+
+</body>
+</html>

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -1,0 +1,101 @@
+// The API client. The web app is served by the API itself, so every call is
+// same-origin ("../" from /app/) and there is no base URL to configure.
+// Bearer token in localStorage — same trust model as the iOS keychain: this
+// is your own server, and the app ships no third-party script that could
+// read it (the CSP in index.html enforces that).
+
+const TOKEN_KEY = "yamp.token";
+const USER_KEY = "yamp.user";
+
+// Matches app/client_gate.py's header shape. Platform "web" is never gated
+// (only ios/* is), but identifying ourselves keeps server logs honest.
+const CLIENT_HEADER = "web/1.0 (1)";
+
+export const session = {
+  get token() {
+    return localStorage.getItem(TOKEN_KEY);
+  },
+  get user() {
+    try {
+      return JSON.parse(localStorage.getItem(USER_KEY));
+    } catch {
+      return null;
+    }
+  },
+  save(auth) {
+    localStorage.setItem(TOKEN_KEY, auth.token);
+    localStorage.setItem(USER_KEY, JSON.stringify(auth.user));
+  },
+  saveUser(user) {
+    localStorage.setItem(USER_KEY, JSON.stringify(user));
+  },
+  clear() {
+    localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(USER_KEY);
+  },
+};
+
+export class ApiError extends Error {
+  constructor(status, detail) {
+    super(detail);
+    this.status = status;
+    this.detail = detail;
+  }
+}
+
+// FastAPI's 422 validation detail is a list of {loc, msg}; everything else in
+// this API is a deliberate sentence written to be shown to the caller.
+function detailText(data, status) {
+  const detail = data?.detail;
+  if (typeof detail === "string") return detail;
+  if (Array.isArray(detail)) {
+    return detail
+      .map((e) => {
+        const field = (e.loc || []).filter((p) => p !== "body").join(".");
+        const msg = (e.msg || "").replace(/^Value error,\s*/i, "");
+        return field ? `${field}: ${msg}` : msg;
+      })
+      .join("\n");
+  }
+  return `request failed (${status})`;
+}
+
+export async function api(path, { method = "GET", body, query } = {}) {
+  const url = new URL(".." + path, window.location.href);
+  for (const [key, value] of Object.entries(query || {})) {
+    if (value !== undefined && value !== null && value !== "") url.searchParams.set(key, value);
+  }
+
+  const headers = { "X-Meals-Client": CLIENT_HEADER };
+  if (session.token) headers["Authorization"] = `Bearer ${session.token}`;
+  if (body !== undefined) headers["Content-Type"] = "application/json";
+
+  const response = await fetch(url, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+  if (response.status === 204) return null;
+  const data = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    // A 401 usually means the session token expired or was revoked → back to
+    // the login screen. But three endpoints answer 401 for a *typed* password
+    // being wrong, which must not sign anyone out.
+    const typedPassword =
+      path === "/auth/login" || path === "/auth/password" || (path === "/auth/me" && method === "DELETE");
+    if (response.status === 401 && session.token && !typedPassword) {
+      session.clear();
+      window.location.hash = "#/login";
+    }
+    throw new ApiError(response.status, detailText(data, response.status));
+  }
+  return data;
+}
+
+let aisleCache = null;
+export async function aisles() {
+  aisleCache ||= await api("/aisles");
+  return aisleCache;
+}

--- a/web/js/dom.js
+++ b/web/js/dom.js
@@ -1,0 +1,146 @@
+// Rendering helpers. No framework: views build HTML with the `html` tagged
+// template, which escapes every interpolated value unless it is itself a
+// template result (or wrapped in raw()). That one rule is the XSS boundary —
+// recipe titles, meal names and error details all pass through here.
+
+class Raw {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+export const esc = (value) =>
+  String(value).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]);
+
+const part = (value) => {
+  if (value === null || value === undefined || value === false) return "";
+  if (value instanceof Raw) return value.value;
+  if (Array.isArray(value)) return value.map(part).join("");
+  return esc(value);
+};
+
+export function html(strings, ...values) {
+  let out = strings[0];
+  for (let i = 0; i < values.length; i++) out += part(values[i]) + strings[i + 1];
+  return new Raw(out);
+}
+
+export const raw = (value) => new Raw(String(value));
+
+export function render(root, template) {
+  root.innerHTML = template instanceof Raw ? template.value : String(template);
+}
+
+// ── small utilities ──────────────────────────────────────────────────
+
+export function debounce(fn, ms = 250) {
+  let timer;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), ms);
+  };
+}
+
+// The API serialises datetimes as naive UTC ("2026-07-31T18:38:52") — tell
+// the Date parser so, but leave anything already carrying an offset alone.
+export const parseUtc = (iso) => new Date(iso.endsWith("Z") || iso.includes("+") ? iso : iso + "Z");
+
+const REL = new Intl.RelativeTimeFormat("en-GB", { numeric: "auto" });
+
+export function fmtRel(iso) {
+  if (!iso) return "";
+  const days = Math.round((parseUtc(iso) - Date.now()) / 86_400_000);
+  if (Math.abs(days) >= 365) return REL.format(Math.trunc(days / 365), "year");
+  if (Math.abs(days) >= 30) return REL.format(Math.trunc(days / 30), "month");
+  if (Math.abs(days) >= 7) return REL.format(Math.trunc(days / 7), "week");
+  if (days !== 0) return REL.format(days, "day");
+  return "today";
+}
+
+export function fmtDate(iso) {
+  if (!iso) return "";
+  return parseUtc(iso).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" });
+}
+
+// A stable food emoji per name, so the plan reads like the menu card on the
+// marketing site without anyone having to pick emoji by hand. An explicit
+// array: spreading a string would split multi-codepoint emoji (🌶️, 🍽️).
+const FOOD = ["🍲", "🍛", "🥧", "🍅", "🌯", "🥘", "🍝", "🍜", "🍳", "🥗", "🌮", "🍕", "🐟", "🍗", "🥬", "🍆", "🫕", "🥟", "🍚", "🫘", "🌶️", "🧀", "🥕", "🍄"];
+export function foodEmoji(name) {
+  let hash = 0;
+  for (const ch of String(name)) hash = (hash * 31 + ch.codePointAt(0)) >>> 0;
+  return FOOD[hash % FOOD.length];
+}
+
+// ── toast ────────────────────────────────────────────────────────────
+
+export function toast(message, kind = "") {
+  const rack = document.getElementById("toast-rack");
+  const el = document.createElement("div");
+  el.className = `toast ${kind}`;
+  el.textContent = message;
+  rack.append(el);
+  setTimeout(() => {
+    el.classList.add("leaving");
+    setTimeout(() => el.remove(), 350);
+  }, kind === "error" ? 7000 : 4000);
+}
+
+// ── dialogs ──────────────────────────────────────────────────────────
+
+export function openDialog(template) {
+  const dialog = document.createElement("dialog");
+  render(dialog, template);
+  document.body.append(dialog);
+  // Nothing here may depend on the dialog 'close' *event* — some embedded
+  // browsers never deliver it (found the hard way: confirms hung forever).
+  // close() is patched to also remove the element, and Escape (the 'cancel'
+  // event) is routed through the same path.
+  const nativeClose = dialog.close.bind(dialog);
+  dialog.close = (value) => {
+    nativeClose(value);
+    dialog.remove();
+  };
+  dialog.addEventListener("cancel", (event) => {
+    event.preventDefault();
+    dialog.close();
+  });
+  dialog.addEventListener("click", (event) => {
+    if (event.target === dialog) dialog.close(); // click on the backdrop
+  });
+  dialog.showModal();
+  return dialog;
+}
+
+export function confirmDialog({ title, body, confirmLabel = "Confirm", danger = false }) {
+  return new Promise((resolve) => {
+    const dialog = openDialog(html`
+      <h2>${title}</h2>
+      <p>${body}</p>
+      <div class="dialog-actions">
+        <button class="btn ghost" data-x="cancel">Cancel</button>
+        <button class="btn ${danger ? "danger" : ""}" data-x="ok">${confirmLabel}</button>
+      </div>
+    `);
+    const settle = (value) => {
+      resolve(value);
+      dialog.close();
+    };
+    dialog.querySelector('[data-x="ok"]').onclick = () => settle(true);
+    dialog.querySelector('[data-x="cancel"]').onclick = () => settle(false);
+    dialog.addEventListener("cancel", () => resolve(false)); // Escape
+  });
+}
+
+export const skeleton = () => html`
+  <div class="skeleton"><div class="bone"></div><div class="bone"></div><div class="bone"></div></div>
+`;
+
+export const emptyState = (emoji, title, body, actions = "") => html`
+  <div class="empty">
+    <span class="e-emoji">${emoji}</span>
+    <h2>${title}</h2>
+    <p>${body}</p>
+    ${actions}
+  </div>
+`;

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -1,0 +1,151 @@
+// Shell and router. Hash routing, so the server only ever serves /app/ and
+// its assets — deep links (#/recipes/…) never need server-side routes.
+
+import { api, session } from "./api.js";
+import { html, render, toast } from "./dom.js";
+import { renderIngredients } from "./views/ingredients.js";
+import { renderLogin } from "./views/login.js";
+import { renderMealDetail, renderMealEditor, renderMeals } from "./views/meals.js";
+import { renderPlan } from "./views/plan.js";
+import { renderRecipeDetail, renderRecipeEditor, renderRecipes } from "./views/recipes.js";
+import { renderSettings } from "./views/settings.js";
+import { renderShopping, renderShoppingArchive } from "./views/shopping.js";
+
+const NAV = [
+  { hash: "#/plan", emoji: "🍲", label: "Plan", match: /^#\/plans?/ },
+  { hash: "#/list", emoji: "🛒", label: "Shopping list", match: /^#\/list/ },
+  { hash: "#/recipes", emoji: "📖", label: "Recipes", match: /^#\/recipes/ },
+  { hash: "#/meals", emoji: "🍽️", label: "Meals", match: /^#\/meals/ },
+  { hash: "#/ingredients", emoji: "🥕", label: "Ingredients", match: /^#\/ingredients/ },
+  { hash: "#/settings", emoji: "⚙️", label: "Settings", match: /^#\/settings/ },
+];
+
+const ROUTES = [
+  [/^#\/plan$/, (root) => renderPlan(root), "Plan"],
+  [/^#\/plans\/([0-9a-f-]+)$/, (root, m) => renderPlan(root, m[1]), "Plan"],
+  [/^#\/list$/, (root) => renderShopping(root), "Shopping list"],
+  [/^#\/list\/archived$/, (root) => renderShoppingArchive(root), "Previous shops"],
+  [/^#\/recipes$/, (root) => renderRecipes(root), "Recipes"],
+  [/^#\/recipes\/new$/, (root) => renderRecipeEditor(root, null), "New recipe"],
+  [/^#\/recipes\/([0-9a-f-]+)$/, (root, m) => renderRecipeDetail(root, m[1]), "Recipe"],
+  [/^#\/recipes\/([0-9a-f-]+)\/edit$/, (root, m) => renderRecipeEditor(root, m[1]), "Edit recipe"],
+  [/^#\/meals$/, (root) => renderMeals(root), "Meals"],
+  [/^#\/meals\/new$/, (root) => renderMealEditor(root, null), "New meal"],
+  [/^#\/meals\/([0-9a-f-]+)$/, (root, m) => renderMealDetail(root, m[1]), "Meal"],
+  [/^#\/meals\/([0-9a-f-]+)\/edit$/, (root, m) => renderMealEditor(root, m[1]), "Edit meal"],
+  [/^#\/ingredients$/, (root) => renderIngredients(root), "Ingredients"],
+  [/^#\/settings$/, (root) => renderSettings(root), "Settings"],
+];
+
+const shell = document.getElementById("shell");
+let contentRoot = null;
+
+function renderShell() {
+  const user = session.user;
+  render(shell, html`
+    <div class="app">
+      <aside class="side">
+        <a class="wordmark" href="#/plan">yamp<span class="dot">.</span></a>
+        <nav aria-label="Sections">
+          ${NAV.map(
+            (item) => html`
+              <a class="nav-link" data-nav href="${item.hash}">
+                <span class="n-emoji" aria-hidden="true">${item.emoji}</span>
+                <span class="n-label">${item.label}</span>
+              </a>
+            `,
+          )}
+        </nav>
+        <div class="spacer"></div>
+        <div class="side-user">
+          <b>${user?.household_name || "Home"}</b>
+          ${user?.display_name || ""} · <button class="link-btn" data-signout>sign out</button>
+        </div>
+      </aside>
+      <main class="content"><div id="view"></div></main>
+    </div>
+  `);
+  shell.querySelector("[data-signout]").onclick = () => {
+    session.clear();
+    window.location.hash = "#/login";
+  };
+  contentRoot = shell.querySelector("#view");
+}
+
+function markActive(hash) {
+  for (const link of shell.querySelectorAll("[data-nav]")) {
+    const item = NAV.find((n) => n.hash === link.getAttribute("href"));
+    link.classList.toggle("active", item.match.test(hash));
+  }
+}
+
+async function route() {
+  const hash = window.location.hash || "#/plan";
+
+  if (!session.token) {
+    contentRoot = null;
+    if (hash !== "#/login") {
+      window.location.hash = "#/login";
+      return;
+    }
+    renderLogin(shell);
+    document.title = "YAMP";
+    return;
+  }
+  if (hash === "#/login") {
+    window.location.hash = "#/plan";
+    return;
+  }
+
+  if (!contentRoot) renderShell();
+  markActive(hash);
+
+  for (const [pattern, handler, title] of ROUTES) {
+    const match = hash.match(pattern);
+    if (match) {
+      document.title = `${title} · YAMP`;
+      try {
+        await handler(contentRoot, match);
+      } catch (error) {
+        toast(error.detail || error.message, "error");
+      }
+      return;
+    }
+  }
+  window.location.hash = "#/plan";
+}
+
+window.addEventListener("hashchange", route);
+
+// "/" focuses the search box on list views, like every good big-screen tool.
+window.addEventListener("keydown", (event) => {
+  if (event.key !== "/" || event.target.matches("input, textarea, select")) return;
+  const search = document.querySelector("input[type=search]");
+  if (search) {
+    event.preventDefault();
+    search.focus();
+  }
+});
+
+// Boot: trust the cached session for instant paint, then verify it (and
+// refresh the cached user/household names) in the background — api() drops
+// us back at #/login on a 401.
+route();
+if (session.token) {
+  api("/auth/me")
+    .then((user) => {
+      session.saveUser(user);
+      const badge = document.querySelector(".side-user");
+      if (badge) {
+        render(badge, html`
+          <b>${user.household_name || "Home"}</b>
+          ${user.display_name} · <button class="link-btn" data-signout>sign out</button>
+        `);
+        badge.querySelector("[data-signout]").onclick = () => {
+          session.clear();
+          window.location.hash = "#/login";
+        };
+      }
+    })
+    .catch(() => {}); // a 401 already routed to login; network errors keep the cached shell
+}

--- a/web/js/views/ingredients.js
+++ b/web/js/views/ingredients.js
@@ -1,0 +1,189 @@
+// The ingredient catalogue: aisles, staples and the household's own
+// premium/budget verdicts (Q17 — never guessed, so this is where they get
+// set). Also the duplicates clean-up (Q21), which finally gets a screen —
+// until now only an AI over MCP could run it.
+
+import { aisles, api } from "../api.js";
+import { confirmDialog, emptyState, html, openDialog, render, skeleton, toast } from "../dom.js";
+
+let query = { search: "", staplesOnly: false, tier: "" };
+
+export async function renderIngredients(root) {
+  render(root, skeleton());
+  const [items, aisleList] = await Promise.all([
+    api("/ingredients", {
+      query: {
+        search: query.search || undefined,
+        staples_only: query.staplesOnly || undefined,
+        value_tier: query.tier || undefined,
+      },
+    }),
+    aisles(),
+  ]);
+
+  render(root, html`
+    <div class="page">
+      <div class="page-head">
+        <div>
+          <h1>Ingredients</h1>
+          <p class="sub">aisles, staples, and your own ⭐ premium / 💷 budget verdicts</p>
+        </div>
+        <div class="page-actions">
+          <button class="btn ghost" data-dupes>🧹 Find duplicates</button>
+        </div>
+      </div>
+
+      <div class="toolbar">
+        <input type="search" placeholder="Search ingredients…  ( / )" value="${query.search}" data-search>
+        <button class="chip click ${query.staplesOnly ? "on" : ""}" data-staples>staples only</button>
+        <select data-tier aria-label="Value tier">
+          <option value="">any verdict</option>
+          <option value="premium" ${query.tier === "premium" ? "selected" : ""}>⭐ premium</option>
+          <option value="budget" ${query.tier === "budget" ? "selected" : ""}>💷 budget</option>
+        </select>
+      </div>
+
+      ${items.length === 0
+        ? emptyState("🥕", "Nothing here", "Ingredients appear as recipes and shopping lists use them.")
+        : html`
+            <div class="card">
+              <div class="ing-row ing-head">
+                <span class="field-label">name</span><span class="field-label">staple</span>
+                <span class="field-label">aisle</span><span></span>
+                <span class="field-label">verdict</span><span class="field-label">why</span><span></span>
+              </div>
+              ${items.map((item) => ingredientRow(item, aisleList))}
+            </div>
+          `}
+    </div>
+  `);
+
+  const search = root.querySelector("[data-search]");
+  let timer;
+  search.oninput = () => {
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      query.search = search.value.trim();
+      renderIngredients(root);
+    }, 250);
+  };
+  root.querySelector("[data-staples]").onclick = () => {
+    query.staplesOnly = !query.staplesOnly;
+    renderIngredients(root);
+  };
+  root.querySelector("[data-tier]").onchange = (event) => {
+    query.tier = event.target.value;
+    renderIngredients(root);
+  };
+  root.querySelector("[data-dupes]").onclick = () => duplicatesDialog(root);
+
+  for (const row of root.querySelectorAll("[data-ing]")) bindRow(row, root);
+}
+
+function ingredientRow(item, aisleList) {
+  return html`
+    <div class="ing-row" data-ing="${item.id}">
+      <span class="name" title="${item.name}">${item.name}</span>
+      <input type="checkbox" ${item.is_staple ? "checked" : ""} data-k="is_staple" title="Staples hide from the list until a staples check says you're low">
+      <select data-k="aisle" aria-label="Aisle">
+        ${aisleList.map((a) => html`<option value="${a.emoji}" ${a.emoji === item.aisle ? "selected" : ""}>${a.emoji} ${a.label}</option>`)}
+      </select>
+      <span></span>
+      <select data-k="value_tier" aria-label="Value verdict">
+        <option value="any" ${item.value_tier === "any" ? "selected" : ""}>no opinion</option>
+        <option value="premium" ${item.value_tier === "premium" ? "selected" : ""}>⭐ premium</option>
+        <option value="budget" ${item.value_tier === "budget" ? "selected" : ""}>💷 budget</option>
+      </select>
+      <input type="text" value="${item.value_note ?? ""}" placeholder="why (shows at the shelf)" data-k="value_note">
+      <button class="icon-btn warm" data-del title="Only unreferenced ingredients can go">✕</button>
+    </div>
+  `;
+}
+
+function bindRow(row, root) {
+  const id = row.dataset.ing;
+  const save = async (body) => {
+    try {
+      await api(`/ingredients/${id}`, { method: "PATCH", body });
+      row.classList.remove("flash");
+      void row.offsetWidth; // restart the saved-flash animation
+      row.classList.add("flash");
+    } catch (error) {
+      toast(error.detail || error.message, "error");
+    }
+  };
+  row.querySelector('[data-k="is_staple"]').onchange = (e) => save({ is_staple: e.target.checked });
+  row.querySelector('[data-k="aisle"]').onchange = (e) => save({ aisle: e.target.value });
+  row.querySelector('[data-k="value_tier"]').onchange = (e) => save({ value_tier: e.target.value });
+  const note = row.querySelector('[data-k="value_note"]');
+  note.onchange = () => save({ value_note: note.value.trim() || null });
+  row.querySelector("[data-del]").onclick = async () => {
+    const name = row.querySelector(".name").textContent;
+    const ok = await confirmDialog({
+      title: `Delete “${name}”?`,
+      body: "Only works if nothing references it — recipes, meals and list lines all protect their ingredients.",
+      confirmLabel: "Delete",
+      danger: true,
+    });
+    if (!ok) return;
+    try {
+      await api(`/ingredients/${id}`, { method: "DELETE" });
+      toast("Deleted.", "ok");
+      renderIngredients(root);
+    } catch (error) {
+      toast(error.detail || error.message, "error");
+    }
+  };
+}
+
+async function duplicatesDialog(root) {
+  const dialog = openDialog(html`
+    <h2>Duplicate ingredients</h2>
+    <p class="sub">Same food, different spellings — merging repoints every recipe line and list item at the keeper, then removes the spares.</p>
+    <div data-body>${skeleton()}</div>
+    <div class="dialog-actions"><button class="btn ghost" data-x>Close</button></div>
+  `);
+  dialog.querySelector("[data-x]").onclick = () => dialog.close();
+
+  const body = dialog.querySelector("[data-body]");
+  const load = async () => {
+    const dupes = await api("/ingredients/duplicates");
+    if (dupes.groups.length === 0) {
+      render(body, html`<div class="empty"><span class="e-emoji">✨</span><h2>Catalogue is clean</h2><p>No duplicate names found.</p></div>`);
+      return;
+    }
+    render(body, html`
+      <ul class="picker-list">
+        ${dupes.groups.map(
+          (group) => html`
+            <li>
+              <div class="p-main">
+                <div class="p-title">${group.keeper.name} <span class="chip green">keeper</span></div>
+                <div class="p-sub">absorbs: ${group.duplicates.map((d) => d.name).join(", ")}</div>
+              </div>
+              <button class="btn small" data-merge="${group.keeper.id}" data-dupes-ids="${group.duplicates.map((d) => d.id).join(",")}">Merge</button>
+            </li>
+          `,
+        )}
+      </ul>
+    `);
+    for (const button of body.querySelectorAll("[data-merge]")) {
+      button.onclick = async () => {
+        button.disabled = true;
+        try {
+          const result = await api(`/ingredients/${button.dataset.merge}/merge`, {
+            method: "POST",
+            body: { duplicate_ids: button.dataset.dupesIds.split(",") },
+          });
+          toast(`Merged ${result.merged} into “${result.ingredient.name}”.`, "ok");
+          await load();
+          renderIngredients(root);
+        } catch (error) {
+          button.disabled = false;
+          toast(error.detail || error.message, "error");
+        }
+      };
+    }
+  };
+  await load();
+}

--- a/web/js/views/lines.js
+++ b/web/js/views/lines.js
@@ -1,0 +1,92 @@
+// Repeatable ingredient-line rows, shared by the recipe editor and the meal
+// editor's loose ingredients. Quantities follow the server's convention:
+// metric (g/kg/ml/l) or a count of a natural unit — the API's 422 explains
+// any conversion, so the editor doesn't police units itself.
+
+import { html, render } from "../dom.js";
+
+const UNIT_SUGGESTIONS = ["g", "kg", "ml", "l", "item", "tin", "clove", "bunch", "head", "pack", "jar", "slice", "stick", "sprig", "leaf", "sheet", "sausage", "egg"];
+
+export function linesEditor(container, initial = []) {
+  let lines = initial.map((line) => ({
+    name: line.name,
+    quantity: line.quantity,
+    unit: line.unit,
+    raw: line.raw ?? null,
+    dirty: false,
+  }));
+  if (lines.length === 0) lines.push(blank());
+
+  function blank() {
+    return { name: "", quantity: null, unit: null, raw: null, dirty: true };
+  }
+
+  function draw() {
+    render(container, html`
+      <datalist id="unit-suggestions">
+        ${UNIT_SUGGESTIONS.map((u) => html`<option value="${u}"></option>`)}
+      </datalist>
+      ${lines.map(
+        (line, index) => html`
+          <div class="line-row" data-index="${index}">
+            <input type="number" step="any" min="0" placeholder="qty" value="${line.quantity ?? ""}" data-k="quantity" aria-label="Quantity">
+            <input type="text" placeholder="unit" value="${line.unit ?? ""}" list="unit-suggestions" data-k="unit" aria-label="Unit">
+            <input type="text" placeholder="ingredient" value="${line.name}" data-k="name" aria-label="Ingredient" required>
+            <button type="button" class="icon-btn warm" data-drop tabindex="-1" title="Remove line">✕</button>
+          </div>
+        `,
+      )}
+      <button type="button" class="icon-btn" data-more>＋ another ingredient</button>
+    `);
+
+    for (const row of container.querySelectorAll(".line-row")) {
+      const index = Number(row.dataset.index);
+      for (const input of row.querySelectorAll("[data-k]")) {
+        input.oninput = () => {
+          const key = input.dataset.k;
+          lines[index][key] = key === "quantity" ? (input.value === "" ? null : Number(input.value)) : input.value;
+          // Hand-edited lines drop their scraped raw text — it no longer
+          // describes what the row says.
+          lines[index].dirty = true;
+        };
+        if (input.dataset.k === "name") {
+          input.onkeydown = (event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              if (index === lines.length - 1) {
+                lines.push(blank());
+                draw();
+                container.querySelectorAll('[data-k="quantity"]')[lines.length - 1].focus();
+              }
+            }
+          };
+        }
+      }
+      row.querySelector("[data-drop]").onclick = () => {
+        lines.splice(index, 1);
+        if (lines.length === 0) lines.push(blank());
+        draw();
+      };
+    }
+    container.querySelector("[data-more]").onclick = () => {
+      lines.push(blank());
+      draw();
+      container.querySelectorAll('[data-k="quantity"]')[lines.length - 1].focus();
+    };
+  }
+
+  draw();
+
+  return {
+    read() {
+      return lines
+        .filter((line) => line.name.trim() !== "")
+        .map((line) => ({
+          name: line.name.trim(),
+          quantity: line.quantity,
+          unit: line.unit?.trim() || null,
+          raw: line.dirty ? null : line.raw,
+        }));
+    },
+  };
+}

--- a/web/js/views/login.js
+++ b/web/js/views/login.js
@@ -1,0 +1,162 @@
+// Sign in / create a household / join with an invite / reset a password.
+// The register modes mirror decision Q19: no invite code → a brand-new
+// household; with one → join whoever minted it. A server with
+// REGISTRATION_ENABLED=false answers 403 with an explanation we just show.
+
+import { api, session } from "../api.js";
+import { html, render, toast } from "../dom.js";
+
+let mode = "signin"; // signin | register | reset
+let joinMode = "new"; // new | invite
+let resetStage = "request"; // request | confirm
+
+export function renderLogin(root) {
+  render(root, html`
+    <div class="login-wrap">
+      <div class="login-card">
+        <span class="wordmark">yamp<span class="dot">.</span></span>
+        <p class="strap">the big-screen half of your meal planner</p>
+        <div class="login-tabs" role="tablist">
+          <button data-mode="signin" class="${mode === "signin" ? "on" : ""}">Sign in</button>
+          <button data-mode="register" class="${mode === "register" ? "on" : ""}">Register</button>
+        </div>
+        <form data-form>${formBody()}</form>
+        <p class="login-foot">${footNote()}</p>
+      </div>
+    </div>
+  `);
+
+  for (const tab of root.querySelectorAll("[data-mode]")) {
+    tab.onclick = () => {
+      mode = tab.dataset.mode;
+      resetStage = "request";
+      renderLogin(root);
+    };
+  }
+  const forgot = root.querySelector("[data-forgot]");
+  if (forgot) {
+    forgot.onclick = () => {
+      mode = "reset";
+      resetStage = "request";
+      renderLogin(root);
+    };
+  }
+  const back = root.querySelector("[data-back]");
+  if (back) {
+    back.onclick = () => {
+      mode = "signin";
+      renderLogin(root);
+    };
+  }
+  for (const seg of root.querySelectorAll("[data-join]")) {
+    seg.onclick = () => {
+      joinMode = seg.dataset.join;
+      renderLogin(root);
+    };
+  }
+
+  const form = root.querySelector("[data-form]");
+  form.onsubmit = async (event) => {
+    event.preventDefault();
+    const data = Object.fromEntries(new FormData(form));
+    const button = form.querySelector("button[type=submit]");
+    button.disabled = true;
+    try {
+      await submit(data, root);
+    } catch (error) {
+      toast(error.detail || error.message, "error");
+    } finally {
+      button.disabled = false;
+    }
+  };
+}
+
+function formBody() {
+  if (mode === "signin") {
+    return html`
+      <label class="field"><span>Email</span>
+        <input type="email" name="email" required autocomplete="email" autofocus></label>
+      <label class="field"><span>Password</span>
+        <input type="password" name="password" required autocomplete="current-password"></label>
+      <button class="btn" type="submit">Sign in</button>
+    `;
+  }
+  if (mode === "register") {
+    return html`
+      <div class="seg">
+        <button type="button" data-join="new" class="${joinMode === "new" ? "on" : ""}">Start a household</button>
+        <button type="button" data-join="invite" class="${joinMode === "invite" ? "on" : ""}">Join with an invite</button>
+      </div>
+      <label class="field"><span>Your name</span>
+        <input type="text" name="display_name" required autocomplete="name" placeholder="Marcus"></label>
+      <label class="field"><span>Email</span>
+        <input type="email" name="email" required autocomplete="email"></label>
+      <label class="field"><span>Password</span>
+        <input type="password" name="password" required minlength="8" autocomplete="new-password"></label>
+      ${joinMode === "new"
+        ? html`<label class="field"><span>Household name (optional)</span>
+            <input type="text" name="household_name" placeholder="Home"></label>`
+        : html`<label class="field"><span>Invite code</span>
+            <input type="text" name="invite_code" required autocomplete="off"
+                   placeholder="from whoever runs your household"></label>`}
+      <button class="btn" type="submit">${joinMode === "new" ? "Create household" : "Join household"}</button>
+    `;
+  }
+  // reset
+  if (resetStage === "request") {
+    return html`
+      <label class="field"><span>Email</span>
+        <input type="email" name="email" required autocomplete="email" autofocus></label>
+      <button class="btn" type="submit">Email me a reset code</button>
+    `;
+  }
+  return html`
+    <label class="field"><span>Reset code</span>
+      <input type="text" name="code" required autocomplete="one-time-code" placeholder="from the email"></label>
+    <label class="field"><span>New password</span>
+      <input type="password" name="new_password" required minlength="8" autocomplete="new-password"></label>
+    <button class="btn" type="submit">Set password &amp; sign in</button>
+  `;
+}
+
+function footNote() {
+  if (mode === "signin") return html`<button class="link-btn" data-forgot>Forgotten your password?</button>`;
+  if (mode === "register") {
+    return joinMode === "new"
+      ? html`Your recipes, plan and list are visible only to your household.`
+      : html`An invite code joins you to an existing household and everything in it.`;
+  }
+  return html`<button class="link-btn" data-back>Back to sign in</button>`;
+}
+
+async function submit(data, root) {
+  if (mode === "signin") {
+    const auth = await api("/auth/login", { method: "POST", body: data });
+    session.save(auth);
+    window.location.hash = "#/plan";
+    return;
+  }
+  if (mode === "register") {
+    const body = { email: data.email, password: data.password, display_name: data.display_name };
+    if (joinMode === "invite") body.invite_code = data.invite_code.trim();
+    else if (data.household_name?.trim()) body.household_name = data.household_name.trim();
+    const auth = await api("/auth/register", { method: "POST", body });
+    session.save(auth);
+    window.location.hash = "#/plan";
+    return;
+  }
+  if (resetStage === "request") {
+    const accepted = await api("/auth/password-reset", { method: "POST", body: { email: data.email } });
+    toast(accepted.detail, "ok");
+    resetStage = "confirm";
+    renderLogin(root);
+    return;
+  }
+  const auth = await api("/auth/password/reset-confirm", {
+    method: "POST",
+    body: { code: data.code.trim(), new_password: data.new_password },
+  });
+  session.save(auth);
+  toast("Password changed — you're signed in.", "ok");
+  window.location.hash = "#/plan";
+}

--- a/web/js/views/meals.js
+++ b/web/js/views/meals.js
@@ -1,0 +1,292 @@
+// Meals: the thing you actually put on a plan. One or more recipes (with an
+// optional scale) plus loose ingredients — "cottage pie with peas & carrots".
+
+import { api } from "../api.js";
+import { confirmDialog, emptyState, fmtRel, foodEmoji, html, render, skeleton, toast } from "../dom.js";
+import { linesEditor } from "./lines.js";
+
+let query = { search: "", slot: "" };
+
+export async function renderMeals(root) {
+  render(root, skeleton());
+  const meals = await api("/meals", {
+    query: { search: query.search || undefined, slot: query.slot || undefined },
+  });
+  const slots = [...new Set(meals.map((m) => m.slot).filter(Boolean))].sort();
+
+  render(root, html`
+    <div class="page narrow">
+      <div class="page-head">
+        <div>
+          <h1>Meals</h1>
+          <p class="sub">${meals.length} to choose from</p>
+        </div>
+        <div class="page-actions"><a class="btn" href="#/meals/new">＋ New meal</a></div>
+      </div>
+
+      <div class="toolbar">
+        <input type="search" placeholder="Search meals…  ( / )" value="${query.search}" data-search>
+        ${slots.map((slot) => html`<button class="chip click ${query.slot === slot ? "on" : ""}" data-slot="${slot}">${slot}</button>`)}
+      </div>
+
+      ${meals.length === 0
+        ? emptyState("🍽️", "No meals yet", "A meal is a recipe (or a few) with any extras — make one and it becomes a plan option.", html`<a class="btn" href="#/meals/new">＋ New meal</a>`)
+        : html`
+            <ul class="row-list">
+              ${meals.map(
+                (meal) => html`
+                  <a class="row-card" href="#/meals/${meal.id}">
+                    <span class="rc-emoji" aria-hidden="true">${foodEmoji(meal.name)}</span>
+                    <div class="rc-main">
+                      <div class="rc-title">${meal.name}</div>
+                      <div class="rc-sub">
+                        ${meal.recipes.map((r) => r.title).join(" + ") || "loose ingredients"}
+                        ${meal.loose_ingredients.length > 0 && meal.recipes.length > 0 ? " + extras" : ""}
+                      </div>
+                    </div>
+                    <div class="rc-side">
+                      ${meal.slot && html`<span class="chip">${meal.slot}</span>`}
+                      ${meal.times_cooked > 0
+                        ? html`<span class="chip red">cooked ${meal.times_cooked}×</span>`
+                        : html`<span class="chip green">new</span>`}
+                    </div>
+                  </a>
+                `,
+              )}
+            </ul>
+          `}
+    </div>
+  `);
+
+  const search = root.querySelector("[data-search]");
+  let timer;
+  search.oninput = () => {
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      query.search = search.value.trim();
+      renderMeals(root);
+    }, 250);
+  };
+  for (const chip of root.querySelectorAll("[data-slot]")) {
+    chip.onclick = () => {
+      query.slot = query.slot === chip.dataset.slot ? "" : chip.dataset.slot;
+      renderMeals(root);
+    };
+  }
+}
+
+export async function renderMealDetail(root, mealId) {
+  render(root, skeleton());
+  const meal = await api(`/meals/${mealId}`);
+
+  render(root, html`
+    <div class="page narrow">
+      <div class="crumb"><a href="#/meals">← Meals</a></div>
+      <div class="page-head">
+        <div>
+          <h1>${foodEmoji(meal.name)} ${meal.name}</h1>
+          <div class="meta-chips">
+            ${meal.slot && html`<span class="chip">${meal.slot}</span>`}
+            ${meal.times_cooked > 0
+              ? html`<span class="chip red">cooked ${meal.times_cooked}× · last ${fmtRel(meal.last_cooked_at)}</span>`
+              : html`<span class="chip green">never cooked</span>`}
+          </div>
+        </div>
+        <div class="page-actions">
+          <button class="btn" data-to-plan>🍲 Put it on the plan</button>
+          <a class="btn ghost" href="#/meals/${meal.id}/edit">Edit</a>
+          <button class="btn danger" data-del>Delete</button>
+        </div>
+      </div>
+
+      ${meal.recipes.length > 0 &&
+      html`
+        <div class="section">
+          <h2>Recipes</h2>
+          <ul class="row-list">
+            ${meal.recipes.map(
+              (recipe) => html`
+                <a class="row-card" href="#/recipes/${recipe.id}">
+                  <span class="rc-emoji" aria-hidden="true">📖</span>
+                  <div class="rc-main">
+                    <div class="rc-title">${recipe.title}${recipe.scale && recipe.scale !== 1 ? html` <span class="chip butter">×${recipe.scale}</span>` : ""}</div>
+                    <div class="rc-sub">${recipe.servings ? `serves ${recipe.servings}` : ""}${recipe.times_cooked > 0 ? ` · cooked ${recipe.times_cooked}×` : ""}</div>
+                  </div>
+                </a>
+              `,
+            )}
+          </ul>
+        </div>
+      `}
+
+      ${meal.loose_ingredients.length > 0 &&
+      html`
+        <div class="section">
+          <h2>Extras</h2>
+          <div class="card">
+            <ul class="ing-list">
+              ${meal.loose_ingredients.map(
+                (line) => html`<li><span class="qty">${line.display}</span><span>${line.aisle} ${line.name}</span></li>`,
+              )}
+            </ul>
+          </div>
+        </div>
+      `}
+    </div>
+  `);
+
+  root.querySelector("[data-to-plan]").onclick = async () => {
+    let plan;
+    try {
+      plan = await api("/plans/current");
+    } catch (error) {
+      if (error.status !== 404) throw error;
+      plan = await api("/plans", { method: "POST", body: { label: "This week" } });
+    }
+    try {
+      await api(`/plans/${plan.id}/meals`, { method: "POST", body: { meal_id: meal.id } });
+      toast("On the plan — ingredients joined the shopping list.", "ok");
+    } catch (error) {
+      if (error.status === 409) toast("Already on the plan.", "ok");
+      else toast(error.detail || error.message, "error");
+    }
+  };
+
+  root.querySelector("[data-del]").onclick = async () => {
+    const ok = await confirmDialog({
+      title: `Delete “${meal.name}”?`,
+      body: "It comes off any plan it is on, and its share leaves the shopping list. Recipes stay in the library; cooked history stays on the record.",
+      confirmLabel: "Delete",
+      danger: true,
+    });
+    if (!ok) return;
+    await api(`/meals/${meal.id}`, { method: "DELETE" });
+    toast("Meal deleted.", "ok");
+    window.location.hash = "#/meals";
+  };
+}
+
+export async function renderMealEditor(root, mealId) {
+  render(root, skeleton());
+  const meal = mealId ? await api(`/meals/${mealId}`) : null;
+  let picked = meal ? meal.recipes.map((r) => ({ recipe_id: r.id, title: r.title, scale: r.scale ?? 1 })) : [];
+
+  render(root, html`
+    <div class="page narrow">
+      <div class="crumb"><a href="${meal ? `#/meals/${meal.id}` : "#/meals"}">← ${meal ? meal.name : "Meals"}</a></div>
+      <div class="page-head"><h1>${meal ? "Edit meal" : "New meal"}</h1></div>
+      <form class="card" data-f>
+        <div class="form-row">
+          <label class="field"><span>Name</span>
+            <input type="text" name="name" required value="${meal?.name ?? ""}" placeholder="Cottage pie with peas"></label>
+          <label class="field"><span>Slot (optional)</span>
+            <input type="text" name="slot" value="${meal?.slot ?? ""}" list="slot-suggestions" placeholder="dinner">
+            <datalist id="slot-suggestions"><option value="dinner"><option value="lunch"><option value="breakfast"></datalist></label>
+        </div>
+
+        <div class="field-label">Recipes</div>
+        <div data-picked></div>
+        <input type="search" placeholder="Search the library to add a recipe…" data-recipe-q autocomplete="off">
+        <ul class="picker-list" data-recipe-results></ul>
+
+        <div class="field-label" data-extras-label>Extras (loose ingredients — the peas and carrots)</div>
+        <div data-lines></div>
+
+        <div class="dialog-actions">
+          <a class="btn ghost" href="${meal ? `#/meals/${meal.id}` : "#/meals"}">Cancel</a>
+          <button class="btn" type="submit">${meal ? "Save changes" : "Create meal"}</button>
+        </div>
+      </form>
+    </div>
+  `);
+
+  const pickedBox = root.querySelector("[data-picked]");
+  const drawPicked = () => {
+    render(pickedBox, html`
+      ${picked.length === 0 && html`<p class="sub">No recipes — a meal can be loose ingredients alone.</p>`}
+      <ul class="picker-list">
+        ${picked.map(
+          (entry, index) => html`
+            <li>
+              <span aria-hidden="true">📖</span>
+              <div class="p-main"><div class="p-title">${entry.title}</div></div>
+              <label class="check-line" title="Scale — ×2 for batch cooking">×
+                <input type="number" step="0.5" min="0.5" value="${entry.scale}" data-scale="${index}" class="scale-input"></label>
+              <button type="button" class="icon-btn warm" data-unpick="${index}">remove</button>
+            </li>
+          `,
+        )}
+      </ul>
+    `);
+    for (const input of pickedBox.querySelectorAll("[data-scale]")) {
+      input.oninput = () => {
+        picked[Number(input.dataset.scale)].scale = Number(input.value) || 1;
+      };
+    }
+    for (const button of pickedBox.querySelectorAll("[data-unpick]")) {
+      button.onclick = () => {
+        picked.splice(Number(button.dataset.unpick), 1);
+        drawPicked();
+      };
+    }
+  };
+  drawPicked();
+
+  const results = root.querySelector("[data-recipe-results]");
+  const recipeQuery = root.querySelector("[data-recipe-q]");
+  const searchRecipes = async () => {
+    if (!recipeQuery.value.trim()) {
+      render(results, "");
+      return;
+    }
+    const recipes = await api("/recipes", { query: { search: recipeQuery.value.trim() } });
+    render(results, html`
+      ${recipes.length === 0 && html`<li><span class="p-sub">Nothing in the library matches.</span></li>`}
+      ${recipes.slice(0, 6).map((recipe) => {
+        const already = picked.some((p) => p.recipe_id === recipe.id);
+        return html`
+          <li>
+            <span aria-hidden="true">📖</span>
+            <div class="p-main"><div class="p-title">${recipe.title}</div></div>
+            ${already ? html`<span class="chip green">added</span>` : html`<button type="button" class="btn small" data-add-recipe="${recipe.id}" data-title="${recipe.title}">Add</button>`}
+          </li>
+        `;
+      })}
+    `);
+    for (const button of results.querySelectorAll("[data-add-recipe]")) {
+      button.onclick = () => {
+        picked.push({ recipe_id: button.dataset.addRecipe, title: button.dataset.title, scale: 1 });
+        recipeQuery.value = "";
+        render(results, "");
+        drawPicked();
+      };
+    }
+  };
+  let timer;
+  recipeQuery.oninput = () => {
+    clearTimeout(timer);
+    timer = setTimeout(searchRecipes, 250);
+  };
+
+  const lines = linesEditor(root.querySelector("[data-lines]"), meal?.loose_ingredients ?? []);
+
+  root.querySelector("[data-f]").onsubmit = async (event) => {
+    event.preventDefault();
+    const data = Object.fromEntries(new FormData(event.target));
+    const body = {
+      name: data.name.trim(),
+      slot: data.slot.trim() || null,
+      recipes: picked.map(({ recipe_id, scale }) => ({ recipe_id, scale })),
+      loose_ingredients: lines.read(),
+    };
+    try {
+      const saved = meal
+        ? await api(`/meals/${meal.id}`, { method: "PATCH", body })
+        : await api("/meals", { method: "POST", body });
+      toast(meal ? "Saved — any plan using it resyncs the list." : "Meal created.", "ok");
+      window.location.hash = `#/meals/${saved.id}`;
+    } catch (error) {
+      toast(error.detail || error.message, "error");
+    }
+  };
+}

--- a/web/js/views/plan.js
+++ b/web/js/views/plan.js
@@ -1,0 +1,276 @@
+// The plan: a pool of meals you'd be happy to cook, no days attached (Q1/Q4).
+// Rendered as the menu card from the marketing site, because that is what it
+// is. Adding and removing meals reshapes the shopping list server-side; we
+// just say so.
+
+import { api } from "../api.js";
+import { confirmDialog, emptyState, fmtRel, foodEmoji, html, openDialog, parseUtc, render, skeleton, toast } from "../dom.js";
+
+export async function renderPlan(root, planId = null) {
+  render(root, skeleton());
+
+  let plan = null;
+  if (planId) {
+    plan = await api(`/plans/${planId}`);
+  } else {
+    try {
+      plan = await api("/plans/current");
+    } catch (error) {
+      if (error.status !== 404) throw error;
+    }
+  }
+  const archived = await api("/plans", { query: { status: "archived" } });
+
+  if (!plan) {
+    render(root, html`
+      <div class="page narrow">
+        ${emptyState("🍲", "No plan on the go", "A plan is a handful of meals you'd be happy to cook — in any order, no days attached.", html`<button class="btn" data-new-plan>Start a plan</button>`)}
+        ${previousPlans(archived, null)}
+      </div>
+    `);
+    root.querySelector("[data-new-plan]").onclick = () => newPlanDialog(root, null);
+    return;
+  }
+
+  const isActive = plan.status === "active";
+  const uncooked = plan.meals.filter((m) => !m.cooked_at).length;
+
+  render(root, html`
+    <div class="page narrow">
+      <div class="page-head">
+        <div>
+          <h1>${isActive ? "The plan" : "Previous plan"}</h1>
+          <p class="sub">${isActive ? "" : `wrapped up ${fmtRel(plan.archived_at)} · `}cook them in any order, or don't</p>
+        </div>
+        <div class="page-actions">
+          ${isActive
+            ? html`
+                <button class="btn" data-add>＋ Add a meal</button>
+                <button class="btn ghost" data-new-plan>New plan</button>
+                <button class="btn ghost" data-archive>Wrap up</button>
+              `
+            : html`<a class="btn ghost" href="#/plan">Back to the current plan</a>`}
+        </div>
+      </div>
+
+      <div class="menu-card">
+        <div class="menu-title-row">
+          <div>
+            <div class="menu-title" data-label ${isActive ? 'title="Click to rename"' : ""}>${plan.label}</div>
+            <p class="menu-sub">${plan.meals.length} ${plan.meals.length === 1 ? "option" : "options"} · no days attached</p>
+          </div>
+        </div>
+        ${plan.meals.length === 0
+          ? emptyState("🫕", "Nothing on the menu yet", "Add a few meals and the shopping list writes itself.")
+          : html`<ul class="menu-list">${plan.meals.map((pm) => planMeal(pm, plan, isActive))}</ul>`}
+        ${plan.meals.length > 0 && html`<p class="menu-foot">${uncooked === 0 ? "all cooked — nicely done" : `${uncooked} still to cook`}</p>`}
+      </div>
+
+      ${previousPlans(archived, plan.id)}
+    </div>
+  `);
+
+  if (!isActive) return;
+
+  root.querySelector("[data-add]").onclick = () => addMealDialog(plan, root);
+  root.querySelector("[data-new-plan]").onclick = () => newPlanDialog(root, plan);
+  root.querySelector("[data-archive]").onclick = async () => {
+    const ok = await confirmDialog({
+      title: "Wrap up this plan?",
+      body: "It moves to your previous plans; meals and their cooked history stay put. The shopping list keeps its items until you finish the shop.",
+      confirmLabel: "Wrap up",
+    });
+    if (!ok) return;
+    await api(`/plans/${plan.id}/archive`, { method: "POST" });
+    toast(`“${plan.label}” wrapped up.`, "ok");
+    renderPlan(root);
+  };
+
+  const label = root.querySelector("[data-label]");
+  label.onclick = () => renameInline(label, plan, root);
+
+  for (const button of root.querySelectorAll("[data-cooked]")) {
+    button.onclick = async () => {
+      await api(`/plans/${plan.id}/meals/${button.dataset.cooked}/cooked`, { method: "POST" });
+      toast("Marked cooked — it goes on the record.", "ok");
+      renderPlan(root);
+    };
+  }
+  for (const button of root.querySelectorAll("[data-remove]")) {
+    button.onclick = async () => {
+      await api(`/plans/${plan.id}/meals/${button.dataset.remove}`, { method: "DELETE" });
+      toast("Removed — its share left the shopping list.", "ok");
+      renderPlan(root);
+    };
+  }
+}
+
+function planMeal(pm, plan, isActive) {
+  const meal = pm.meal;
+  return html`
+    <li class="menu-item ${pm.cooked_at ? "cooked" : ""}">
+      <span class="m-emoji" aria-hidden="true">${foodEmoji(meal.name)}</span>
+      <div class="m-main">
+        <a class="m-name" href="#/meals/${meal.id}">${meal.name}</a>
+        <div class="m-meta">
+          ${meal.slot && html`<span class="chip">${meal.slot}</span>`}
+          ${cookedChip(pm, meal)}
+        </div>
+      </div>
+      ${isActive &&
+      html`
+        <div class="m-actions">
+          ${!pm.cooked_at && html`<button class="icon-btn" data-cooked="${pm.id}" title="Mark cooked">✓ cooked</button>`}
+          <button class="icon-btn warm" data-remove="${pm.id}" title="Remove from plan">remove</button>
+        </div>
+      `}
+    </li>
+  `;
+}
+
+function cookedChip(pm, meal) {
+  if (pm.cooked_at) return html`<span class="chip green">cooked ${fmtRel(pm.cooked_at)}</span>`;
+  if (meal.times_cooked === 0) return html`<span class="chip green">new</span>`;
+  const chips = [html`<span class="chip red">cooked ${meal.times_cooked}×</span>`];
+  if (meal.last_cooked_at && Date.now() - parseUtc(meal.last_cooked_at) > 28 * 86_400_000) {
+    chips.push(html`<span class="chip butter">not in a while</span>`);
+  }
+  return chips;
+}
+
+function previousPlans(archived, currentId) {
+  const others = archived.filter((p) => p.id !== currentId);
+  if (others.length === 0) return "";
+  return html`
+    <div class="section" data-previous>
+      <h2>Previous plans</h2>
+      <ul class="row-list">
+        ${others.slice(0, 8).map(
+          (p) => html`
+            <a class="row-card" href="#/plans/${p.id}">
+              <span class="rc-emoji" aria-hidden="true">🗂️</span>
+              <div class="rc-main">
+                <div class="rc-title">${p.label}</div>
+                <div class="rc-sub">${p.meal_count} ${p.meal_count === 1 ? "meal" : "meals"}</div>
+              </div>
+            </a>
+          `,
+        )}
+      </ul>
+    </div>
+  `;
+}
+
+async function renameInline(label, plan, root) {
+  const input = document.createElement("input");
+  input.type = "text";
+  input.value = plan.label;
+  label.replaceWith(input);
+  input.focus();
+  input.select();
+  let closed = false;
+  const done = async (save) => {
+    if (closed) return; // Enter triggers blur too — settle once
+    closed = true;
+    if (save && input.value.trim() && input.value.trim() !== plan.label) {
+      await api(`/plans/${plan.id}`, { method: "PATCH", body: { label: input.value.trim() } });
+    }
+    renderPlan(root, plan.status === "active" ? null : plan.id);
+  };
+  input.onkeydown = (e) => {
+    if (e.key === "Enter") done(true);
+    if (e.key === "Escape") done(false);
+  };
+  input.onblur = () => done(true);
+}
+
+function newPlanDialog(root, currentPlan) {
+  const dialog = openDialog(html`
+    <h2>Start a new plan</h2>
+    <form data-f>
+      <label class="field"><span>Label</span>
+        <input type="text" name="label" required placeholder="Next week" autofocus></label>
+      ${currentPlan &&
+      html`<label class="check-line">
+        <input type="checkbox" name="carry"> carry over the meals from “${currentPlan.label}”
+      </label>`}
+      <div class="dialog-actions">
+        <button class="btn ghost" type="button" data-x>Cancel</button>
+        <button class="btn" type="submit">Start plan</button>
+      </div>
+    </form>
+  `);
+  dialog.querySelector("[data-x]").onclick = () => dialog.close();
+  dialog.querySelector("[data-f]").onsubmit = async (event) => {
+    event.preventDefault();
+    const data = new FormData(event.target);
+    const body = { label: data.get("label").trim() };
+    if (currentPlan && data.get("carry")) body.copy_from_plan_id = currentPlan.id;
+    try {
+      await api("/plans", { method: "POST", body });
+      dialog.close();
+      toast("New plan started — the old one wrapped up itself.", "ok");
+      renderPlan(root);
+    } catch (error) {
+      toast(error.detail || error.message, "error");
+    }
+  };
+}
+
+async function addMealDialog(plan, root) {
+  const inPlan = new Set(plan.meals.map((pm) => pm.meal.id));
+  const dialog = openDialog(html`
+    <h2>Add a meal</h2>
+    <input type="search" placeholder="Search meals…" data-q autocomplete="off">
+    <ul class="picker-list" data-results>${skeleton()}</ul>
+    <p class="login-foot">or <a href="#/meals/new" data-close>make a new meal</a></p>
+  `);
+  dialog.querySelector("[data-close]").onclick = () => dialog.close();
+
+  const results = dialog.querySelector("[data-results]");
+  const query = dialog.querySelector("[data-q]");
+  const search = async () => {
+    const meals = await api("/meals", { query: { search: query.value.trim() || undefined } });
+    render(results, html`
+      ${meals.length === 0 && html`<li><span class="p-sub">Nothing matches — make a new meal?</span></li>`}
+      ${meals.map(
+        (meal) => html`
+          <li>
+            <span aria-hidden="true">${foodEmoji(meal.name)}</span>
+            <div class="p-main">
+              <div class="p-title">${meal.name}</div>
+              <div class="p-sub">
+                ${meal.recipes.map((r) => r.title).join(" + ") || "loose ingredients"}
+                ${meal.times_cooked > 0 ? ` · cooked ${meal.times_cooked}×` : " · new"}
+              </div>
+            </div>
+            ${inPlan.has(meal.id)
+              ? html`<span class="chip green">on the menu</span>`
+              : html`<button class="btn small" data-pick="${meal.id}">Add</button>`}
+          </li>
+        `,
+      )}
+    `);
+    for (const button of results.querySelectorAll("[data-pick]")) {
+      button.onclick = async () => {
+        button.disabled = true;
+        try {
+          await api(`/plans/${plan.id}/meals`, { method: "POST", body: { meal_id: button.dataset.pick } });
+          dialog.close();
+          toast("Added — its ingredients just joined the shopping list.", "ok");
+          renderPlan(root);
+        } catch (error) {
+          button.disabled = false;
+          toast(error.detail || error.message, "error");
+        }
+      };
+    }
+  };
+  let timer;
+  query.oninput = () => {
+    clearTimeout(timer);
+    timer = setTimeout(search, 220);
+  };
+  await search();
+  query.focus();
+}

--- a/web/js/views/recipes.js
+++ b/web/js/views/recipes.js
@@ -1,0 +1,322 @@
+// The recipe library. Ingest-by-URL is the headline: paste a link, the server
+// pulls the page's schema.org JSON-LD (parse once, reuse forever — Q3), and
+// the recipe lands in the library with its lines already on the unit
+// convention. Pages without usable JSON-LD 422 with advice we show verbatim.
+
+import { api } from "../api.js";
+import { confirmDialog, emptyState, fmtRel, html, openDialog, render, skeleton, toast } from "../dom.js";
+import { linesEditor } from "./lines.js";
+
+let query = { search: "", tag: "", sort: "title", under30: false };
+
+export async function renderRecipes(root) {
+  render(root, skeleton());
+  const recipes = await api("/recipes", {
+    query: {
+      search: query.search || undefined,
+      tag: query.tag || undefined,
+      sort: query.sort,
+      max_total_minutes: query.under30 ? 30 : undefined,
+    },
+  });
+  const tags = [...new Set(recipes.flatMap((r) => r.tags))].sort();
+
+  render(root, html`
+    <div class="page">
+      <div class="page-head">
+        <div>
+          <h1>Recipes</h1>
+          <p class="sub">${recipes.length} in the library</p>
+        </div>
+        <div class="page-actions">
+          <button class="btn" data-ingest>🔗 From a URL</button>
+          <a class="btn ghost" href="#/recipes/new">Write one in</a>
+        </div>
+      </div>
+
+      <div class="toolbar">
+        <input type="search" placeholder="Search recipes…  ( / )" value="${query.search}" data-search>
+        <select data-sort aria-label="Sort">
+          <option value="title" ${query.sort === "title" ? "selected" : ""}>A → Z</option>
+          <option value="most_cooked" ${query.sort === "most_cooked" ? "selected" : ""}>Most cooked</option>
+          <option value="least_recently_cooked" ${query.sort === "least_recently_cooked" ? "selected" : ""}>Not had in a while</option>
+        </select>
+        <button class="chip click ${query.under30 ? "on" : ""}" data-under30>under 30 min</button>
+        <span class="gap"></span>
+        ${tags.map((tag) => html`<button class="chip click ${query.tag === tag ? "on" : ""}" data-tag="${tag}">${tag}</button>`)}
+      </div>
+
+      ${recipes.length === 0
+        ? emptyState("📖", "No recipes yet", "Paste a recipe URL and the library starts itself — or ask your AI to fill it while you put the kettle on.", html`<button class="btn" data-ingest-empty>🔗 Add one from a URL</button>`)
+        : html`
+            <div class="recipe-grid">
+              ${recipes.map(
+                (recipe) => html`
+                  <a class="recipe-card" href="#/recipes/${recipe.id}">
+                    <div class="r-img">${recipe.image_url ? html`<img src="${recipe.image_url}" alt="" loading="lazy">` : "🍳"}</div>
+                    <div class="r-body">
+                      <div class="r-title">${recipe.title}</div>
+                      <div class="r-meta">
+                        ${totalMinutes(recipe) !== null && html`<span>⏱ ${totalMinutes(recipe)} min</span>`}
+                        ${recipe.servings > 0 && html`<span>serves ${recipe.servings}</span>`}
+                        ${recipe.times_cooked > 0
+                          ? html`<span>cooked ${recipe.times_cooked}×</span>`
+                          : html`<span>never cooked</span>`}
+                      </div>
+                    </div>
+                  </a>
+                `,
+              )}
+            </div>
+          `}
+    </div>
+  `);
+
+  const search = root.querySelector("[data-search]");
+  let timer;
+  search.oninput = () => {
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      query.search = search.value.trim();
+      renderRecipes(root);
+    }, 250);
+  };
+  root.querySelector("[data-sort]").onchange = (event) => {
+    query.sort = event.target.value;
+    renderRecipes(root);
+  };
+  root.querySelector("[data-under30]").onclick = () => {
+    query.under30 = !query.under30;
+    renderRecipes(root);
+  };
+  for (const chip of root.querySelectorAll("[data-tag]")) {
+    chip.onclick = () => {
+      query.tag = query.tag === chip.dataset.tag ? "" : chip.dataset.tag;
+      renderRecipes(root);
+    };
+  }
+  for (const button of root.querySelectorAll("[data-ingest], [data-ingest-empty]")) {
+    button.onclick = () => ingestDialog(root);
+  }
+}
+
+const totalMinutes = (recipe) => (recipe.prep_minutes || 0) + (recipe.cook_minutes || 0) || null;
+
+function ingestDialog(root) {
+  const dialog = openDialog(html`
+    <h2>Recipe from a URL</h2>
+    <p class="sub">Most recipe sites carry machine-readable data; if this one does, the whole thing lands in one go. Already-known URLs come back from the library instead of duplicating.</p>
+    <form data-f>
+      <label class="field"><span>Recipe page</span>
+        <input type="url" name="url" required placeholder="https://www.bbcgoodfood.com/recipes/…" autofocus></label>
+      <div data-msg></div>
+      <div class="dialog-actions">
+        <button class="btn ghost" type="button" data-x>Cancel</button>
+        <button class="btn" type="submit">Fetch it</button>
+      </div>
+    </form>
+  `);
+  dialog.querySelector("[data-x]").onclick = () => dialog.close();
+  dialog.querySelector("[data-f]").onsubmit = async (event) => {
+    event.preventDefault();
+    const button = event.target.querySelector("button[type=submit]");
+    const msg = dialog.querySelector("[data-msg]");
+    button.disabled = true;
+    button.textContent = "Fetching…";
+    try {
+      const result = await api("/recipes/ingest", { method: "POST", body: { url: event.target.url.value.trim() } });
+      dialog.close();
+      toast(result.cached ? "Already in the library — took you there." : `“${result.recipe.title}” landed.`, "ok");
+      window.location.hash = `#/recipes/${result.recipe.id}`;
+    } catch (error) {
+      button.disabled = false;
+      button.textContent = "Fetch it";
+      render(msg, html`<div class="staples-banner">${error.detail || error.message}
+        ${error.status === 422 && html`<br><br>You can still <a href="#/recipes/new" data-manual>write it in by hand</a> — or paste the page at your AI, which can read what the site didn't mark up.`}</div>`);
+      const manual = msg.querySelector("[data-manual]");
+      if (manual) manual.onclick = () => dialog.close();
+    }
+  };
+}
+
+export async function renderRecipeDetail(root, recipeId) {
+  render(root, skeleton());
+  const recipe = await api(`/recipes/${recipeId}`);
+  const total = totalMinutes(recipe);
+
+  render(root, html`
+    <div class="page">
+      <div class="crumb"><a href="#/recipes">← Recipes</a></div>
+      <div class="page-head">
+        <div>
+          <h1>${recipe.title}</h1>
+          <div class="meta-chips">
+            ${recipe.servings > 0 && html`<span class="chip">serves ${recipe.servings}</span>`}
+            ${recipe.prep_minutes > 0 && html`<span class="chip">prep ${recipe.prep_minutes} min</span>`}
+            ${recipe.cook_minutes > 0 && html`<span class="chip">cook ${recipe.cook_minutes} min</span>`}
+            ${total !== null && html`<span class="chip butter">⏱ ${total} min all in</span>`}
+            ${recipe.times_cooked > 0
+              ? html`<span class="chip red">cooked ${recipe.times_cooked}× · last ${fmtRel(recipe.last_cooked_at)}</span>`
+              : html`<span class="chip green">never cooked</span>`}
+            ${recipe.tags.map((tag) => html`<span class="chip">${tag}</span>`)}
+            ${recipe.edited && html`<span class="chip">edited</span>`}
+          </div>
+        </div>
+        <div class="page-actions">
+          <button class="btn" data-plan-it>🍲 Put it on the plan</button>
+          <a class="btn ghost" href="#/recipes/${recipe.id}/edit">Edit</a>
+          <button class="btn danger" data-del>Delete</button>
+        </div>
+      </div>
+
+      ${recipe.image_url && html`<div class="hero-img"><img src="${recipe.image_url}" alt="${recipe.title}"></div>`}
+
+      <div class="detail-cols">
+        <div class="card">
+          <h2>Ingredients</h2>
+          <ul class="ing-list">
+            ${recipe.ingredients.map(
+              (line) => html`
+                <li>
+                  <span class="qty">${line.display}</span>
+                  <span>${line.aisle} ${line.name}${line.value_tier === "premium" ? html` <span class="value-badge" title="${line.value_note || "worth paying up"}">⭐</span>` : ""}${line.value_tier === "budget" ? html` <span class="value-badge" title="${line.value_note || "own-brand is fine"}">💷</span>` : ""}</span>
+                </li>
+              `,
+            )}
+          </ul>
+        </div>
+        <div>
+          ${recipe.source_url &&
+          html`<p class="sub">From <a href="${recipe.source_url}" target="_blank" rel="noopener noreferrer">${hostOf(recipe.source_url)}</a>${recipe.parse_source === "ai" ? " · parsed by an AI" : ""}</p>`}
+          <div class="prose">${instructions(recipe.instructions)}</div>
+        </div>
+      </div>
+    </div>
+  `);
+
+  root.querySelector("[data-del]").onclick = async () => {
+    const ok = await confirmDialog({
+      title: `Delete “${recipe.title}”?`,
+      body: "Gone from the library for the whole household. Its cooked history stays on the record.",
+      confirmLabel: "Delete",
+      danger: true,
+    });
+    if (!ok) return;
+    try {
+      await api(`/recipes/${recipe.id}`, { method: "DELETE" });
+      toast("Recipe deleted.", "ok");
+      window.location.hash = "#/recipes";
+    } catch (error) {
+      toast(error.detail || error.message, "error"); // 409: still used by meals
+    }
+  };
+
+  root.querySelector("[data-plan-it]").onclick = () => planIt(recipe);
+}
+
+function hostOf(url) {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
+// instructions are free text; if most lines are numbered steps, render a list
+function instructions(text) {
+  if (!text) return html`<p class="sub">No method written down — the source link has it.</p>`;
+  const lines = text.split("\n").map((l) => l.trim()).filter(Boolean);
+  const numbered = lines.filter((l) => /^\d+[.)]\s/.test(l));
+  if (lines.length > 1 && numbered.length >= lines.length / 2) {
+    return html`<ol>${lines.map((l) => html`<li>${l.replace(/^\d+[.)]\s*/, "")}</li>`)}</ol>`;
+  }
+  return lines.map((l) => html`<p>${l}</p>`);
+}
+
+// The core loop, one click: recipe → meal (reusing one named after it) →
+// current plan (creating one if the household has none).
+async function planIt(recipe) {
+  const meals = await api("/meals", { query: { search: recipe.title } });
+  let meal = meals.find((m) => m.name.toLowerCase() === recipe.title.toLowerCase());
+  meal ||= await api("/meals", { method: "POST", body: { name: recipe.title, slot: "dinner", recipes: [{ recipe_id: recipe.id }] } });
+
+  let plan;
+  try {
+    plan = await api("/plans/current");
+  } catch (error) {
+    if (error.status !== 404) throw error;
+    plan = await api("/plans", { method: "POST", body: { label: "This week" } });
+  }
+  try {
+    await api(`/plans/${plan.id}/meals`, { method: "POST", body: { meal_id: meal.id } });
+    toast(`On the plan — its ingredients just joined the shopping list.`, "ok");
+  } catch (error) {
+    if (error.status === 409) toast("Already on the plan.", "ok");
+    else throw error;
+  }
+}
+
+export async function renderRecipeEditor(root, recipeId) {
+  render(root, skeleton());
+  const recipe = recipeId ? await api(`/recipes/${recipeId}`) : null;
+
+  render(root, html`
+    <div class="page narrow">
+      <div class="crumb"><a href="${recipe ? `#/recipes/${recipe.id}` : "#/recipes"}">← ${recipe ? recipe.title : "Recipes"}</a></div>
+      <div class="page-head"><h1>${recipe ? "Edit recipe" : "Write a recipe in"}</h1></div>
+      <form class="card" data-f>
+        <label class="field"><span>Title</span>
+          <input type="text" name="title" required value="${recipe?.title ?? ""}"></label>
+        <div class="form-row">
+          <label class="field"><span>Serves</span>
+            <input type="number" name="servings" min="1" value="${recipe?.servings ?? ""}"></label>
+          <label class="field"><span>Prep (min)</span>
+            <input type="number" name="prep_minutes" min="0" value="${recipe?.prep_minutes ?? ""}"></label>
+          <label class="field"><span>Cook (min)</span>
+            <input type="number" name="cook_minutes" min="0" value="${recipe?.cook_minutes ?? ""}"></label>
+        </div>
+        <label class="field"><span>Tags (comma-separated)</span>
+          <input type="text" name="tags" value="${recipe?.tags?.join(", ") ?? ""}" placeholder="italian, family favourite"></label>
+        <label class="field"><span>Image URL (optional)</span>
+          <input type="url" name="image_url" value="${recipe?.image_url ?? ""}"></label>
+
+        <div class="field-label">Ingredients</div>
+        <div data-lines></div>
+
+        <label class="field" for="instructions"><span>Method</span>
+          <textarea name="instructions" id="instructions" placeholder="1. Brown the mince.&#10;2. …">${recipe?.instructions ?? ""}</textarea></label>
+
+        <div class="dialog-actions">
+          <a class="btn ghost" href="${recipe ? `#/recipes/${recipe.id}` : "#/recipes"}">Cancel</a>
+          <button class="btn" type="submit">${recipe ? "Save changes" : "Add to the library"}</button>
+        </div>
+      </form>
+    </div>
+  `);
+
+  const lines = linesEditor(root.querySelector("[data-lines]"), recipe?.ingredients ?? []);
+
+  root.querySelector("[data-f]").onsubmit = async (event) => {
+    event.preventDefault();
+    const data = Object.fromEntries(new FormData(event.target));
+    const body = {
+      title: data.title.trim(),
+      servings: data.servings ? Number(data.servings) : null,
+      prep_minutes: data.prep_minutes ? Number(data.prep_minutes) : null,
+      cook_minutes: data.cook_minutes ? Number(data.cook_minutes) : null,
+      image_url: data.image_url.trim() || null,
+      instructions: data.instructions.trim() || null,
+      tags: data.tags.split(",").map((t) => t.trim()).filter(Boolean),
+      ingredients: lines.read(),
+    };
+    try {
+      const saved = recipe
+        ? await api(`/recipes/${recipe.id}`, { method: "PATCH", body })
+        : await api("/recipes", { method: "POST", body });
+      toast(recipe ? "Saved — meals using it resync their list lines." : "In the library.", "ok");
+      window.location.hash = `#/recipes/${saved.id}`;
+    } catch (error) {
+      toast(error.detail || error.message, "error");
+    }
+  };
+}

--- a/web/js/views/settings.js
+++ b/web/js/views/settings.js
@@ -1,0 +1,248 @@
+// Settings: account, household invites (Q19), AI access tokens, and the
+// danger zone (Q20). Invite codes and API tokens are shown exactly once —
+// the server stores only hashes.
+
+import { api, session } from "../api.js";
+import { confirmDialog, fmtDate, fmtRel, html, openDialog, parseUtc, render, skeleton, toast } from "../dom.js";
+
+export async function renderSettings(root) {
+  render(root, skeleton());
+  const [user, invites, tokens] = await Promise.all([
+    api("/auth/me"),
+    api("/auth/invites"),
+    api("/auth/tokens"),
+  ]);
+  session.saveUser(user);
+
+  render(root, html`
+    <div class="page narrow">
+      <div class="page-head">
+        <div>
+          <h1>Settings</h1>
+          <p class="sub">${user.household_name || "Home"} · signed in as ${user.display_name}</p>
+        </div>
+      </div>
+
+      <div class="section card">
+        <h2>Household</h2>
+        <p class="sub">Everyone in “${user.household_name || "Home"}” shares the recipes, plan and shopping list. Invite codes are single-use and expire; send one like you'd send a password.</p>
+        ${invites.length > 0
+          ? html`
+              <table class="plain">
+                <thead><tr><th>Created</th><th>Expires</th><th>Status</th><th></th></tr></thead>
+                <tbody>
+                  ${invites.map(
+                    (invite) => html`
+                      <tr>
+                        <td>${fmtDate(invite.created_at)}</td>
+                        <td>${fmtDate(invite.expires_at)}</td>
+                        <td>${inviteStatus(invite)}</td>
+                        <td>${!invite.accepted_at && parseUtc(invite.expires_at) > Date.now()
+                          ? html`<button class="icon-btn warm" data-revoke="${invite.id}">revoke</button>`
+                          : ""}</td>
+                      </tr>
+                    `,
+                  )}
+                </tbody>
+              </table>
+            `
+          : html`<p class="sub">No invites issued yet.</p>`}
+        <div class="dialog-actions"><button class="btn" data-invite>Invite someone</button></div>
+      </div>
+
+      <div class="section card">
+        <h2>Your AI's key to the kitchen</h2>
+        <p class="sub">
+          A personal API token lets an assistant drive this server — the
+          <a href="../skill" target="_blank" rel="noopener">skill</a> is its operating manual, the
+          <a href="../prompt-pack" target="_blank" rel="noopener">prompt pack</a> a paste-anywhere version.
+        </p>
+        ${tokens.length > 0
+          ? html`
+              <table class="plain">
+                <thead><tr><th>Label</th><th>Created</th><th>Last used</th><th>Expires</th><th></th></tr></thead>
+                <tbody>
+                  ${tokens.map(
+                    (token) => html`
+                      <tr>
+                        <td>${token.label || "—"}</td>
+                        <td>${fmtDate(token.created_at)}</td>
+                        <td>${token.last_used_at ? fmtRel(token.last_used_at) : "never"}</td>
+                        <td>${token.expires_at ? fmtDate(token.expires_at) : "never"}</td>
+                        <td><button class="icon-btn warm" data-revoke-token="${token.id}">revoke</button></td>
+                      </tr>
+                    `,
+                  )}
+                </tbody>
+              </table>
+            `
+          : html`<p class="sub">No API tokens yet.</p>`}
+        <div class="dialog-actions"><button class="btn" data-token>New API token</button></div>
+      </div>
+
+      <div class="section card">
+        <h2>Password</h2>
+        <form data-password>
+          <div class="form-row">
+            <label class="field"><span>Current password</span>
+              <input type="password" name="current_password" required autocomplete="current-password"></label>
+            <label class="field"><span>New password</span>
+              <input type="password" name="new_password" required minlength="8" autocomplete="new-password"></label>
+          </div>
+          <p class="sub">Other signed-in devices get logged out; API tokens deliberately survive.</p>
+          <div class="dialog-actions"><button class="btn" type="submit">Change password</button></div>
+        </form>
+      </div>
+
+      <div class="section card danger-zone">
+        <h2>Delete account</h2>
+        <p class="sub">
+          Permanent, no grace period. If you're the last member the whole
+          household goes — recipes, plans, history, all of it. Otherwise only
+          you go, and the household keeps what it cooked.
+        </p>
+        <div class="dialog-actions"><button class="btn danger" data-delete-account>Delete my account…</button></div>
+      </div>
+    </div>
+  `);
+
+  root.querySelector("[data-invite]").onclick = async () => {
+    const invite = await api("/auth/invites", { method: "POST", body: { expires_in_days: 7 } });
+    revealDialog(
+      "Invite code",
+      invite.code,
+      `Valid for one person, for 7 days. They register at this server with it and land in “${user.household_name || "Home"}”.`,
+    );
+    renderSettings(root);
+  };
+
+  for (const button of root.querySelectorAll("[data-revoke]")) {
+    button.onclick = async () => {
+      await api(`/auth/invites/${button.dataset.revoke}`, { method: "DELETE" });
+      toast("Invite revoked.", "ok");
+      renderSettings(root);
+    };
+  }
+
+  root.querySelector("[data-token]").onclick = () => tokenDialog(root);
+
+  for (const button of root.querySelectorAll("[data-revoke-token]")) {
+    button.onclick = async () => {
+      const ok = await confirmDialog({
+        title: "Revoke this token?",
+        body: "Whatever AI client holds it stops working immediately.",
+        confirmLabel: "Revoke",
+        danger: true,
+      });
+      if (!ok) return;
+      await api(`/auth/tokens/${button.dataset.revokeToken}`, { method: "DELETE" });
+      toast("Token revoked.", "ok");
+      renderSettings(root);
+    };
+  }
+
+  root.querySelector("[data-password]").onsubmit = async (event) => {
+    event.preventDefault();
+    const data = Object.fromEntries(new FormData(event.target));
+    try {
+      const auth = await api("/auth/password", { method: "POST", body: data });
+      session.save(auth); // the fresh token replaces the one just revoked
+      toast("Password changed — this device stays signed in.", "ok");
+      renderSettings(root);
+    } catch (error) {
+      toast(error.detail || error.message, "error");
+    }
+  };
+
+  root.querySelector("[data-delete-account]").onclick = () => deleteAccountDialog();
+}
+
+function inviteStatus(invite) {
+  if (invite.accepted_at) return html`<span class="chip green">redeemed ${fmtRel(invite.accepted_at)}</span>`;
+  if (parseUtc(invite.expires_at) <= Date.now()) return html`<span class="chip">expired</span>`;
+  return html`<span class="chip butter">open</span>`;
+}
+
+function revealDialog(title, secret, note) {
+  const dialog = openDialog(html`
+    <h2>${title}</h2>
+    <p class="sub">${note} Shown once — the server keeps only a hash.</p>
+    <div class="copy-row">
+      <div class="code-reveal">${secret}</div>
+      <button class="btn ghost" data-copy>Copy</button>
+    </div>
+    <div class="dialog-actions"><button class="btn" data-x>Done</button></div>
+  `);
+  dialog.querySelector("[data-x]").onclick = () => dialog.close();
+  dialog.querySelector("[data-copy]").onclick = async (event) => {
+    await navigator.clipboard.writeText(secret);
+    event.target.textContent = "Copied ✓";
+  };
+}
+
+function tokenDialog(root) {
+  const dialog = openDialog(html`
+    <h2>New API token</h2>
+    <form data-f>
+      <label class="field"><span>Label</span>
+        <input type="text" name="label" required placeholder="Claude on the laptop" autofocus></label>
+      <label class="field"><span>Expires</span>
+        <select name="expires_in_days">
+          <option value="">never</option>
+          <option value="30">in 30 days</option>
+          <option value="90">in 90 days</option>
+          <option value="365">in a year</option>
+        </select></label>
+      <div class="dialog-actions">
+        <button class="btn ghost" type="button" data-x>Cancel</button>
+        <button class="btn" type="submit">Create</button>
+      </div>
+    </form>
+  `);
+  dialog.querySelector("[data-x]").onclick = () => dialog.close();
+  dialog.querySelector("[data-f]").onsubmit = async (event) => {
+    event.preventDefault();
+    const data = new FormData(event.target);
+    const body = { label: data.get("label").trim() };
+    if (data.get("expires_in_days")) body.expires_in_days = Number(data.get("expires_in_days"));
+    try {
+      const token = await api("/auth/tokens", { method: "POST", body });
+      dialog.close();
+      revealDialog("API token", token.token, "Give it to your assistant as a Bearer token.");
+      renderSettings(root);
+    } catch (error) {
+      toast(error.detail || error.message, "error");
+    }
+  };
+}
+
+function deleteAccountDialog() {
+  const dialog = openDialog(html`
+    <h2>Delete your account?</h2>
+    <p class="sub">This cannot be undone. Type your password to confirm.</p>
+    <form data-f>
+      <label class="field"><span>Password</span>
+        <input type="password" name="password" required autocomplete="current-password"></label>
+      <div class="dialog-actions">
+        <button class="btn ghost" type="button" data-x>Keep my account</button>
+        <button class="btn danger" type="submit">Delete it</button>
+      </div>
+    </form>
+  `);
+  dialog.querySelector("[data-x]").onclick = () => dialog.close();
+  dialog.querySelector("[data-f]").onsubmit = async (event) => {
+    event.preventDefault();
+    try {
+      const result = await api("/auth/me", {
+        method: "DELETE",
+        body: { password: new FormData(event.target).get("password") },
+      });
+      dialog.close();
+      session.clear();
+      alert(result.detail); // last words before the login screen
+      window.location.hash = "#/login";
+    } catch (error) {
+      toast(error.detail || error.message, "error");
+    }
+  };
+}

--- a/web/js/views/shopping.js
+++ b/web/js/views/shopping.js
@@ -14,6 +14,13 @@ export async function renderShopping(root) {
     query: { include_staples: staplesMode || undefined, include_excluded: showExcluded || undefined },
   });
 
+  // The staples check is its own screen: just the staples, nothing else,
+  // matching the flow the skill teaches (include_staples → mark what's low).
+  if (staplesMode) {
+    renderStaplesCheck(root, list);
+    return;
+  }
+
   const ticked = list.items.filter((i) => i.checked && !i.excluded).length;
   const toGet = list.items.filter((i) => !i.excluded).length;
   const excluded = list.items.filter((i) => i.excluded);
@@ -25,13 +32,11 @@ export async function renderShopping(root) {
           <h1>Shopping list</h1>
           <p class="sub">
             <span data-count>${toGet === 0 ? "nothing to get" : `${ticked} of ${toGet} in the trolley`}</span>
-            ${!staplesMode && list.hidden_staples > 0 ? ` · ${list.hidden_staples} staples waiting for a check` : ""}
+            ${list.hidden_staples > 0 ? ` · ${list.hidden_staples} ${list.hidden_staples === 1 ? "staple" : "staples"} waiting for a check` : ""}
           </p>
         </div>
         <div class="page-actions">
-          <button class="btn ghost ${staplesMode ? "leek" : ""}" data-staples>
-            ${staplesMode ? "Done checking staples" : "🧂 Staples check"}
-          </button>
+          <button class="btn ghost" data-staples>🧂 Staples check</button>
           <a class="btn ghost" href="#/list/archived">Previous shops</a>
           <button class="btn" data-finish>Finish the shop</button>
         </div>
@@ -41,12 +46,6 @@ export async function renderShopping(root) {
         <input type="text" name="q" placeholder="Add something — “milk”, “2 l milk”, “500 g flour”…" autocomplete="off">
         <button class="btn" type="submit">Add</button>
       </form>
-
-      ${staplesMode &&
-      html`<div class="staples-banner">
-        <b>Staples check.</b> These usually live at home, so they hide from the list —
-        tick <i>low</i> on anything running out and it joins the shop in its aisle.
-      </div>`}
 
       ${list.items.length === 0
         ? emptyState("🛒", "The list writes itself", "Add meals to the plan and their ingredients appear here, merged and sorted by aisle. Or add one-offs above.")
@@ -70,15 +69,18 @@ export async function renderShopping(root) {
   bind(root, list);
 }
 
-function aisleGroups(list) {
-  const visible = list.items.filter((i) => !i.excluded);
+function groupByAisle(items) {
   const groups = [];
-  for (const item of visible) {
+  for (const item of items) {
     const last = groups[groups.length - 1];
     if (last && last.label === item.aisle_label) last.items.push(item);
     else groups.push({ emoji: item.aisle, label: item.aisle_label, items: [item] });
   }
-  return groups.map(
+  return groups;
+}
+
+function aisleGroups(list) {
+  return groupByAisle(list.items.filter((i) => !i.excluded)).map(
     (group) => html`
       <section class="aisle-group">
         <div class="aisle-head">
@@ -94,12 +96,9 @@ function aisleGroups(list) {
 
 function itemRow(item, inExcludedPile) {
   const adhocOnly = item.sources.every((s) => s.ad_hoc);
-  const staplePending = item.is_staple && !item.staple_needed;
   return html`
     <div class="shop-item ${item.checked ? "done" : ""}" data-item="${item.id}">
-      ${staplePending && staplesMode
-        ? html`<button class="icon-btn" data-low="${item.id}" title="Running low — put it on the list">low?</button>`
-        : html`<button class="tick" data-tick="${item.id}" aria-pressed="${item.checked}" aria-label="Got it"></button>`}
+      <button class="tick" data-tick="${item.id}" aria-pressed="${item.checked}" aria-label="Got it"></button>
       <span class="qty">${item.display}</span>
       <div class="i-main">
         <span class="i-name">${item.name}</span>
@@ -190,13 +189,6 @@ function bind(root, list) {
       }
     };
   }
-  for (const button of root.querySelectorAll("[data-low]")) {
-    button.onclick = async () => {
-      await api(`/shopping-list/items/${button.dataset.low}`, { method: "PATCH", body: { staple_needed: true } });
-      toast("On the list, in its aisle.", "ok");
-      renderShopping(root);
-    };
-  }
   for (const button of root.querySelectorAll("[data-have]")) {
     button.onclick = async () => {
       await api(`/shopping-list/items/${button.dataset.have}`, { method: "PATCH", body: { excluded: true } });
@@ -219,6 +211,84 @@ function bind(root, list) {
       }
     };
   }
+}
+
+// The staples check: only the staples, run down like a pantry list. A staple
+// marked low joins the main list in its aisle (staple_needed); the rest stay
+// hidden from the shop. Staples appear here once something has ever put them
+// on the list — that's the server's model, and the skill's.
+function renderStaplesCheck(root, list) {
+  const staples = list.items.filter((i) => i.is_staple);
+  const low = staples.filter((i) => i.staple_needed).length;
+
+  render(root, html`
+    <div class="page narrow">
+      <div class="page-head">
+        <div>
+          <h1>Staples check</h1>
+          <p class="sub">${staples.length === 0 ? "nothing is marked as a staple yet" : `${staples.length} ${staples.length === 1 ? "staple" : "staples"} · ${low} on the list`}</p>
+        </div>
+        <div class="page-actions">
+          <button class="btn leek" data-staples>Done — back to the list</button>
+        </div>
+      </div>
+
+      <div class="staples-banner">
+        <b>Pre-shop pantry sweep.</b> Staples live at home, so they stay off the
+        list until you say you're low — anything you mark joins the shop in its
+        aisle, the rest stay hidden.
+      </div>
+
+      ${staples.length === 0
+        ? emptyState("🧂", "No staples to check", "Mark things like olive oil and salt as staples on the Ingredients page. Once a recipe or a quick-add has ever put one on a list, it shows up here before each shop.")
+        : groupByAisle(staples).map(
+            (group) => html`
+              <section class="aisle-group">
+                <div class="aisle-head">
+                  <span class="a-emoji" aria-hidden="true">${group.emoji}</span>
+                  <span class="a-label">${group.label}</span>
+                  <span class="a-count">${group.items.filter((i) => i.staple_needed).length}/${group.items.length} low</span>
+                </div>
+                <div>${group.items.map((item) => stapleRow(item))}</div>
+              </section>
+            `,
+          )}
+    </div>
+  `);
+
+  root.querySelector("[data-staples]").onclick = () => {
+    staplesMode = false;
+    renderShopping(root);
+  };
+  for (const button of root.querySelectorAll("[data-low]")) {
+    button.onclick = async () => {
+      const needed = button.dataset.needed === "true";
+      try {
+        await api(`/shopping-list/items/${button.dataset.low}`, { method: "PATCH", body: { staple_needed: !needed } });
+        if (!needed) toast("On the list, in its aisle.", "ok");
+        renderShopping(root);
+      } catch (error) {
+        toast(error.detail || error.message, "error");
+      }
+    };
+  }
+}
+
+function stapleRow(item) {
+  return html`
+    <div class="shop-item">
+      <span class="qty">${item.display}</span>
+      <div class="i-main">
+        <span class="i-name">${item.name}</span>${valueBadge(item)}
+      </div>
+      ${item.staple_needed
+        ? html`
+            <span class="chip butter">on the list</span>
+            <button class="icon-btn" data-low="${item.id}" data-needed="true">stocked after all</button>
+          `
+        : html`<button class="btn small" data-low="${item.id}" data-needed="false">Low — add it</button>`}
+    </div>
+  `;
 }
 
 // Keep the header and per-aisle tallies honest during optimistic ticking,

--- a/web/js/views/shopping.js
+++ b/web/js/views/shopping.js
@@ -1,0 +1,289 @@
+// The shopping list, in store-walking order. Every line knows why it exists
+// (its sources), quantities are the server's derived truth, and checking off
+// is optimistic — the strike-through should never wait for a round trip.
+
+import { api } from "../api.js";
+import { confirmDialog, emptyState, fmtDate, html, render, skeleton, toast } from "../dom.js";
+
+let staplesMode = false;
+let showExcluded = false;
+
+export async function renderShopping(root) {
+  render(root, skeleton());
+  const list = await api("/shopping-list", {
+    query: { include_staples: staplesMode || undefined, include_excluded: showExcluded || undefined },
+  });
+
+  const ticked = list.items.filter((i) => i.checked && !i.excluded).length;
+  const toGet = list.items.filter((i) => !i.excluded).length;
+  const excluded = list.items.filter((i) => i.excluded);
+
+  render(root, html`
+    <div class="page">
+      <div class="page-head">
+        <div>
+          <h1>Shopping list</h1>
+          <p class="sub">
+            <span data-count>${toGet === 0 ? "nothing to get" : `${ticked} of ${toGet} in the trolley`}</span>
+            ${!staplesMode && list.hidden_staples > 0 ? ` · ${list.hidden_staples} staples waiting for a check` : ""}
+          </p>
+        </div>
+        <div class="page-actions">
+          <button class="btn ghost ${staplesMode ? "leek" : ""}" data-staples>
+            ${staplesMode ? "Done checking staples" : "🧂 Staples check"}
+          </button>
+          <a class="btn ghost" href="#/list/archived">Previous shops</a>
+          <button class="btn" data-finish>Finish the shop</button>
+        </div>
+      </div>
+
+      <form class="quick-add" data-add>
+        <input type="text" name="q" placeholder="Add something — “milk”, “2 l milk”, “500 g flour”…" autocomplete="off">
+        <button class="btn" type="submit">Add</button>
+      </form>
+
+      ${staplesMode &&
+      html`<div class="staples-banner">
+        <b>Staples check.</b> These usually live at home, so they hide from the list —
+        tick <i>low</i> on anything running out and it joins the shop in its aisle.
+      </div>`}
+
+      ${list.items.length === 0
+        ? emptyState("🛒", "The list writes itself", "Add meals to the plan and their ingredients appear here, merged and sorted by aisle. Or add one-offs above.")
+        : html`<div class="aisle-columns">${aisleGroups(list)}</div>`}
+
+      ${excluded.length > 0 &&
+      html`
+        <div class="section">
+          <h2>Already have it (${excluded.length})</h2>
+          <div>${excluded.map((item) => itemRow(item, true))}</div>
+        </div>
+      `}
+      <p class="menu-foot">
+        <button class="link-btn" data-show-excluded>
+          ${showExcluded ? "hide the “already have it” pile" : "show the “already have it” pile"}
+        </button>
+      </p>
+    </div>
+  `);
+
+  bind(root, list);
+}
+
+function aisleGroups(list) {
+  const visible = list.items.filter((i) => !i.excluded);
+  const groups = [];
+  for (const item of visible) {
+    const last = groups[groups.length - 1];
+    if (last && last.label === item.aisle_label) last.items.push(item);
+    else groups.push({ emoji: item.aisle, label: item.aisle_label, items: [item] });
+  }
+  return groups.map(
+    (group) => html`
+      <section class="aisle-group">
+        <div class="aisle-head">
+          <span class="a-emoji" aria-hidden="true">${group.emoji}</span>
+          <span class="a-label">${group.label}</span>
+          <span class="a-count" data-aisle-count>${group.items.filter((i) => i.checked).length}/${group.items.length}</span>
+        </div>
+        <div>${group.items.map((item) => itemRow(item, false))}</div>
+      </section>
+    `,
+  );
+}
+
+function itemRow(item, inExcludedPile) {
+  const adhocOnly = item.sources.every((s) => s.ad_hoc);
+  const staplePending = item.is_staple && !item.staple_needed;
+  return html`
+    <div class="shop-item ${item.checked ? "done" : ""}" data-item="${item.id}">
+      ${staplePending && staplesMode
+        ? html`<button class="icon-btn" data-low="${item.id}" title="Running low — put it on the list">low?</button>`
+        : html`<button class="tick" data-tick="${item.id}" aria-pressed="${item.checked}" aria-label="Got it"></button>`}
+      <span class="qty">${item.display}</span>
+      <div class="i-main">
+        <span class="i-name">${item.name}</span>
+        ${valueBadge(item)}
+        ${item.is_staple && item.staple_needed && html`<span class="chip butter">low</span>`}
+        <div class="i-why">${whyLine(item)}</div>
+      </div>
+      <div class="i-actions">
+        ${inExcludedPile
+          ? html`<button class="icon-btn" data-need="${item.id}">need it after all</button>`
+          : html`<button class="icon-btn" data-have="${item.id}" title="Skip this shop without forgetting why it was needed">have it</button>`}
+        ${adhocOnly && html`<button class="icon-btn warm" data-del="${item.id}">delete</button>`}
+      </div>
+    </div>
+  `;
+}
+
+function valueBadge(item) {
+  if (item.value_tier === "premium") return html` <span class="value-badge" title="Worth paying up: ${item.value_note || "household verdict"}">⭐</span>`;
+  if (item.value_tier === "budget") return html` <span class="value-badge" title="Own-brand is fine: ${item.value_note || "household verdict"}">💷</span>`;
+  return "";
+}
+
+function whyLine(item) {
+  const mealNames = [...new Set(item.sources.filter((s) => s.meal_name).map((s) => s.meal_name))];
+  const adhoc = item.sources.some((s) => s.ad_hoc);
+  const parts = [];
+  if (mealNames.length > 0) parts.push(`for ${mealNames.slice(0, 2).join(" + ")}${mealNames.length > 2 ? ` + ${mealNames.length - 2} more` : ""}`);
+  if (adhoc) parts.push(mealNames.length > 0 ? "and added by hand" : "added by hand");
+  if (item.is_staple && !parts.length) parts.push("staple");
+  return parts.join(" ");
+}
+
+function bind(root, list) {
+  root.querySelector("[data-staples]").onclick = () => {
+    staplesMode = !staplesMode;
+    renderShopping(root);
+  };
+  root.querySelector("[data-show-excluded]").onclick = () => {
+    showExcluded = !showExcluded;
+    renderShopping(root);
+  };
+
+  root.querySelector("[data-finish]").onclick = async () => {
+    const ok = await confirmDialog({
+      title: "Finish the shop?",
+      body: "This list is archived for the record and a fresh, empty one starts — adding meals to the plan fills it again.",
+      confirmLabel: "Finish",
+    });
+    if (!ok) return;
+    await api("/shopping-list/archive", { method: "POST" });
+    toast("Shop finished — fresh list started.", "ok");
+    renderShopping(root);
+  };
+
+  const addForm = root.querySelector("[data-add]");
+  addForm.onsubmit = async (event) => {
+    event.preventDefault();
+    const text = addForm.q.value.trim();
+    if (!text) return;
+    try {
+      await api("/shopping-list/items", {
+        method: "POST",
+        body: { ...parseQuick(text), id: crypto.randomUUID() },
+      });
+      addForm.q.value = "";
+      renderShopping(root);
+    } catch (error) {
+      toast(error.detail || error.message, "error"); // e.g. the metric-units guidance
+    }
+  };
+
+  // Optimistic tick: strike immediately, roll back if the server disagrees.
+  for (const tick of root.querySelectorAll("[data-tick]")) {
+    tick.onclick = async () => {
+      const row = tick.closest("[data-item]");
+      const was = tick.getAttribute("aria-pressed") === "true";
+      tick.setAttribute("aria-pressed", String(!was));
+      row.classList.toggle("done", !was);
+      updateCounts(root);
+      try {
+        await api(`/shopping-list/items/${tick.dataset.tick}`, { method: "PATCH", body: { checked: !was } });
+      } catch (error) {
+        tick.setAttribute("aria-pressed", String(was));
+        row.classList.toggle("done", was);
+        updateCounts(root);
+        toast(error.detail || error.message, "error");
+      }
+    };
+  }
+  for (const button of root.querySelectorAll("[data-low]")) {
+    button.onclick = async () => {
+      await api(`/shopping-list/items/${button.dataset.low}`, { method: "PATCH", body: { staple_needed: true } });
+      toast("On the list, in its aisle.", "ok");
+      renderShopping(root);
+    };
+  }
+  for (const button of root.querySelectorAll("[data-have]")) {
+    button.onclick = async () => {
+      await api(`/shopping-list/items/${button.dataset.have}`, { method: "PATCH", body: { excluded: true } });
+      renderShopping(root);
+    };
+  }
+  for (const button of root.querySelectorAll("[data-need]")) {
+    button.onclick = async () => {
+      await api(`/shopping-list/items/${button.dataset.need}`, { method: "PATCH", body: { excluded: false } });
+      renderShopping(root);
+    };
+  }
+  for (const button of root.querySelectorAll("[data-del]")) {
+    button.onclick = async () => {
+      try {
+        await api(`/shopping-list/items/${button.dataset.del}`, { method: "DELETE" });
+        renderShopping(root);
+      } catch (error) {
+        toast(error.detail || error.message, "error"); // the 409 names the meals that need it
+      }
+    };
+  }
+}
+
+// Keep the header and per-aisle tallies honest during optimistic ticking,
+// without a full re-render that would cut the strike animation short.
+function updateCounts(root) {
+  for (const group of root.querySelectorAll(".aisle-group")) {
+    const rows = group.querySelectorAll(".shop-item");
+    const done = group.querySelectorAll(".shop-item.done").length;
+    const count = group.querySelector("[data-aisle-count]");
+    if (count) count.textContent = `${done}/${rows.length}`;
+  }
+  const rows = root.querySelectorAll(".aisle-columns .shop-item");
+  const done = root.querySelectorAll(".aisle-columns .shop-item.done").length;
+  const label = root.querySelector("[data-count]");
+  if (label) label.textContent = rows.length === 0 ? "nothing to get" : `${done} of ${rows.length} in the trolley`;
+}
+
+// "2 l milk" / "500g flour" / "2 tins of chopped tomatoes" / plain "milk".
+// The server enforces the unit convention (metric or a natural count) and its
+// 422 explains the conversion, so this parser can stay naive.
+function parseQuick(text) {
+  const match = text.match(/^(\d+(?:[.,]\d+)?)\s*([a-zA-Z]+)?\s+(.+)$/);
+  if (!match) return { name: text };
+  let name = match[3].trim();
+  if (name.toLowerCase().startsWith("of ")) name = name.slice(3);
+  return {
+    name,
+    quantity: parseFloat(match[1].replace(",", ".")),
+    unit: match[2] || null,
+    raw: text,
+  };
+}
+
+export async function renderShoppingArchive(root) {
+  render(root, skeleton());
+  const lists = await api("/shopping-list/archived");
+  render(root, html`
+    <div class="page narrow">
+      <div class="crumb"><a href="#/list">← Shopping list</a></div>
+      <div class="page-head">
+        <div>
+          <h1>Previous shops</h1>
+          <p class="sub">what a finished list looked like, for the record</p>
+        </div>
+      </div>
+      ${lists.length === 0
+        ? emptyState("🧾", "No previous shops yet", "Finish a shop and it lands here.")
+        : html`
+            <div class="card">
+              <table class="plain">
+                <thead><tr><th>Shopped</th><th>Started</th><th>Items</th></tr></thead>
+                <tbody>
+                  ${lists.map(
+                    (l) => html`
+                      <tr>
+                        <td>${fmtDate(l.archived_at)}</td>
+                        <td>${fmtDate(l.created_at)}</td>
+                        <td>${l.item_count}</td>
+                      </tr>
+                    `,
+                  )}
+                </tbody>
+              </table>
+            </div>
+          `}
+    </div>
+  `);
+}


### PR DESCRIPTION
## What and why

Marcus wanted the plan and the shopping list on something bigger than a phone. `web/` is a fourth client of the same REST API: hand-written HTML/CSS + ES modules, no build step, no external requests, served by the backend itself at `/app` (same two-place lookup as `skill/`) so it is always same-origin with the endpoints it calls and ships with every deployment for free.

Covers the whole loop: plan (menu-card view, cooked marks, carry-over), shopping list (aisle order, optimistic check-off, a dedicated staples-check screen, "already have it", finish-the-shop, previous shops), recipes (search/sort, URL ingest, editor), meals (composition editor with per-recipe scale), ingredients (aisle/staple/value verdicts inline, duplicate merge), settings (invites, API tokens, password change, account deletion).

Serving decisions:

- Assets go out `Cache-Control: no-cache` — no build step means no hashed filenames, and heuristic caching would keep browsers on weeks-stale modules after a deploy. ETags make the steady state 304s.
- Browsers at `/` with no `marketing_url` land on `/app/` instead of `/docs`; the JSON landing advertises `app`. Production sets `marketing_url`, so the public root is unchanged.
- Identifies as `X-Meals-Client: web/1.0 (1)`; only `ios/*` is gated.
- CI's stack smoke now curls `/app/` so an image that forgets to `COPY web/` fails before it ships.

Verified end to end in the browser against seeded data: register-with-invite, plan/cooked/remove, check-off with rollback, quick-add incl. unit-rejection toasts, ingest 422 path, staples check, finish-the-shop, duplicate merge, dark mode, tablet layout.

## Checklist

- [x] **API contract stayed additive** — new mount + new landing key only; the root redirect change applies only when `marketing_url` is unset, and machine clients (no `Accept: text/html`) see no change.
- [x] **Every new query filters on `household_id`** — no new queries; the web app talks to the existing API.

(Model/migration, quantity-derivation, and skill items don't apply: no schema change, no endpoint change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)