### PR TITLE
Ingredients: sort by aisle or verdict as well as name

### DIFF
--- a/backend/app/routers/ingredients.py
+++ b/backend/app/routers/ingredients.py
@@ -1,8 +1,9 @@
 import uuid
+from typing import Literal
 
 from fastapi import APIRouter, HTTPException, Query, status
 from pydantic import BaseModel, Field
-from sqlalchemy import func, select
+from sqlalchemy import case, func, select
 
 from app.deps import CurrentUser, DbSession
 from app.models import Ingredient, ListItem, MealIngredient, RecipeIngredient
@@ -16,11 +17,11 @@ from app.schemas.catalog import (
     UnfoldedIngredient,
 )
 from app.serializers import ingredient_out
-from app.services.aisles import AISLES, is_valid_aisle
+from app.services.aisles import AISLE_ORDER, AISLES, is_valid_aisle
 from app.services.catalog import get_or_create_ingredient
 from app.services.ingredient_merge import MergeError, find_duplicate_groups, find_unfolded, merge_ingredients
 from app.services.ingredient_names import canonical_ingredient_name
-from app.services.values import VALUE_TIER_HINT, is_valid_value_tier
+from app.services.values import VALUE_TIER_HINT, VALUE_TIER_NAMES, is_valid_value_tier
 
 router = APIRouter(tags=["ingredients"])
 
@@ -36,6 +37,17 @@ class IngredientCreate(BaseModel):
     is_staple: bool = False
     value_tier: str | None = None
     value_note: str | None = Field(default=None, max_length=200)
+
+
+def _sort_order(sort: str) -> tuple:
+    """Name is always the tiebreak so ordering is stable across requests."""
+    if sort == "aisle":
+        return (case(AISLE_ORDER, value=Ingredient.aisle, else_=len(AISLES)), Ingredient.name)
+    if sort == "value_tier":
+        # VALUE_TIERS is already premium → budget → any: opinions first, unrated last.
+        tier_order = {tier: index for index, tier in enumerate(VALUE_TIER_NAMES)}
+        return (case(tier_order, value=Ingredient.value_tier, else_=len(tier_order)), Ingredient.name)
+    return (Ingredient.name,)
 
 
 @router.get("/aisles", response_model=list[AisleOut])
@@ -57,6 +69,13 @@ async def list_ingredients(
     ),
     staples_only: bool = Query(default=False),
     value_tier: str | None = Query(default=None, description=f"filter by buying advice; {VALUE_TIER_HINT}"),
+    sort: Literal["name", "aisle", "value_tier"] = Query(
+        default="name",
+        description=(
+            "name (default), aisle (store-walking order, the same walk the shopping list uses), "
+            "or value_tier (⭐ premium first, then 💷 budget, then no opinion)"
+        ),
+    ),
 ) -> list[IngredientOut]:
     """Filter by `value_tier=premium` for the shopping list of things the
     household has decided are worth paying up for (and `budget` for the
@@ -69,7 +88,7 @@ async def list_ingredients(
     substring hit."""
     if value_tier is not None and not is_valid_value_tier(value_tier):
         raise HTTPException(status_code=422, detail=f"unknown value tier '{value_tier}'; {VALUE_TIER_HINT}")
-    query = select(Ingredient).where(Ingredient.household_id == user.household_id).order_by(Ingredient.name)
+    query = select(Ingredient).where(Ingredient.household_id == user.household_id).order_by(*_sort_order(sort))
     if search:
         query = query.where(Ingredient.name.ilike(f"%{search.lower()}%"))
     if name is not None:

--- a/backend/tests/integration/test_ingredients.py
+++ b/backend/tests/integration/test_ingredients.py
@@ -61,6 +61,28 @@ class TestIngredients:
         staples = await auth_client.get("/ingredients", params={"staples_only": "true"})
         assert [i["name"] for i in staples.json()] == ["salt"]
 
