### PR TITLE
Web app: search keeps focus while filtering; blank ingredient rows don't block saves

### DIFF
--- a/web/app.css
+++ b/web/app.css
@@ -326,6 +326,10 @@ select { cursor: pointer; }
 .toolbar input[type="search"] { max-width: 300px; }
 .toolbar select { width: auto; }
 .toolbar .gap { flex: 1; }
+/* Data-derived chip sets (recipe tags, meal slots) refresh with the results
+   while the toolbar around them stays put; the wrapper must not disturb the
+   toolbar's own flex flow. */
+.toolbar .facet-chips { display: contents; }
 
 /* ── menu card (the plan) ───────────────────────────────────────────── */
 

--- a/web/js/views/ingredients.js
+++ b/web/js/views/ingredients.js
@@ -4,23 +4,11 @@
 // until now only an AI over MCP could run it.
 
 import { aisles, api } from "../api.js";
-import { confirmDialog, emptyState, html, openDialog, render, skeleton, toast } from "../dom.js";
+import { confirmDialog, debounce, emptyState, html, openDialog, render, skeleton, toast } from "../dom.js";
 
 let query = { search: "", staplesOnly: false, tier: "" };
 
 export async function renderIngredients(root) {
-  render(root, skeleton());
-  const [items, aisleList] = await Promise.all([
-    api("/ingredients", {
-      query: {
-        search: query.search || undefined,
-        staples_only: query.staplesOnly || undefined,
-        value_tier: query.tier || undefined,
-      },
-    }),
-    aisles(),
-  ]);
-
   render(root, html`
     <div class="page">
       <div class="page-head">
@@ -43,7 +31,29 @@ export async function renderIngredients(root) {
         </select>
       </div>
 
-      ${items.length === 0
+      <div data-results>${skeleton()}</div>
+    </div>
+  `);
+
+  // Filter changes redraw [data-results] only — the toolbar (and the search
+  // input mid-typing) must survive, so never re-render the whole page here.
+  const results = root.querySelector("[data-results]");
+  let seq = 0;
+  const refresh = async () => {
+    const ticket = ++seq;
+    try {
+      const [items, aisleList] = await Promise.all([
+        api("/ingredients", {
+          query: {
+            search: query.search || undefined,
+            staples_only: query.staplesOnly || undefined,
+            value_tier: query.tier || undefined,
+          },
+        }),
+        aisles(),
+      ]);
+      if (ticket !== seq) return; // a newer filter overtook this fetch
+      render(results, items.length === 0
         ? emptyState("🥕", "Nothing here", "Ingredients appear as recipes and shopping lists use them.")
         : html`
             <div class="card">
@@ -54,30 +64,31 @@ export async function renderIngredients(root) {
               </div>
               ${items.map((item) => ingredientRow(item, aisleList))}
             </div>
-          `}
-    </div>
-  `);
+          `);
+      for (const row of results.querySelectorAll("[data-ing]")) bindRow(row, refresh);
+    } catch (error) {
+      if (ticket === seq) toast(error.detail || error.message, "error");
+    }
+  };
 
   const search = root.querySelector("[data-search]");