+    async def test_sort_by_aisle_walks_the_store(self, auth_client):
+        await auth_client.post("/ingredients", json={"name": "milk"})  # 🥛 Dairy
+        await auth_client.post("/ingredients", json={"name": "chicken"})  # 🥩 Meat & fish
+        await auth_client.post("/ingredients", json={"name": "banana"})  # 🥬 Fruit & veg
+        await auth_client.post("/ingredients", json={"name": "apple"})  # 🥬 Fruit & veg
+
+        response = await auth_client.get("/ingredients", params={"sort": "aisle"})
+        # store-walking order, name as the tiebreak within an aisle
+        assert [i["name"] for i in response.json()] == ["apple", "banana", "chicken", "milk"]
+
+    async def test_sort_by_value_tier_opinions_first(self, auth_client):
+        await auth_client.post("/ingredients", json={"name": "milk"})
+        await auth_client.post("/ingredients", json={"name": "plain flour", "value_tier": "budget"})
+        await auth_client.post("/ingredients", json={"name": "olive oil", "value_tier": "premium"})
+
+        response = await auth_client.get("/ingredients", params={"sort": "value_tier"})
+        assert [i["name"] for i in response.json()] == ["olive oil", "plain flour", "milk"]
+
+    async def test_sort_rejects_unknown_field(self, auth_client):
+        response = await auth_client.get("/ingredients", params={"sort": "price"})
+        assert response.status_code == 422
+
     async def test_aisles_endpoint_in_store_order(self, auth_client):
         response = await auth_client.get("/aisles")
         assert response.status_code == 200

--- a/web/js/views/ingredients.js
+++ b/web/js/views/ingredients.js
@@ -8,7 +8,7 @@
 import { aisles, api } from "../api.js";
 import { confirmDialog, debounce, emptyState, html, openDialog, render, skeleton, toast } from "../dom.js";
 
-let query = { search: "", staplesOnly: false, tier: "" };
+let query = { search: "", staplesOnly: false, tier: "", sort: "name" };
 
 export async function renderIngredients(root) {
   render(root, html`
@@ -25,6 +25,11 @@ export async function renderIngredients(root) {
 
       <div class="toolbar">
         <input type="search" placeholder="Search ingredients…  ( / )" value="${query.search}" data-search>
+        <select data-sort aria-label="Sort">
+          <option value="name" ${query.sort === "name" ? "selected" : ""}>A → Z</option>
+          <option value="aisle" ${query.sort === "aisle" ? "selected" : ""}>By aisle</option>
+          <option value="value_tier" ${query.sort === "value_tier" ? "selected" : ""}>By verdict</option>
+        </select>
         <button class="chip click ${query.staplesOnly ? "on" : ""}" data-staples>staples only</button>
         <select data-tier aria-label="Value tier">
           <option value="">any verdict</option>
@@ -50,6 +55,7 @@ export async function renderIngredients(root) {
             search: query.search || undefined,
             staples_only: query.staplesOnly || undefined,
             value_tier: query.tier || undefined,
+            sort: query.sort,
           },
         }),
         aisles(),
@@ -82,6 +88,10 @@ export async function renderIngredients(root) {
   staplesChip.onclick = () => {
     query.staplesOnly = !query.staplesOnly;
     staplesChip.classList.toggle("on", query.staplesOnly);
+    refresh();
+  };
+  root.querySelector("[data-sort]").onchange = (event) => {
+    query.sort = event.target.value;
     refresh();
   };
   root.querySelector("[data-tier]").onchange = (event) => {


### PR DESCRIPTION
## What

`GET /ingredients` grows an optional `sort` query param — `name` (default, unchanged), `aisle`, or `value_tier` — and the web catalogue gets the matching toolbar select (A → Z / By aisle / By verdict), same shape as the recipes sort.

- `aisle` sorts in store-walking order, the same walk the shopping list does (CASE over `AISLE_ORDER`).
- `value_tier` puts the household's opinions first: ⭐ premium, then 💷 budget, then unrated (`VALUE_TIERS` is already in that order).
- Name is always the tiebreak so ordering is stable across requests; an unknown sort value 422s naming the valid options.

## Scope notes

- Purely additive: optional param with the old default, so nothing changes for existing clients. iOS never fetches the list endpoint and the MCP server only uses `/ingredients` as a name resolver, so neither needs a change; skill docs untouched (AI clients re-order results themselves).
- No staples sort on purpose — the "staples only" filter chip already covers that case better than sorting a boolean would.

## Testing

- New integration tests: store-walk order (incl. name tiebreak within an aisle), opinions-first verdict order, 422 on unknown sort.
- Full backend suite passes locally (513 tests), lint clean.
- Verified live: booted the API on scratch SQLite and drove the web page — switching the select re-orders the rows correctly in both new modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)