-  let timer;
-  search.oninput = () => {
-    clearTimeout(timer);
-    timer = setTimeout(() => {
-      query.search = search.value.trim();
-      renderIngredients(root);
-    }, 250);
-  };
-  root.querySelector("[data-staples]").onclick = () => {
+  search.oninput = debounce(() => {
+    query.search = search.value.trim();
+    refresh();
+  });
+  const staplesChip = root.querySelector("[data-staples]");
+  staplesChip.onclick = () => {
     query.staplesOnly = !query.staplesOnly;
-    renderIngredients(root);
+    staplesChip.classList.toggle("on", query.staplesOnly);
+    refresh();
   };
   root.querySelector("[data-tier]").onchange = (event) => {
     query.tier = event.target.value;
-    renderIngredients(root);
+    refresh();
   };
-  root.querySelector("[data-dupes]").onclick = () => duplicatesDialog(root);
+  root.querySelector("[data-dupes]").onclick = () => duplicatesDialog(refresh);
 
-  for (const row of root.querySelectorAll("[data-ing]")) bindRow(row, root);
+  await refresh();
 }
 
 function ingredientRow(item, aisleList) {
@@ -100,7 +111,7 @@ function ingredientRow(item, aisleList) {
   `;
 }
 
-function bindRow(row, root) {
+function bindRow(row, refresh) {
   const id = row.dataset.ing;
   const save = async (body) => {
     try {
@@ -129,14 +140,14 @@ function bindRow(row, root) {
     try {
       await api(`/ingredients/${id}`, { method: "DELETE" });
       toast("Deleted.", "ok");
-      renderIngredients(root);
+      refresh();
     } catch (error) {
       toast(error.detail || error.message, "error");
     }
   };
 }
 
-async function duplicatesDialog(root) {
+async function duplicatesDialog(refresh) {
   const dialog = openDialog(html`
     <h2>Duplicate ingredients</h2>
     <p class="sub">Same food, different spellings — merging repoints every recipe line and list item at the keeper, then removes the spares.</p>
@@ -177,7 +188,7 @@ async function duplicatesDialog(root) {
           });
           toast(`Merged ${result.merged} into “${result.ingredient.name}”.`, "ok");
           await load();
-          renderIngredients(root);
+          refresh();
         } catch (error) {
           button.disabled = false;
           toast(error.detail || error.message, "error");

--- a/web/js/views/lines.js
+++ b/web/js/views/lines.js
@@ -21,6 +21,11 @@ export function linesEditor(container, initial = []) {
     return { name: "", quantity: null, unit: null, raw: null, dirty: true };
   }
 
+  // A wholly blank row is dropped by read(), so it must never block submit;
+  // `required` on the name only guards rows that would otherwise lose typed
+  // qty/unit data silently.
+  const hasContent = (line) => line.quantity !== null || (line.unit ?? "").trim() !== "" || line.name.trim() !== "";
+
   function draw() {
     render(container, html`
       <datalist id="unit-suggestions">
@@ -31,7 +36,7 @@ export function linesEditor(container, initial = []) {
           <div class="line-row" data-index="${index}">
             <input type="number" step="any" min="0" placeholder="qty" value="${line.quantity ?? ""}" data-k="quantity" aria-label="Quantity">
             <input type="text" placeholder="unit" value="${line.unit ?? ""}" list="unit-suggestions" data-k="unit" aria-label="Unit">
-            <input type="text" placeholder="ingredient" value="${line.name}" data-k="name" aria-label="Ingredient" required>
+            <input type="text" placeholder="ingredient" value="${line.name}" data-k="name" aria-label="Ingredient" ${hasContent(line) ? "required" : ""}>
             <button type="button" class="icon-btn warm" data-drop tabindex="-1" title="Remove line">✕</button>
           </div>
         `,
@@ -48,6 +53,7 @@ export function linesEditor(container, initial = []) {
           // Hand-edited lines drop their scraped raw text — it no longer
           // describes what the row says.
           lines[index].dirty = true;
+          row.querySelector('[data-k="name"]').required = hasContent(lines[index]);
         };
         if (input.dataset.k === "name") {
           input.onkeydown = (event) => {

--- a/web/js/views/meals.js
+++ b/web/js/views/meals.js
@@ -2,34 +2,57 @@
 // optional scale) plus loose ingredients — "cottage pie with peas & carrots".
 
 import { api } from "../api.js";
-import { confirmDialog, emptyState, fmtRel, foodEmoji, html, render, skeleton, toast } from "../dom.js";
+import { confirmDialog, debounce, emptyState, fmtRel, foodEmoji, html, render, skeleton, toast } from "../dom.js";
 import { linesEditor } from "./lines.js";
 
 let query = { search: "", slot: "" };
 
 export async function renderMeals(root) {
-  render(root, skeleton());
-  const meals = await api("/meals", {
-    query: { search: query.search || undefined, slot: query.slot || undefined },
-  });
-  const slots = [...new Set(meals.map((m) => m.slot).filter(Boolean))].sort();
-
   render(root, html`
     <div class="page narrow">
       <div class="page-head">
         <div>
           <h1>Meals</h1>
-          <p class="sub">${meals.length} to choose from</p>
+          <p class="sub" data-count>&nbsp;</p>
         </div>
         <div class="page-actions"><a class="btn" href="#/meals/new">＋ New meal</a></div>
       </div>
 
       <div class="toolbar">
         <input type="search" placeholder="Search meals…  ( / )" value="${query.search}" data-search>
-        ${slots.map((slot) => html`<button class="chip click ${query.slot === slot ? "on" : ""}" data-slot="${slot}">${slot}</button>`)}
+        <span class="facet-chips" data-slots></span>
       </div>
 
-      ${meals.length === 0
+      <div data-results>${skeleton()}</div>
+    </div>
+  `);
+
+  // Filter changes redraw the results (and the data-derived count and slot
+  // chips) only — the toolbar stays put so typing in the search box never
+  // loses the input, its focus, or the caret.
+  const results = root.querySelector("[data-results]");
+  const slotsBox = root.querySelector("[data-slots]");
+  const count = root.querySelector("[data-count]");
+  let seq = 0;
+  const refresh = async () => {
+    const ticket = ++seq;
+    try {
+      const meals = await api("/meals", {
+        query: { search: query.search || undefined, slot: query.slot || undefined },
+      });
+      if (ticket !== seq) return; // a newer filter overtook this fetch
+      count.textContent = `${meals.length} to choose from`;
+
+      const slots = [...new Set(meals.map((m) => m.slot).filter(Boolean))].sort();
+      render(slotsBox, html`${slots.map((slot) => html`<button class="chip click ${query.slot === slot ? "on" : ""}" data-slot="${slot}">${slot}</button>`)}`);
+      for (const chip of slotsBox.querySelectorAll("[data-slot]")) {
+        chip.onclick = () => {
+          query.slot = query.slot === chip.dataset.slot ? "" : chip.dataset.slot;
+          refresh();
+        };
+      }
+
+      render(results, meals.length === 0
         ? emptyState("🍽️", "No meals yet", "A meal is a recipe (or a few) with any extras — make one and it becomes a plan option.", html`<a class="btn" href="#/meals/new">＋ New meal</a>`)
         : html`
             <ul class="row-list">
@@ -54,25 +77,19 @@ export async function renderMeals(root) {
                 `,
               )}
             </ul>
-          `}
-    </div>
-  `);
+          `);
+    } catch (error) {
+      if (ticket === seq) toast(error.detail || error.message, "error");
+    }
+  };
 
   const search = root.querySelector("[data-search]");
-  let timer;
-  search.oninput = () => {
-    clearTimeout(timer);
-    timer = setTimeout(() => {
-      query.search = search.value.trim();
-      renderMeals(root);
-    }, 250);
-  };
-  for (const chip of root.querySelectorAll("[data-slot]")) {
-    chip.onclick = () => {
-      query.slot = query.slot === chip.dataset.slot ? "" : chip.dataset.slot;
-      renderMeals(root);
-    };
-  }
+  search.oninput = debounce(() => {
+    query.search = search.value.trim();
+    refresh();
+  });
+
+  await refresh();
 }
 
 export async function renderMealDetail(root, mealId) {

--- a/web/js/views/recipes.js
+++ b/web/js/views/recipes.js
@@ -4,29 +4,18 @@
 // convention. Pages without usable JSON-LD 422 with advice we show verbatim.
 
 import { api } from "../api.js";
-import { confirmDialog, emptyState, fmtRel, html, openDialog, render, skeleton, toast } from "../dom.js";
+import { confirmDialog, debounce, emptyState, fmtRel, html, openDialog, render, skeleton, toast } from "../dom.js";
 import { linesEditor } from "./lines.js";
 
 let query = { search: "", tag: "", sort: "title", under30: false };
 
 export async function renderRecipes(root) {
-  render(root, skeleton());
-  const recipes = await api("/recipes", {
-    query: {
-      search: query.search || undefined,
-      tag: query.tag || undefined,
-      sort: query.sort,
-      max_total_minutes: query.under30 ? 30 : undefined,
-    },
-  });
-  const tags = [...new Set(recipes.flatMap((r) => r.tags))].sort();
-
   render(root, html`
     <div class="page">
       <div class="page-head">
         <div>
           <h1>Recipes</h1>
-          <p class="sub">${recipes.length} in the library</p>
+          <p class="sub" data-count>&nbsp;</p>
         </div>
         <div class="page-actions">
           <button class="btn" data-ingest>🔗 From a URL</button>
@@ -43,10 +32,44 @@ export async function renderRecipes(root) {
         </select>
         <button class="chip click ${query.under30 ? "on" : ""}" data-under30>under 30 min</button>
         <span class="gap"></span>
-        ${tags.map((tag) => html`<button class="chip click ${query.tag === tag ? "on" : ""}" data-tag="${tag}">${tag}</button>`)}
+        <span class="facet-chips" data-tags></span>
       </div>
 
-      ${recipes.length === 0
+      <div data-results>${skeleton()}</div>
+    </div>
+  `);
+
+  // Filter changes redraw the results (and the data-derived count and tag
+  // chips) only — the toolbar stays put so typing in the search box never
+  // loses the input, its focus, or the caret.
+  const results = root.querySelector("[data-results]");
+  const tagsBox = root.querySelector("[data-tags]");
+  const count = root.querySelector("[data-count]");
+  let seq = 0;
+  const refresh = async () => {
+    const ticket = ++seq;
+    try {
+      const recipes = await api("/recipes", {
+        query: {
+          search: query.search || undefined,
+          tag: query.tag || undefined,
+          sort: query.sort,
+          max_total_minutes: query.under30 ? 30 : undefined,
+        },
+      });
+      if (ticket !== seq) return; // a newer filter overtook this fetch
+      count.textContent = `${recipes.length} in the library`;
+
+      const tags = [...new Set(recipes.flatMap((r) => r.tags))].sort();
+      render(tagsBox, html`${tags.map((tag) => html`<button class="chip click ${query.tag === tag ? "on" : ""}" data-tag="${tag}">${tag}</button>`)}`);
+      for (const chip of tagsBox.querySelectorAll("[data-tag]")) {
+        chip.onclick = () => {
+          query.tag = query.tag === chip.dataset.tag ? "" : chip.dataset.tag;
+          refresh();
+        };
+      }
+
+      render(results, recipes.length === 0
         ? emptyState("📖", "No recipes yet", "Paste a recipe URL and the library starts itself — or ask your AI to fill it while you put the kettle on.", html`<button class="btn" data-ingest-empty>🔗 Add one from a URL</button>`)
         : html`
             <div class="recipe-grid">
@@ -68,41 +91,37 @@ export async function renderRecipes(root) {
                 `,
               )}
             </div>
-          `}
-    </div>
-  `);
+          `);
+      const ingestEmpty = results.querySelector("[data-ingest-empty]");
+      if (ingestEmpty) ingestEmpty.onclick = () => ingestDialog();
+    } catch (error) {
+      if (ticket === seq) toast(error.detail || error.message, "error");
+    }
+  };
 
   const search = root.querySelector("[data-search]");
-  let timer;
-  search.oninput = () => {
-    clearTimeout(timer);
-    timer = setTimeout(() => {
-      query.search = search.value.trim();
-      renderRecipes(root);
-    }, 250);
-  };
+  search.oninput = debounce(() => {
+    query.search = search.value.trim();
+    refresh();
+  });
   root.querySelector("[data-sort]").onchange = (event) => {
     query.sort = event.target.value;
-    renderRecipes(root);
+    refresh();
   };
-  root.querySelector("[data-under30]").onclick = () => {
+  const under30 = root.querySelector("[data-under30]");
+  under30.onclick = () => {
     query.under30 = !query.under30;
-    renderRecipes(root);
+    under30.classList.toggle("on", query.under30);
+    refresh();
   };
-  for (const chip of root.querySelectorAll("[data-tag]")) {
-    chip.onclick = () => {
-      query.tag = query.tag === chip.dataset.tag ? "" : chip.dataset.tag;
-      renderRecipes(root);
-    };
-  }
-  for (const button of root.querySelectorAll("[data-ingest], [data-ingest-empty]")) {
-    button.onclick = () => ingestDialog(root);
-  }
+  root.querySelector("[data-ingest]").onclick = () => ingestDialog();
+
+  await refresh();
 }
 
 const totalMinutes = (recipe) => (recipe.prep_minutes || 0) + (recipe.cook_minutes || 0) || null;
 
-function ingestDialog(root) {
+function ingestDialog() {
   const dialog = openDialog(html`
     <h2>Recipe from a URL</h2>
     <p class="sub">Most recipe sites carry machine-readable data; if this one does, the whole thing lands in one go. Already-known URLs come back from the library instead of duplicating.</p>


### PR DESCRIPTION
## What and why

Two web-app papercuts. Typing in the ingredients/recipes/meals search re-rendered the whole page on every (debounced) keystroke, flashing a skeleton and replacing the search input mid-word, so focus and caret died; the list views now render their shell once and filter changes redraw only the results region (plus the data-derived counts and facet chips), with a ticket guard so a slow older fetch can't land over a newer one. Separately, the lines editor's seeded blank row carried a hardcoded `required`, so a recipe-only meal (or ingredient-less recipe) refused to save even though `read()` drops blank rows anyway; `required` now tracks row content, still blocking rows with a qty/unit but no name so typed data is never silently dropped.

Checklist deleted: web client only — no API, model, query, skill, or error-string surface touched.

Verified in the browser against a worktree API: typing across multiple refresh cycles keeps focus/caret on all three list pages, facet chips and counts stay live, staples/tier/sort/tag/slot filters work, recipe-only meal saves and partial rows still block, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)