### PR TITLE
Supermarkets: user-defined aisle orders per store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,8 +105,13 @@ from `deps.py`; every query filters on `user.household_id`.
   `ShoppingListStore` renders *server truth + queued `PendingOp`s*, persists
   both to disk, and replays ops in order — changes there must preserve
   idempotency and id-remapping.
-- **Aisle order** (`services/aisles.py`) is the shopping-list sort order and
-  its emoji vocabulary is published in the skill. Keep the two in sync.
+- **Aisle order** (`services/aisles.py`) is the default shopping-list sort
+  order and its emoji vocabulary is published in the skill. Keep the two in
+  sync. Households can override the *order* (never the vocabulary) per store
+  via `/supermarkets` (`services/supermarkets.py`): the active supermarket's
+  order drives the list sort and `GET /aisles`, which is how iOS learns it
+  without an app change. Orders saved before a new aisle existed gain it at
+  the end — adding an aisle must never invalidate a saved supermarket.
 - **Premium vs budget** (`services/values.py`, Q17). An ingredient's
   `value_tier` (`premium`/`budget`/`any`, plus a one-line `value_note`) is the
   household's own verdict — unlike an aisle it is **never guessed**, so no

--- a/backend/alembic/versions/e7a94d21c8b3_add_supermarkets.py
+++ b/backend/alembic/versions/e7a94d21c8b3_add_supermarkets.py
@@ -1,0 +1,46 @@
+"""add supermarkets
+
+Revision ID: e7a94d21c8b3
+Revises: b8f4c6d2e701
+Create Date: 2026-08-03 09:00:00.000000
+
+Per-supermarket aisle orders: a household saves the walking order per store
+and marks one active; the active order drives the shopping-list sort and
+GET /aisles. Additive only — no existing table changes, and with no rows the
+built-in order applies exactly as before, so old and new code coexist during
+the rollout.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e7a94d21c8b3'
+down_revision: Union[str, Sequence[str], None] = 'b8f4c6d2e701'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'supermarkets',
+        sa.Column('id', sa.Uuid(), nullable=False),
+        sa.Column('household_id', sa.Uuid(), nullable=False),
+        sa.Column('name', sa.String(length=120), nullable=False),
+        sa.Column('aisle_order', sa.JSON(), nullable=False),
+        sa.Column('is_active', sa.Boolean(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+        # No ondelete on household_id, like every other household-scoped table:
+        # deletion order is handled explicitly in services/accounts.py.
+        sa.ForeignKeyConstraint(['household_id'], ['households.id']),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('household_id', 'name', name='uq_supermarket_household_name'),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table('supermarkets')

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,7 @@ from fastapi.staticfiles import StaticFiles
 
 from app import client_gate
 from app.config import get_settings
-from app.routers import auth, ingredients, meals, pages, plans, recipes, shopping, skill
+from app.routers import auth, ingredients, meals, pages, plans, recipes, shopping, skill, supermarkets
 from app.routers.skill import base_url, playbook_version
 
 settings = get_settings()
@@ -69,6 +69,7 @@ app.include_router(recipes.router)
 app.include_router(meals.router)
 app.include_router(plans.router)
 app.include_router(shopping.router)
+app.include_router(supermarkets.router)
 app.include_router(skill.router)
 app.include_router(pages.router)
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,6 +1,6 @@
 from app.models.catalog import Ingredient, Recipe, RecipeIngredient
 from app.models.planning import CookedEvent, Meal, MealIngredient, MealRecipe, Plan, PlanMeal
-from app.models.shopping import ListItem, ListItemSource, ShoppingList
+from app.models.shopping import ListItem, ListItemSource, ShoppingList, Supermarket
 from app.models.users import AuthToken, Household, HouseholdInvite, User
 
 __all__ = [
@@ -19,5 +19,6 @@ __all__ = [
     "Recipe",
     "RecipeIngredient",
     "ShoppingList",
+    "Supermarket",
     "User",
 ]

--- a/backend/app/models/shopping.py
+++ b/backend/app/models/shopping.py
@@ -1,13 +1,34 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, Float, ForeignKey, String, Uuid
+from sqlalchemy import JSON, Boolean, DateTime, Float, ForeignKey, String, UniqueConstraint, Uuid
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
 from app.models.catalog import Ingredient, Recipe
 from app.models.planning import PlanMeal
 from app.models.users import utcnow
+
+
+class Supermarket(Base):
+    """A store the household shops at, with its own aisle walking order.
+
+    `aisle_order` is a sequence of aisle emojis; the *active* supermarket's
+    order is what the shopping list sorts by and what GET /aisles returns
+    (which is also how the iOS app learns it — it refetches /aisles and sorts
+    locally). No active supermarket means the built-in order in
+    `services/aisles.py`. An order saved before a new aisle joined the
+    vocabulary simply gains it at the end (`effective_aisle_order`)."""
+
+    __tablename__ = "supermarkets"
+    __table_args__ = (UniqueConstraint("household_id", "name", name="uq_supermarket_household_name"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    household_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("households.id"))
+    name: Mapped[str] = mapped_column(String(120))
+    aisle_order: Mapped[list] = mapped_column(JSON, default=list)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)
 
 
 class ShoppingList(Base):

--- a/backend/app/routers/ingredients.py
+++ b/backend/app/routers/ingredients.py
@@ -20,6 +20,7 @@ from app.services.aisles import AISLES, is_valid_aisle
 from app.services.catalog import get_or_create_ingredient
 from app.services.ingredient_merge import MergeError, find_duplicate_groups, find_unfolded, merge_ingredients
 from app.services.ingredient_names import canonical_ingredient_name
+from app.services.supermarkets import effective_aisle_order, get_active_supermarket
 from app.services.values import VALUE_TIER_HINT, is_valid_value_tier
 
 router = APIRouter(tags=["ingredients"])
@@ -39,10 +40,17 @@ class IngredientCreate(BaseModel):
 
 
 @router.get("/aisles", response_model=list[AisleOut])
-async def list_aisles(user: CurrentUser) -> list[AisleOut]:
+async def list_aisles(user: CurrentUser, db: DbSession) -> list[AisleOut]:
     """The aisle vocabulary, in store-walking order — the same order the
-    shopping list is sorted in."""
-    return [AisleOut(emoji=emoji, label=label) for emoji, label in AISLES]
+    shopping list is sorted in. When the household has an active supermarket
+    (see /supermarkets) this is that store's saved walking order; otherwise
+    the built-in one."""
+    market = await get_active_supermarket(db, user.household_id)
+    labels = dict(AISLES)
+    return [
+        AisleOut(emoji=emoji, label=labels[emoji])
+        for emoji in effective_aisle_order(market.aisle_order if market else None)
+    ]
 
 
 @router.get("/ingredients", response_model=list[IngredientOut])

--- a/backend/app/routers/shopping.py
+++ b/backend/app/routers/shopping.py
@@ -10,6 +10,7 @@ from app.models import ListItem, ShoppingList
 from app.schemas.shopping import AdhocItemIn, ArchiveOut, ListItemOut, ListItemUpdate, ShoppingListOut
 from app.serializers import list_item_out, shopping_list_out
 from app.services.shopping import add_adhoc_item, archive_and_replace, get_active_list, get_list_full, is_adhoc_only
+from app.services.supermarkets import effective_aisle_order, get_active_supermarket
 
 router = APIRouter(prefix="/shopping-list", tags=["shopping-list"])
 
@@ -24,11 +25,22 @@ async def get_shopping_list(
     """The live shopping list, sorted in store-walking order (aisle emoji,
     then name). Staples and 'already have it' items are hidden by default;
     hidden_staples says how many are waiting for a staples check. A staple
-    marked staple_needed ("I'm low") stays on the list in its aisle."""
+    marked staple_needed ("I'm low") stays on the list in its aisle.
+
+    The walk follows the household's active supermarket when one is set
+    (`supermarket` names it — see /supermarkets); otherwise the built-in
+    order."""
     active = await get_active_list(db, user.household_id)
     await db.commit()  # persist the list if it was just created
     full = await get_list_full(db, active.id)
-    return shopping_list_out(full, include_staples=include_staples, include_excluded=include_excluded)
+    market = await get_active_supermarket(db, user.household_id)
+    return shopping_list_out(
+        full,
+        include_staples=include_staples,
+        include_excluded=include_excluded,
+        supermarket=market,
+        aisle_sequence=effective_aisle_order(market.aisle_order) if market else None,
+    )
 
 
 @router.post("/items", response_model=ListItemOut, status_code=status.HTTP_201_CREATED)

--- a/backend/app/routers/supermarkets.py
+++ b/backend/app/routers/supermarkets.py
@@ -1,0 +1,151 @@
+"""Per-supermarket aisle orders.
+
+Each household can save the aisle walking order for the stores it actually
+shops at and mark one *active*. The active order is what `GET /shopping-list`
+sorts by and what `GET /aisles` returns — clients (including iOS, which
+refetches `/aisles` every list load) follow along without knowing
+supermarkets exist. No active supermarket = the built-in order.
+"""
+
+import uuid
+
+from fastapi import APIRouter, HTTPException, status
+from sqlalchemy import select, update
+
+from app.deps import CurrentUser, DbSession
+from app.models import Supermarket
+from app.schemas.shopping import SupermarketCreate, SupermarketOut, SupermarketUpdate
+from app.services.supermarkets import effective_aisle_order, invalid_aisle_order_detail
+
+router = APIRouter(prefix="/supermarkets", tags=["supermarkets"])
+
+
+def _out(market: Supermarket) -> SupermarketOut:
+    return SupermarketOut(
+        id=market.id,
+        name=market.name,
+        aisle_order=effective_aisle_order(market.aisle_order),
+        is_active=market.is_active,
+        created_at=market.created_at,
+    )
+
+
+@router.get("", response_model=list[SupermarketOut])
+async def list_supermarkets(user: CurrentUser, db: DbSession) -> list[SupermarketOut]:
+    """The household's supermarkets and their saved aisle walking orders.
+
+    The `is_active` one decides the order the shopping list is sorted in and
+    the order `GET /aisles` returns; when none is active the built-in
+    store-walking order applies."""
+    result = await db.execute(
+        select(Supermarket).where(Supermarket.household_id == user.household_id).order_by(Supermarket.created_at)
+    )
+    return [_out(market) for market in result.scalars()]
+
+
+@router.post("", response_model=SupermarketOut, status_code=status.HTTP_201_CREATED)
+async def create_supermarket(payload: SupermarketCreate, user: CurrentUser, db: DbSession) -> SupermarketOut:
+    """Save a supermarket and, optionally, its aisle walking order.
+
+    `aisle_order` is aisle emojis first-to-last as you walk that store; any
+    you leave out keep their usual place at the end, and omitting it entirely
+    starts from the built-in order. `is_active: true` makes it the order the
+    shopping list sorts in right away."""
+    name = payload.name.strip()
+    if not name:
+        raise HTTPException(status_code=422, detail="supermarket name cannot be blank")
+    existing = await _find_by_name(db, user.household_id, name)
+    if existing is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"a supermarket called '{existing.name}' already exists; change its order with "
+                f"PATCH /supermarkets/{existing.id}, or pick another name"
+            ),
+        )
+    if payload.aisle_order is not None:
+        problem = invalid_aisle_order_detail(payload.aisle_order)
+        if problem is not None:
+            raise HTTPException(status_code=422, detail=problem)
+    market = Supermarket(
+        household_id=user.household_id,
+        name=name,
+        aisle_order=payload.aisle_order or [],
+        is_active=payload.is_active,
+    )
+    if payload.is_active:
+        await _deactivate_all(db, user.household_id)
+    db.add(market)
+    await db.commit()
+    return _out(market)
+
+
+@router.patch("/{supermarket_id}", response_model=SupermarketOut)
+async def update_supermarket(
+    supermarket_id: uuid.UUID, payload: SupermarketUpdate, user: CurrentUser, db: DbSession
+) -> SupermarketOut:
+    """Rename a supermarket, replace its aisle walking order, or switch the
+    active store: `{"is_active": true}` sorts the shopping list for this one
+    ("we're at Aldi today"), `{"is_active": false}` goes back to the built-in
+    order."""
+    market = await _get(db, user.household_id, supermarket_id)
+    if payload.name is not None:
+        name = payload.name.strip()
+        if not name:
+            raise HTTPException(status_code=422, detail="supermarket name cannot be blank")
+        clash = await _find_by_name(db, user.household_id, name)
+        if clash is not None and clash.id != market.id:
+            raise HTTPException(
+                status_code=409, detail=f"a supermarket called '{clash.name}' already exists; pick another name"
+            )
+        market.name = name
+    if payload.aisle_order is not None:
+        problem = invalid_aisle_order_detail(payload.aisle_order)
+        if problem is not None:
+            raise HTTPException(status_code=422, detail=problem)
+        market.aisle_order = payload.aisle_order
+    if payload.is_active is not None:
+        if payload.is_active:
+            # keep= skips this row: bulk-updating it while its ORM attribute
+            # still reads True would leave the flag flipped off in the database
+            # with no ORM change event to flip it back.
+            await _deactivate_all(db, user.household_id, keep=market.id)
+        market.is_active = payload.is_active
+    await db.commit()
+    return _out(market)
+
+
+@router.delete("/{supermarket_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_supermarket(supermarket_id: uuid.UUID, user: CurrentUser, db: DbSession) -> None:
+    """Delete a saved supermarket. If it was the active one the shopping list
+    goes back to the built-in store-walking order."""
+    market = await _get(db, user.household_id, supermarket_id)
+    await db.delete(market)
+    await db.commit()
+
+
+async def _get(db: DbSession, household_id: uuid.UUID, supermarket_id: uuid.UUID) -> Supermarket:
+    market = await db.get(Supermarket, supermarket_id)
+    if market is None or market.household_id != household_id:
+        raise HTTPException(status_code=404, detail="supermarket not found; list them via GET /supermarkets")
+    return market
+
+
+async def _find_by_name(db: DbSession, household_id: uuid.UUID, name: str) -> Supermarket | None:
+    # Case-insensitive: "tesco" next to "Tesco" would be two stores nobody wanted.
+    result = await db.execute(select(Supermarket).where(Supermarket.household_id == household_id))
+    folded = name.lower()
+    for market in result.scalars():
+        if market.name.lower() == folded:
+            return market
+    return None
+
+
+async def _deactivate_all(db: DbSession, household_id: uuid.UUID, keep: uuid.UUID | None = None) -> None:
+    query = update(Supermarket).where(
+        Supermarket.household_id == household_id,
+        Supermarket.is_active == True,  # noqa: E712
+    )
+    if keep is not None:
+        query = query.where(Supermarket.id != keep)
+    await db.execute(query.values(is_active=False))

--- a/backend/app/schemas/shopping.py
+++ b/backend/app/schemas/shopping.py
@@ -49,6 +49,11 @@ class ListItemUpdate(BaseModel):
     staple_needed: bool | None = None
 
 
+class SupermarketRef(BaseModel):
+    id: uuid.UUID
+    name: str
+
+
 class ShoppingListOut(BaseModel):
     id: uuid.UUID
     status: str
@@ -56,6 +61,29 @@ class ShoppingListOut(BaseModel):
     archived_at: datetime | None
     items: list[ListItemOut]  # sorted in store-walking order (aisle, then name)
     hidden_staples: int  # staples not shown — list them with ?include_staples=true, surface one via staple_needed
+    supermarket: SupermarketRef | None = None  # whose aisle order the sort follows; null = the built-in order
+
+
+class SupermarketOut(BaseModel):
+    id: uuid.UUID
+    name: str
+    aisle_order: list[str]  # the complete walk, first aisle to last
+    is_active: bool  # the active supermarket's order sorts the list and GET /aisles
+    created_at: datetime
+
+
+class SupermarketCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=120)
+    # Aisle emojis first-to-last as walked; omitted aisles keep their usual
+    # place at the end. Default: the built-in store-walking order.
+    aisle_order: list[str] | None = None
+    is_active: bool = False
+
+
+class SupermarketUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=120)
+    aisle_order: list[str] | None = None
+    is_active: bool | None = None  # true sorts the list for this store; false falls back to the built-in order
 
 
 class ArchiveOut(BaseModel):

--- a/backend/app/serializers.py
+++ b/backend/app/serializers.py
@@ -1,9 +1,9 @@
 """Model → response-schema conversion, including display strings and aisle labels."""
 
-from app.models import Ingredient, ListItem, Meal, Plan, PlanMeal, Recipe, ShoppingList
+from app.models import Ingredient, ListItem, Meal, Plan, PlanMeal, Recipe, ShoppingList, Supermarket
 from app.schemas.catalog import IngredientOut, RecipeLineOut, RecipeOut, RecipeSummary
 from app.schemas.planning import MealOut, MealRecipeOut, PlanMealOut, PlanOut, PlanSummary
-from app.schemas.shopping import ListItemOut, ShoppingListOut, SourceOut
+from app.schemas.shopping import ListItemOut, ShoppingListOut, SourceOut, SupermarketRef
 from app.services.aisles import AISLE_ORDER, AISLES, UNKNOWN_AISLE
 from app.services.units import format_buy_quantity, format_quantity
 from app.services.values import value_tier_label
@@ -162,7 +162,13 @@ def list_item_out(item: ListItem) -> ListItemOut:
     )
 
 
-def shopping_list_out(shopping_list: ShoppingList, include_staples: bool, include_excluded: bool) -> ShoppingListOut:
+def shopping_list_out(
+    shopping_list: ShoppingList,
+    include_staples: bool,
+    include_excluded: bool,
+    supermarket: Supermarket | None = None,
+    aisle_sequence: list[str] | None = None,
+) -> ShoppingListOut:
     visible: list[ListItem] = []
     hidden_staples = 0
     for item in shopping_list.items:
@@ -172,7 +178,8 @@ def shopping_list_out(shopping_list: ShoppingList, include_staples: bool, includ
         if item.excluded and not include_excluded:
             continue
         visible.append(item)
-    visible.sort(key=lambda item: (AISLE_ORDER.get(item.ingredient.aisle, len(AISLE_ORDER)), item.ingredient.name))
+    order = AISLE_ORDER if aisle_sequence is None else {emoji: i for i, emoji in enumerate(aisle_sequence)}
+    visible.sort(key=lambda item: (order.get(item.ingredient.aisle, len(order)), item.ingredient.name))
     return ShoppingListOut(
         id=shopping_list.id,
         status=shopping_list.status,
@@ -180,4 +187,5 @@ def shopping_list_out(shopping_list: ShoppingList, include_staples: bool, includ
         archived_at=shopping_list.archived_at,
         items=[list_item_out(item) for item in visible],
         hidden_staples=hidden_staples,
+        supermarket=SupermarketRef(id=supermarket.id, name=supermarket.name) if supermarket else None,
     )

--- a/backend/app/services/accounts.py
+++ b/backend/app/services/accounts.py
@@ -21,6 +21,7 @@ from app.models import (
     Plan,
     Recipe,
     ShoppingList,
+    Supermarket,
     User,
 )
 
@@ -54,6 +55,7 @@ async def delete_household_data(db: AsyncSession, household_id: uuid.UUID) -> No
     # Ingredients last of the food: list items and meal/recipe lines reference
     # them without a cascade, so they must already be gone.
     await db.execute(delete(Ingredient).where(Ingredient.household_id == household_id))
+    await db.execute(delete(Supermarket).where(Supermarket.household_id == household_id))
     await db.execute(delete(HouseholdInvite).where(HouseholdInvite.household_id == household_id))
     await db.execute(delete(User).where(User.household_id == household_id))
     await db.execute(delete(Household).where(Household.id == household_id))

--- a/backend/app/services/supermarkets.py
+++ b/backend/app/services/supermarkets.py
@@ -1,0 +1,55 @@
+"""Per-supermarket aisle orders — the household's own store walks.
+
+The built-in order in `services/aisles.py` is the default. A household can
+save one order per supermarket and mark one *active*; the active order drives
+the shopping-list sort and `GET /aisles`. That endpoint is also how the iOS
+app learns the order (it refetches on every list load and sorts locally), so
+no client needs to know supermarkets exist to honour one.
+"""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Supermarket
+from app.services.aisles import AISLE_EMOJIS, AISLE_ORDER
+
+
+async def get_active_supermarket(db: AsyncSession, household_id: uuid.UUID) -> Supermarket | None:
+    result = await db.execute(
+        select(Supermarket)
+        .where(Supermarket.household_id == household_id, Supermarket.is_active == True)  # noqa: E712
+        .order_by(Supermarket.created_at)
+    )
+    return result.scalars().first()
+
+
+def effective_aisle_order(stored: list[str] | None) -> list[str]:
+    """A complete aisle sequence from a stored (possibly stale) one.
+
+    Emojis that left the vocabulary are dropped; aisles the row predates are
+    appended in built-in order — so adding an aisle to `AISLES` never breaks
+    a saved supermarket, it just walks the new aisle last until re-saved."""
+    if not stored:
+        return list(AISLE_EMOJIS)
+    known: list[str] = []
+    for emoji in stored:
+        if emoji in AISLE_ORDER and emoji not in known:
+            known.append(emoji)
+    return known + [emoji for emoji in AISLE_EMOJIS if emoji not in known]
+
+
+def invalid_aisle_order_detail(order: list[str]) -> str | None:
+    """Why an aisle_order can't be saved, phrased for the calling AI; None when fine."""
+    unknown = [emoji for emoji in order if emoji not in AISLE_ORDER]
+    if unknown:
+        return (
+            f"unknown aisle(s) {' '.join(unknown)}; valid aisles: {' '.join(AISLE_EMOJIS)}. "
+            "List them first-to-last as you walk the store — any you leave out keep "
+            "their usual place at the end"
+        )
+    duplicates = sorted({emoji for emoji in order if order.count(emoji) > 1})
+    if duplicates:
+        return f"aisle(s) {' '.join(duplicates)} listed more than once; each aisle appears at most once"
+    return None

--- a/backend/tests/integration/test_account_deletion.py
+++ b/backend/tests/integration/test_account_deletion.py
@@ -45,6 +45,7 @@ async def counts(engine) -> dict:
         "list_items",
         "list_item_sources",
         "cooked_events",
+        "supermarkets",
     ]
     async with engine.connect() as conn:
         return {t: (await conn.execute(text(f"select count(*) from {t}"))).scalar() for t in tables}
@@ -63,9 +64,10 @@ class TestLastMemberDeletion:
         pm = (await client.get(f"/plans/{plan['id']}")).json()["meals"][0]
         await client.post(f"/plans/{plan['id']}/meals/{pm['id']}/cooked")
         assert len((await get_list(client))["items"]) > 0
-        # An unredeemed invite too, so every table has a row and "all zero
-        # afterwards" actually proves something.
+        # An unredeemed invite and a supermarket too, so every table has a row
+        # and "all zero afterwards" actually proves something.
         await invite_code(client, token)
+        assert (await client.post("/supermarkets", json={"name": "Big Tesco"})).status_code == 201
 
         before = await counts(engine)
         # Cooking records one event per subject — the meal and the recipe.

--- a/backend/tests/integration/test_misc.py
+++ b/backend/tests/integration/test_misc.py
@@ -161,8 +161,8 @@ class TestPublicPages:
 # Without this, guidance can ship under an unchanged number — which is exactly
 # what happened when the premium/budget tools landed on v1: a stale v1 copy
 # compared v1 to v1, found no drift, and never learned the tools existed.
-PINNED_PLAYBOOK_VERSION = 11
-PINNED_PLAYBOOK_DIGEST = "24f7eb30ffbe54fee9c2df8cbf48cf532826f120b2c0af211cf0e2e896c27e68"
+PINNED_PLAYBOOK_VERSION = 12
+PINNED_PLAYBOOK_DIGEST = "0624e2bd16fabe9f9b6da71b79fa64cd0df0abc36ba8ba6841685a803eae7bb3"
 
 _VERSION_STAMP = re.compile(r"<!--\s*playbook-version:\s*\d+\s*-->\n?")
 _VERSION_PROSE = re.compile(r"playbook v\d+", re.IGNORECASE)

--- a/backend/tests/integration/test_supermarkets.py
+++ b/backend/tests/integration/test_supermarkets.py
@@ -1,0 +1,150 @@
+"""Per-supermarket aisle orders: /supermarkets CRUD, the single-active rule,
+and the two read paths that follow the active order — GET /aisles (how iOS
+learns it) and the GET /shopping-list sort."""
+
+from app.services.aisles import AISLE_EMOJIS
+from tests.conftest import create_meal, create_plan, create_recipe, get_list, register
+
+# The built-in walk starts 🥬 🍞 🥩; this store meets frozen and drinks first.
+BACKWARDS = ["🧊", "🥤", "🥫", "🥛", "🥩", "🍞", "🥬"]
+
+
+async def create_market(client, name="Big Tesco", **overrides):
+    response = await client.post("/supermarkets", json={"name": name, **overrides})
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+async def plan_spag_bol(client):
+    """Recipe → meal → plan, so the list holds beef (🥩), onion (🥬), tomatoes (🥫)."""
+    recipe = await create_recipe(client)
+    meal = await create_meal(client)
+    await client.patch(f"/meals/{meal['id']}", json={"recipe_ids": [recipe["id"]]})
+    plan = await create_plan(client)
+    response = await client.post(f"/plans/{plan['id']}/meals", json={"meal_id": meal["id"]})
+    assert response.status_code == 201, response.text
+
+
+class TestCrud:
+    async def test_create_defaults_to_the_built_in_order(self, auth_client):
+        market = await create_market(auth_client)
+        assert market["name"] == "Big Tesco"
+        assert market["aisle_order"] == AISLE_EMOJIS
+        assert market["is_active"] is False
+
+    async def test_a_partial_order_is_completed_with_the_missing_aisles(self, auth_client):
+        market = await create_market(auth_client, aisle_order=BACKWARDS)
+        assert market["aisle_order"][: len(BACKWARDS)] == BACKWARDS
+        assert sorted(market["aisle_order"]) == sorted(AISLE_EMOJIS)  # nothing lost
+        # The aisles left unsaid keep their built-in relative order at the end.
+        tail = [emoji for emoji in AISLE_EMOJIS if emoji not in BACKWARDS]
+        assert market["aisle_order"][len(BACKWARDS) :] == tail
+
+    async def test_duplicate_names_are_rejected_with_the_existing_id(self, auth_client):
+        market = await create_market(auth_client)
+        response = await auth_client.post("/supermarkets", json={"name": "  big TESCO "})
+        assert response.status_code == 409
+        assert market["id"] in response.json()["detail"]
+
+    async def test_unknown_aisles_are_rejected_with_the_vocabulary(self, auth_client):
+        response = await auth_client.post("/supermarkets", json={"name": "Aldi", "aisle_order": ["🧀"]})
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert "🧀" in detail and "🥬" in detail  # names the culprit, teaches the vocabulary
+
+    async def test_repeated_aisles_are_rejected(self, auth_client):
+        response = await auth_client.post("/supermarkets", json={"name": "Aldi", "aisle_order": ["🧊", "🥬", "🧊"]})
+        assert response.status_code == 422
+        assert "more than once" in response.json()["detail"]
+
+    async def test_rename_and_reorder(self, auth_client):
+        market = await create_market(auth_client)
+        response = await auth_client.patch(
+            f"/supermarkets/{market['id']}", json={"name": "Little Tesco", "aisle_order": BACKWARDS}
+        )
+        assert response.status_code == 200
+        updated = response.json()
+        assert updated["name"] == "Little Tesco"
+        assert updated["aisle_order"][: len(BACKWARDS)] == BACKWARDS
+
+    async def test_rename_onto_another_market_is_a_409(self, auth_client):
+        await create_market(auth_client, name="Tesco")
+        aldi = await create_market(auth_client, name="Aldi")
+        response = await auth_client.patch(f"/supermarkets/{aldi['id']}", json={"name": "tesco"})
+        assert response.status_code == 409
+
+    async def test_delete(self, auth_client):
+        market = await create_market(auth_client)
+        assert (await auth_client.delete(f"/supermarkets/{market['id']}")).status_code == 204
+        listed = (await auth_client.get("/supermarkets")).json()
+        assert listed == []
+
+
+class TestActivation:
+    async def test_only_one_supermarket_is_active_at_a_time(self, auth_client):
+        tesco = await create_market(auth_client, name="Tesco", is_active=True)
+        aldi = await create_market(auth_client, name="Aldi")
+        assert (await auth_client.patch(f"/supermarkets/{aldi['id']}", json={"is_active": True})).status_code == 200
+        by_name = {m["name"]: m for m in (await auth_client.get("/supermarkets")).json()}
+        assert by_name["Aldi"]["is_active"] is True
+        assert by_name["Tesco"]["is_active"] is False
+        assert tesco["is_active"] is True  # it *was* active until Aldi took over
+
+    async def test_reactivating_the_active_market_keeps_it_active(self, auth_client):
+        tesco = await create_market(auth_client, name="Tesco", is_active=True)
+        assert (await auth_client.patch(f"/supermarkets/{tesco['id']}", json={"is_active": True})).status_code == 200
+        listed = (await auth_client.get("/supermarkets")).json()
+        assert listed[0]["is_active"] is True
+
+    async def test_aisles_endpoint_follows_the_active_market(self, auth_client):
+        market = await create_market(auth_client, aisle_order=BACKWARDS)
+
+        default = [a["emoji"] for a in (await auth_client.get("/aisles")).json()]
+        assert default == AISLE_EMOJIS  # nothing active yet
+
+        await auth_client.patch(f"/supermarkets/{market['id']}", json={"is_active": True})
+        active = [a["emoji"] for a in (await auth_client.get("/aisles")).json()]
+        assert active[: len(BACKWARDS)] == BACKWARDS
+        assert sorted(active) == sorted(AISLE_EMOJIS)  # still the whole vocabulary
+
+        await auth_client.patch(f"/supermarkets/{market['id']}", json={"is_active": False})
+        assert [a["emoji"] for a in (await auth_client.get("/aisles")).json()] == AISLE_EMOJIS
+
+    async def test_deleting_the_active_market_falls_back_to_the_built_in_order(self, auth_client):
+        market = await create_market(auth_client, aisle_order=BACKWARDS, is_active=True)
+        await auth_client.delete(f"/supermarkets/{market['id']}")
+        assert [a["emoji"] for a in (await auth_client.get("/aisles")).json()] == AISLE_EMOJIS
+        assert (await get_list(auth_client))["supermarket"] is None
+
+
+class TestShoppingListSort:
+    async def test_the_list_walks_the_active_markets_order(self, auth_client):
+        await plan_spag_bol(auth_client)
+
+        default_walk = [item["aisle"] for item in (await get_list(auth_client))["items"]]
+        assert default_walk == ["🥬", "🥩", "🥫"]  # onion, beef, tomatoes
+
+        market = await create_market(auth_client, aisle_order=BACKWARDS, is_active=True)
+        shopping_list = await get_list(auth_client)
+        assert [item["aisle"] for item in shopping_list["items"]] == ["🥫", "🥩", "🥬"]
+        assert shopping_list["supermarket"] == {"id": market["id"], "name": "Big Tesco"}
+
+    async def test_no_active_market_means_no_supermarket_field(self, auth_client):
+        await create_market(auth_client)  # saved but not active
+        shopping_list = await get_list(auth_client)
+        assert shopping_list["supermarket"] is None
+
+
+class TestHouseholdScoping:
+    async def test_another_households_markets_are_invisible_and_untouchable(self, client):
+        first = await register(client, email="marcus@example.com")
+        client.headers["Authorization"] = f"Bearer {first['token']}"
+        market = await create_market(client, is_active=True)
+
+        second = await register(client, email="stranger@example.com", name="Stranger")
+        client.headers["Authorization"] = f"Bearer {second['token']}"
+        assert (await client.get("/supermarkets")).json() == []
+        assert (await client.patch(f"/supermarkets/{market['id']}", json={"is_active": True})).status_code == 404
+        assert (await client.delete(f"/supermarkets/{market['id']}")).status_code == 404
+        # And the neighbour's active market never leaks into this household's sort.
+        assert (await get_list(client))["supermarket"] is None

--- a/mcp/meals_mcp/server.py
+++ b/mcp/meals_mcp/server.py
@@ -32,7 +32,7 @@ from starlette.responses import PlainTextResponse, Response
 # they drift, and the backend suite fails if the guidance changes without a bump).
 # Instructions ship fresh on every connection, so this is the one channel that can
 # tell an assistant its installed skill snapshot has gone stale.
-PLAYBOOK_VERSION = 11
+PLAYBOOK_VERSION = 12
 
 mcp = FastMCP(
     "meals",
@@ -586,6 +586,91 @@ async def finish_shop() -> str:
     except ApiError as exc:
         return str(exc)
     return f"Shop finished. List archived; fresh list started [id: {result['new_list_id']}]."
+
+
+# ---------------------------------------------------------------- supermarkets
+
+
+def _fmt_market(market: dict) -> str:
+    active = "  ← active (the list sorts for this store)" if market["is_active"] else ""
+    return f"{market['name']}: {' '.join(market['aisle_order'])}{active}"
+
+
+@mcp.tool()
+async def list_supermarkets() -> str:
+    """The household's saved supermarkets and their aisle walking orders.
+    The active one is the order the shopping list sorts in; none active means
+    the default store-walking order."""
+    try:
+        markets = await _call("GET", "/supermarkets")
+    except ApiError as exc:
+        return str(exc)
+    if not markets:
+        return (
+            "No supermarkets saved — the list uses the default store-walking order. "
+            "save_supermarket(name, aisle_order) records how the user walks a real store."
+        )
+    lines = [_fmt_market(market) for market in markets]
+    if not any(market["is_active"] for market in markets):
+        lines.append("(none active — the list is on the default store-walking order)")
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def switch_supermarket(name: str) -> str:
+    """Sort the shopping list for a different store — worth doing when the
+    user says where they're shopping ("I'm at Aldi"). Pass 'default' to go
+    back to the built-in order. Stores must be saved first (list_supermarkets
+    / save_supermarket)."""
+    wanted = name.lower().strip()
+    try:
+        markets = await _call("GET", "/supermarkets")
+        if wanted in ("default", "none", ""):
+            active = [market for market in markets if market["is_active"]]
+            if not active:
+                return "Already on the default store-walking order."
+            await _call("PATCH", f"/supermarkets/{active[0]['id']}", json={"is_active": False})
+            return "Back to the default store-walking order."
+        matches = [market for market in markets if market["name"].lower() == wanted]
+        if not matches:
+            names = ", ".join(market["name"] for market in markets)
+            if not names:
+                return f"No supermarkets saved yet — save_supermarket('{name}', [...]) creates one."
+            return f"No supermarket called '{name}'. Saved: {names}. Or save_supermarket to add it."
+        await _call("PATCH", f"/supermarkets/{matches[0]['id']}", json={"is_active": True})
+    except ApiError as exc:
+        return str(exc)
+    return f"Shopping list now sorts for {matches[0]['name']}."
+
+
+@mcp.tool()
+async def save_supermarket(name: str, aisle_order: list[str], make_active: bool = True) -> str:
+    """Save a supermarket's aisle walking order (creating it if new) — use
+    when the user describes how they walk a store ("in our Tesco the frozen
+    aisles come first"). aisle_order is aisle emojis first-to-last; aisles
+    left out keep their usual place at the end. Valid: 🥬 🍞 🥩 ❄️ 🥛 🥫 🍝
+    🌶️ 🥤 🍫 🧊 🧼 🧴 ❓. By default the list starts sorting for the store
+    straight away (make_active)."""
+    try:
+        markets = await _call("GET", "/supermarkets")
+        existing = [market for market in markets if market["name"].lower() == name.lower().strip()]
+        if existing:
+            patch: dict[str, Any] = {"aisle_order": aisle_order}
+            if make_active:
+                patch["is_active"] = True
+            saved = await _call("PATCH", f"/supermarkets/{existing[0]['id']}", json=patch)
+            verb = "updated"
+        else:
+            saved = await _call(
+                "POST",
+                "/supermarkets",
+                json={"name": name.strip(), "aisle_order": aisle_order, "is_active": make_active},
+            )
+            verb = "saved"
+    except ApiError as exc:
+        return str(exc)
+    active = " — the list now sorts for it" if saved["is_active"] else ""
+    return f"{saved['name']} {verb}: {' '.join(saved['aisle_order'])}{active}"
 
 
 async def _find_ingredient(name: str) -> dict:

--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -698,3 +698,90 @@ class TestDeleteIngredient:
         )
         result = await server.delete_ingredient("unobtainium")
         assert "No ingredient 'unobtainium'" in result
+
+
+class TestSupermarkets:
+    """Per-store aisle walking orders: list, switch, save."""
+
+    def _market(self, name, market_id="22222222-2222-2222-2222-222222222222", active=False, order=None):
+        return {
+            "id": market_id,
+            "name": name,
+            "aisle_order": order or ["🧊", "🥤", "🥬"],
+            "is_active": active,
+            "created_at": "2026-08-03T09:00:00",
+        }
+
+    @respx.mock
+    async def test_list_shows_orders_and_the_active_store(self):
+        respx.get(f"{API}/supermarkets").mock(
+            return_value=httpx.Response(200, json=[self._market("Big Tesco", active=True), self._market("Aldi")])
+        )
+        result = await server.list_supermarkets()
+        assert "Big Tesco: 🧊 🥤 🥬  ← active" in result
+        assert "Aldi" in result
+
+    @respx.mock
+    async def test_list_explains_the_default_when_nothing_saved(self):
+        respx.get(f"{API}/supermarkets").mock(return_value=httpx.Response(200, json=[]))
+        result = await server.list_supermarkets()
+        assert "default store-walking order" in result and "save_supermarket" in result
+
+    @respx.mock
+    async def test_switch_resolves_by_name(self):
+        respx.get(f"{API}/supermarkets").mock(return_value=httpx.Response(200, json=[self._market("Big Tesco")]))
+        patch = respx.patch(f"{API}/supermarkets/22222222-2222-2222-2222-222222222222").mock(
+            return_value=httpx.Response(200, json=self._market("Big Tesco", active=True))
+        )
+        result = await server.switch_supermarket("big tesco")
+        assert "sorts for Big Tesco" in result
+        assert json.loads(patch.calls.last.request.content) == {"is_active": True}
+
+    @respx.mock
+    async def test_switch_to_default_deactivates_the_active_store(self):
+        respx.get(f"{API}/supermarkets").mock(
+            return_value=httpx.Response(200, json=[self._market("Big Tesco", active=True)])
+        )
+        patch = respx.patch(f"{API}/supermarkets/22222222-2222-2222-2222-222222222222").mock(
+            return_value=httpx.Response(200, json=self._market("Big Tesco"))
+        )
+        result = await server.switch_supermarket("default")
+        assert "default store-walking order" in result
+        assert json.loads(patch.calls.last.request.content) == {"is_active": False}
+
+    @respx.mock
+    async def test_switch_miss_lists_the_saved_stores(self):
+        respx.get(f"{API}/supermarkets").mock(return_value=httpx.Response(200, json=[self._market("Big Tesco")]))
+        result = await server.switch_supermarket("Lidl")
+        assert "No supermarket called 'Lidl'" in result and "Big Tesco" in result
+
+    @respx.mock
+    async def test_save_creates_when_new_and_activates_by_default(self):
+        respx.get(f"{API}/supermarkets").mock(return_value=httpx.Response(200, json=[]))
+        post = respx.post(f"{API}/supermarkets").mock(
+            return_value=httpx.Response(201, json=self._market("Aldi", active=True, order=["🧊", "🥤", "🥬", "🍞"]))
+        )
+        result = await server.save_supermarket("Aldi", ["🧊", "🥤"])
+        assert "Aldi saved: 🧊 🥤 🥬 🍞" in result and "sorts for it" in result
+        sent = json.loads(post.calls.last.request.content)
+        assert sent == {"name": "Aldi", "aisle_order": ["🧊", "🥤"], "is_active": True}
+
+    @respx.mock
+    async def test_save_updates_the_existing_store_by_name(self):
+        respx.get(f"{API}/supermarkets").mock(return_value=httpx.Response(200, json=[self._market("Aldi")]))
+        patch = respx.patch(f"{API}/supermarkets/22222222-2222-2222-2222-222222222222").mock(
+            return_value=httpx.Response(200, json=self._market("Aldi", active=True))
+        )
+        result = await server.save_supermarket("aldi", ["🧊", "🥤", "🥬"])
+        assert "Aldi updated" in result
+        sent = json.loads(patch.calls.last.request.content)
+        assert sent == {"aisle_order": ["🧊", "🥤", "🥬"], "is_active": True}
+
+    @respx.mock
+    async def test_save_passes_the_apis_validation_detail_back(self):
+        respx.get(f"{API}/supermarkets").mock(return_value=httpx.Response(200, json=[]))
+        respx.post(f"{API}/supermarkets").mock(
+            return_value=httpx.Response(422, json={"detail": "unknown aisle(s) 🧀; valid aisles: 🥬 🍞"})
+        )
+        result = await server.save_supermarket("Aldi", ["🧀"])
+        assert "unknown aisle(s) 🧀" in result

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -3,7 +3,7 @@ name: meal-planner
 description: Plan meals and manage the shopping list through the Meals API/MCP. Use when the user shares recipe links, asks what to cook, wants to plan the week's meals, needs the shopping list, or says they're out of something. Covers recipe ingestion (including parsing pages the backend can't), building meal options, and shopping-mode check-offs.
 ---
 
-<!-- playbook-version: 11 -->
+<!-- playbook-version: 12 -->
 
 # Being a great meal-planning assistant
 
@@ -12,7 +12,7 @@ calendar), a recipe library, and an aisle-sorted shopping list that knows why
 every item is on it. Prefer the MCP tools when connected; otherwise use the
 REST API (OpenAPI at `/openapi.json`, auth via `Authorization: Bearer <PAT>`).
 
-**This is playbook v11, and this file is a snapshot** — once installed it never
+**This is playbook v12, and this file is a snapshot** — once installed it never
 updates itself. If a connected Meals MCP server names a higher playbook version
 in its instructions, or `GET {{API_URL}}/skill/version` reports one, this copy
 is stale: fetch `{{API_URL}}/skill`, follow the fresh copy for the rest of the
@@ -60,11 +60,20 @@ Extract and submit via `submit_recipe` / `POST /recipes`:
 
 ## Shopping list conventions
 
-- Aisle vocabulary (store-walking order): 🥬 fruit & veg · 🍞 bakery ·
+- Aisle vocabulary (default store-walking order): 🥬 fruit & veg · 🍞 bakery ·
   🥩 meat & fish · ❄️ chilled (dips, fresh pasta — the cabinet, not the
   freezer) · 🥛 dairy · 🥫 tins & jars · 🍝 dry goods & pasta ·
   🌶️ herbs & spices · 🥤 drinks · 🍫 snacks · 🧊 frozen · 🧼 toiletries ·
   🧴 household · ❓ unknown. Tag ❓ ingredients with `set_ingredient_aisle` when you can.
+- **The walking order is the household's own.** They can save one per store
+  (Settings → Supermarkets in the web app, or `save_supermarket(name,
+  aisle_order)` when they describe a store's layout) and the active one is
+  the order the list arrives sorted in. When they say where they're shopping
+  ("I'm at Aldi") and that store is saved, `switch_supermarket("Aldi")`
+  re-sorts the walk for it; `switch_supermarket("default")` goes back.
+  `list_supermarkets` shows what's saved. Aisles left out of a saved order
+  keep their usual place at the end — never invent an order the user didn't
+  describe.
 - Ad-hoc items ("we're out of milk") go straight on with `add_to_list` — never
   create a meal for them.
 - "Already have onions" → `mark_already_have("onion")`, don't delete the line.
@@ -154,8 +163,13 @@ something cooked that the user only mentioned in passing.
 - *"What can I cook tonight?"* → `get_plan()`, list un-cooked options with
   cook times. No tool for "tonight" exists — plans have no days; just present
   the options.
-- *"I'm at Tesco, what do I need?"* → `get_shopping_list()`, read it back
-  grouped by aisle, offer to check things off as they shop.
+- *"I'm at Tesco, what do I need?"* → if "Tesco" is a saved supermarket,
+  `switch_supermarket("Tesco")` first so the walk matches the store; then
+  `get_shopping_list()`, read it back grouped by aisle, offer to check
+  things off as they shop.
+- *"In our Tesco you hit frozen first, then drinks, then fruit & veg"* →
+  `save_supermarket("Tesco", ["🧊", "🥤", "🥬", …])` with the aisles in the
+  order they said — unmentioned aisles slot in at the end by themselves.
 - *"Scratch the burgers, we're out Friday"* → `remove_meal_from_plan("burgers")`
   — the list decrements itself; ad-hoc items survive.
 - *"Add garlic bread to the cottage pie"* → `update_meal("cottage pie",

--- a/skill/prompt-pack.md
+++ b/skill/prompt-pack.md
@@ -1,6 +1,6 @@
 # Meals prompt pack (portable)
 
-<!-- playbook-version: 11 -->
+<!-- playbook-version: 12 -->
 
 Paste this into any AI assistant's custom instructions to make it a good
 meal-planning assistant for your Meals server. (Claude-family tools can use
@@ -13,7 +13,7 @@ You help me plan meals and manage shopping through my Meals API at
 `Authorization: Bearer {{YOUR_API_TOKEN}}`. The full OpenAPI spec is at
 `{{API_URL}}/openapi.json` — fetch it if unsure about an endpoint.
 
-These instructions are playbook v11 and don't update themselves. If
+These instructions are playbook v12 and don't update themselves. If
 `{{API_URL}}/skill/version` reports a higher version, tell me — re-fetching
 `{{API_URL}}/prompt-pack` gets the current guidance.
 
@@ -34,7 +34,8 @@ Key endpoints:
 - `DELETE /meals/{id}` — removes it from any active plan and the list first · `DELETE /recipes/{id}` — 409 while a meal still uses the recipe, so detach it with `PATCH /meals/{id}` first
 - `GET /recipes?sort=most_cooked` (our regulars) or `?sort=least_recently_cooked` (never-cooked first) — every recipe and meal carries `times_cooked` and `last_cooked_at`, recorded by `POST /plans/{id}/meals/{plan_meal_id}/cooked` and kept even after the plan or meal is deleted. There is no un-cook: confirm before marking something cooked.
 - `GET /plans/current` · `POST /plans {label}` · `POST /plans/{id}/meals {meal_id}` · `DELETE /plans/{id}/meals/{plan_meal_id}`
-- `GET /shopping-list` (add `?include_staples=true` for a pre-shop staples check; mark any the household is low on with `{"staple_needed": true}` — just that staple joins the main list) — items come sorted in store-walking aisle order: 🥬 fruit & veg, 🍞 bakery, 🥩 meat & fish, ❄️ chilled (houmous, dips, fresh pasta…), 🥛 dairy, 🥫 tins & jars, 🍝 dry goods, 🌶️ herbs & spices, 🥤 drinks, 🍫 snacks, 🧊 frozen, 🧼 toiletries (shower gel, razor blades…), 🧴 household, ❓ unknown
+- `GET /shopping-list` (add `?include_staples=true` for a pre-shop staples check; mark any the household is low on with `{"staple_needed": true}` — just that staple joins the main list) — items come sorted in store-walking aisle order, by default: 🥬 fruit & veg, 🍞 bakery, 🥩 meat & fish, ❄️ chilled (houmous, dips, fresh pasta…), 🥛 dairy, 🥫 tins & jars, 🍝 dry goods, 🌶️ herbs & spices, 🥤 drinks, 🍫 snacks, 🧊 frozen, 🧼 toiletries (shower gel, razor blades…), 🧴 household, ❓ unknown
+- Per-store walking orders: `GET /supermarkets` lists the household's saved stores; the `is_active` one is the order the list (and `GET /aisles`) comes sorted in. "I'm at Aldi" and Aldi is saved → `PATCH /supermarkets/{id} {"is_active": true}`; `{"is_active": false}` returns to the default order. Save a store they describe with `POST /supermarkets {"name", "aisle_order": ["🧊", "🥤", …], "is_active": true}` — aisle emojis first-to-last as they walk it; aisles left out keep their usual place at the end. Never invent an order they didn't describe.
 - `POST /shopping-list/items {name, quantity, unit, id}` — ad-hoc adds ("out of milk"); send a fresh UUID as `id` so retries are safe
 - `PATCH /shopping-list/items/{id}` with `{"checked": true}` (shopping), `{"excluded": true}` ("already have it" — never delete provenance), or `{"staple_needed": true}` (staples check: "I'm low" — surfaces that staple; `false` hides it again)
 - `POST /shopping-list/archive` after the shop · `PATCH /ingredients/{id}` to fix ❓ aisles, flag staples, or record premium-vs-budget advice

--- a/web/app.css
+++ b/web/app.css
@@ -804,6 +804,24 @@ dialog .sub { color: var(--ink-mute); font-size: .9rem; margin: .2rem 0 .9rem; }
 .copy-row { display: flex; gap: .5rem; align-items: center; margin-top: .8rem; }
 .copy-row .code-reveal { flex: 1; }
 
+/* ── supermarkets: settings rows + the shopping-page switcher ───────── */
+
+.market-row { display: flex; align-items: center; gap: .6rem; padding: .55rem .1rem; border-bottom: 1px dashed var(--line); }
+.market-row:last-child { border-bottom: 0; }
+.market-row .m-pick { display: flex; align-items: center; gap: .7rem; flex: 1; min-width: 0; cursor: pointer; }
+.market-row .m-main { display: flex; flex-direction: column; gap: .1rem; min-width: 0; }
+.market-row .aisle-mini { letter-spacing: .22em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.market-row .m-actions { display: flex; gap: .35rem; flex-shrink: 0; flex-wrap: wrap; justify-content: flex-end; }
+
+.order-rows { margin: .6rem 0 .2rem; max-height: 55vh; overflow-y: auto; }
+.order-row { display: flex; align-items: center; gap: .7rem; padding: .35rem .15rem; border-bottom: 1px dashed var(--line); }
+.order-row:last-child { border-bottom: 0; }
+.order-row .o-label { flex: 1; }
+.order-row .icon-btn[disabled] { opacity: .3; cursor: default; }
+.order-row .icon-btn[disabled]:hover { border-color: var(--line); color: var(--ink-soft); }
+
+.market-pick { width: auto; font: inherit; font-size: inherit; color: inherit; background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding: .05rem .35rem; }
+
 /* ── responsive ─────────────────────────────────────────────────────── */
 
 @media (max-width: 900px) {

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -99,3 +99,10 @@ export async function aisles() {
   aisleCache ||= await api("/aisles");
   return aisleCache;
 }
+
+// The order /aisles returns follows the active supermarket, so anything that
+// changes supermarkets (settings, the shopping-page switcher) must drop the
+// cache or the ingredients screen keeps grouping by the old walk.
+export function invalidateAisles() {
+  aisleCache = null;
+}

--- a/web/js/views/settings.js
+++ b/web/js/views/settings.js
@@ -1,16 +1,17 @@
-// Settings: account, household invites (Q19), AI access tokens, and the
-// danger zone (Q20). Invite codes and API tokens are shown exactly once —
-// the server stores only hashes.
+// Settings: account, household invites (Q19), supermarkets & aisle order,
+// AI access tokens, and the danger zone (Q20). Invite codes and API tokens
+// are shown exactly once — the server stores only hashes.
 
-import { api, session } from "../api.js";
+import { aisles, api, invalidateAisles, session } from "../api.js";
 import { confirmDialog, fmtDate, fmtRel, html, openDialog, parseUtc, render, skeleton, toast } from "../dom.js";
 
 export async function renderSettings(root) {
   render(root, skeleton());
-  const [user, invites, tokens] = await Promise.all([
+  const [user, invites, tokens, markets] = await Promise.all([
     api("/auth/me"),
     api("/auth/invites"),
     api("/auth/tokens"),
+    api("/supermarkets"),
   ]);
   session.saveUser(user);
 
@@ -48,6 +49,46 @@ export async function renderSettings(root) {
             `
           : html`<p class="sub">No invites issued yet.</p>`}
         <div class="dialog-actions"><button class="btn" data-invite>Invite someone</button></div>
+      </div>
+
+      <div class="section card">
+        <h2>Supermarkets &amp; aisle order</h2>
+        <p class="sub">
+          The shopping list walks the aisles in this order. Save the stores you
+          actually shop at, arrange each one's aisles the way you meet them,
+          and pick where you're shopping — every device (and your AI) sorts
+          for it.
+        </p>
+        <div class="market-list">
+          <div class="market-row">
+            <label class="m-pick">
+              <input type="radio" name="active-market" value="" ${markets.some((m) => m.is_active) ? "" : "checked"}>
+              <div class="m-main">
+                <b>Default order</b>
+                <span class="sub">the built-in walk, fruit &amp; veg first</span>
+              </div>
+            </label>
+          </div>
+          ${markets.map(
+            (m) => html`
+              <div class="market-row">
+                <label class="m-pick">
+                  <input type="radio" name="active-market" value="${m.id}" ${m.is_active ? "checked" : ""}>
+                  <div class="m-main">
+                    <b>${m.name}</b>
+                    <span class="sub aisle-mini">${m.aisle_order.join(" ")}</span>
+                  </div>
+                </label>
+                <span class="m-actions">
+                  <button class="icon-btn" type="button" data-order-market="${m.id}">aisle order</button>
+                  <button class="icon-btn" type="button" data-rename-market="${m.id}">rename</button>
+                  <button class="icon-btn warm" type="button" data-del-market="${m.id}">delete</button>
+                </span>
+              </div>
+            `,
+          )}
+        </div>
+        <div class="dialog-actions"><button class="btn" data-add-market>Add a supermarket</button></div>
       </div>
 
       <div class="section card">
@@ -124,6 +165,54 @@ export async function renderSettings(root) {
     };
   }
 
+  const activeMarketId = markets.find((m) => m.is_active)?.id || "";
+  for (const radio of root.querySelectorAll('input[name="active-market"]')) {
+    radio.onchange = async () => {
+      try {
+        if (radio.value) {
+          await api(`/supermarkets/${radio.value}`, { method: "PATCH", body: { is_active: true } });
+          toast(`Shopping list now sorts for ${markets.find((m) => m.id === radio.value)?.name}.`, "ok");
+        } else if (activeMarketId) {
+          await api(`/supermarkets/${activeMarketId}`, { method: "PATCH", body: { is_active: false } });
+          toast("Back to the default aisle order.", "ok");
+        }
+        invalidateAisles();
+      } catch (error) {
+        toast(error.detail || error.message, "error");
+      }
+      renderSettings(root);
+    };
+  }
+
+  root.querySelector("[data-add-market]").onclick = () => addMarketDialog(root);
+
+  for (const button of root.querySelectorAll("[data-order-market]")) {
+    button.onclick = () => orderDialog(root, markets.find((m) => m.id === button.dataset.orderMarket));
+  }
+
+  for (const button of root.querySelectorAll("[data-rename-market]")) {
+    button.onclick = () => renameMarketDialog(root, markets.find((m) => m.id === button.dataset.renameMarket));
+  }
+
+  for (const button of root.querySelectorAll("[data-del-market]")) {
+    button.onclick = async () => {
+      const market = markets.find((m) => m.id === button.dataset.delMarket);
+      const ok = await confirmDialog({
+        title: `Delete ${market.name}?`,
+        body: market.is_active
+          ? "Its saved aisle order goes with it and the list goes back to the default order."
+          : "Its saved aisle order goes with it.",
+        confirmLabel: "Delete",
+        danger: true,
+      });
+      if (!ok) return;
+      await api(`/supermarkets/${market.id}`, { method: "DELETE" });
+      invalidateAisles();
+      toast(`${market.name} deleted.`, "ok");
+      renderSettings(root);
+    };
+  }
+
   root.querySelector("[data-token]").onclick = () => tokenDialog(root);
 
   for (const button of root.querySelectorAll("[data-revoke-token]")) {
@@ -155,6 +244,126 @@ export async function renderSettings(root) {
   };
 
   root.querySelector("[data-delete-account]").onclick = () => deleteAccountDialog();
+}
+
+function addMarketDialog(root) {
+  const dialog = openDialog(html`
+    <h2>Add a supermarket</h2>
+    <p class="sub">It starts on the default aisle order — you'll arrange its own walk next.</p>
+    <form data-f>
+      <label class="field"><span>Name</span>
+        <input type="text" name="name" required maxlength="120" placeholder="Big Tesco" autofocus></label>
+      <div class="dialog-actions">
+        <button class="btn ghost" type="button" data-x>Cancel</button>
+        <button class="btn" type="submit">Add</button>
+      </div>
+    </form>
+  `);
+  dialog.querySelector("[data-x]").onclick = () => dialog.close();
+  dialog.querySelector("[data-f]").onsubmit = async (event) => {
+    event.preventDefault();
+    const name = new FormData(event.target).get("name").trim();
+    if (!name) return;
+    try {
+      const market = await api("/supermarkets", { method: "POST", body: { name } });
+      dialog.close();
+      orderDialog(root, market); // straight into arranging the walk
+    } catch (error) {
+      toast(error.detail || error.message, "error"); // e.g. the duplicate-name 409
+    }
+  };
+}
+
+async function orderDialog(root, market) {
+  const labels = new Map((await aisles()).map((a) => [a.emoji, a.label]));
+  const order = [...market.aisle_order];
+  const dialog = openDialog(html`
+    <h2>${market.name} — aisle order</h2>
+    <p class="sub">First aisle you meet at the top; the shopping list walks it top to bottom.</p>
+    <div class="order-rows" data-rows></div>
+    <div class="dialog-actions">
+      <button class="btn ghost" type="button" data-x>Cancel</button>
+      <button class="btn" type="button" data-save>Save order</button>
+    </div>
+  `);
+  const rows = dialog.querySelector("[data-rows]");
+
+  const move = (from, to, dir) => {
+    [order[from], order[to]] = [order[to], order[from]];
+    draw();
+    // Keep focus on the moved aisle's button so keyboard reordering flows.
+    const same = rows.querySelector(`[data-${dir}="${to}"]`);
+    const other = rows.querySelector(`[data-${dir === "up" ? "down" : "up"}="${to}"]`);
+    (same && !same.disabled ? same : other)?.focus();
+  };
+
+  const draw = () => {
+    render(
+      rows,
+      html`${order.map(
+        (emoji, i) => html`
+          <div class="order-row">
+            <span class="o-emoji" aria-hidden="true">${emoji}</span>
+            <span class="o-label">${labels.get(emoji) || "Unknown"}</span>
+            <span class="o-btns">
+              <button class="icon-btn" type="button" data-up="${i}" ${i === 0 ? "disabled" : ""}
+                aria-label="Move ${labels.get(emoji) || emoji} up">↑</button>
+              <button class="icon-btn" type="button" data-down="${i}" ${i === order.length - 1 ? "disabled" : ""}
+                aria-label="Move ${labels.get(emoji) || emoji} down">↓</button>
+            </span>
+          </div>
+        `,
+      )}`,
+    );
+    for (const button of rows.querySelectorAll("[data-up]")) {
+      button.onclick = () => move(Number(button.dataset.up), Number(button.dataset.up) - 1, "up");
+    }
+    for (const button of rows.querySelectorAll("[data-down]")) {
+      button.onclick = () => move(Number(button.dataset.down), Number(button.dataset.down) + 1, "down");
+    }
+  };
+  draw();
+
+  dialog.querySelector("[data-x]").onclick = () => dialog.close();
+  dialog.querySelector("[data-save]").onclick = async () => {
+    try {
+      await api(`/supermarkets/${market.id}`, { method: "PATCH", body: { aisle_order: order } });
+      invalidateAisles();
+      dialog.close();
+      toast(`${market.name}'s aisle order saved.`, "ok");
+      renderSettings(root);
+    } catch (error) {
+      toast(error.detail || error.message, "error");
+    }
+  };
+}
+
+function renameMarketDialog(root, market) {
+  const dialog = openDialog(html`
+    <h2>Rename ${market.name}</h2>
+    <form data-f>
+      <label class="field"><span>Name</span>
+        <input type="text" name="name" required maxlength="120" value="${market.name}" autofocus></label>
+      <div class="dialog-actions">
+        <button class="btn ghost" type="button" data-x>Cancel</button>
+        <button class="btn" type="submit">Rename</button>
+      </div>
+    </form>
+  `);
+  dialog.querySelector("[data-x]").onclick = () => dialog.close();
+  dialog.querySelector("[data-f]").onsubmit = async (event) => {
+    event.preventDefault();
+    const name = new FormData(event.target).get("name").trim();
+    if (!name) return;
+    try {
+      await api(`/supermarkets/${market.id}`, { method: "PATCH", body: { name } });
+      dialog.close();
+      toast("Renamed.", "ok");
+      renderSettings(root);
+    } catch (error) {
+      toast(error.detail || error.message, "error");
+    }
+  };
 }
 
 function inviteStatus(invite) {

--- a/web/js/views/shopping.js
+++ b/web/js/views/shopping.js
@@ -2,7 +2,7 @@
 // (its sources), quantities are the server's derived truth, and checking off
 // is optimistic — the strike-through should never wait for a round trip.
 
-import { api } from "../api.js";
+import { api, invalidateAisles } from "../api.js";
 import { confirmDialog, emptyState, fmtDate, html, render, skeleton, toast } from "../dom.js";
 
 let staplesMode = false;
@@ -10,9 +10,12 @@ let showExcluded = false;
 
 export async function renderShopping(root) {
   render(root, skeleton());
-  const list = await api("/shopping-list", {
-    query: { include_staples: staplesMode || undefined, include_excluded: showExcluded || undefined },
-  });
+  const [list, markets] = await Promise.all([
+    api("/shopping-list", {
+      query: { include_staples: staplesMode || undefined, include_excluded: showExcluded || undefined },
+    }),
+    api("/supermarkets"),
+  ]);
 
   // The staples check is its own screen: just the staples, nothing else,
   // matching the flow the skill teaches (include_staples → mark what's low).
@@ -33,6 +36,13 @@ export async function renderShopping(root) {
           <p class="sub">
             <span data-count>${toGet === 0 ? "nothing to get" : `${ticked} of ${toGet} in the trolley`}</span>
             ${list.hidden_staples > 0 ? ` · ${list.hidden_staples} ${list.hidden_staples === 1 ? "staple" : "staples"} waiting for a check` : ""}
+            ${markets.length > 0
+              ? html` · aisles for
+                  <select class="market-pick" data-market aria-label="Sort the aisles for">
+                    <option value="">default order</option>
+                    ${markets.map((m) => html`<option value="${m.id}" ${m.is_active ? "selected" : ""}>${m.name}</option>`)}
+                  </select>`
+              : ""}
           </p>
         </div>
         <div class="page-actions">
@@ -66,7 +76,7 @@ export async function renderShopping(root) {
     </div>
   `);
 
-  bind(root, list);
+  bind(root, list, markets);
 }
 
 function groupByAisle(items) {
@@ -132,11 +142,30 @@ function whyLine(item) {
   return parts.join(" ");
 }
 
-function bind(root, list) {
+function bind(root, list, markets) {
   root.querySelector("[data-staples]").onclick = () => {
     staplesMode = !staplesMode;
     renderShopping(root);
   };
+
+  // "I'm in a different store today" — re-sort the walk without a settings trip.
+  const picker = root.querySelector("[data-market]");
+  if (picker) {
+    picker.onchange = async () => {
+      const activeId = markets.find((m) => m.is_active)?.id;
+      try {
+        if (picker.value) {
+          await api(`/supermarkets/${picker.value}`, { method: "PATCH", body: { is_active: true } });
+        } else if (activeId) {
+          await api(`/supermarkets/${activeId}`, { method: "PATCH", body: { is_active: false } });
+        }
+        invalidateAisles();
+        renderShopping(root);
+      } catch (error) {
+        toast(error.detail || error.message, "error");
+      }
+    };
+  }
   root.querySelector("[data-show-excluded]").onclick = () => {
     showExcluded = !showExcluded;
     renderShopping(root);


### PR DESCRIPTION
## What

Lets a household define the aisle walking order of each supermarket it shops at, under **Settings → Supermarkets & aisle order**, and pick which store the list is sorted for.

The active supermarket's order drives the shopping-list sort **and** `GET /aisles`. iOS already refetches `/aisles` on every list load and sorts locally by it, so it adopts custom orders with no app change and no client gate.

## How

- New `supermarkets` table (migration `e7a94d21c8b3`, additive): name + `aisle_order` (emoji sequence) + `is_active`, unique per household, wiped with the household in the Q20 deletion path.
- New `/supermarkets` CRUD; `PATCH {"is_active": true/false}` switches store (single-active rule). 4xx details teach the vocabulary.
- Partial orders are legal and future-proof: aisles not mentioned keep their built-in relative order at the end, so adding an aisle to the vocabulary never invalidates a saved store.
- `GET /shopping-list` gains an optional `supermarket` field (additive; tolerant decoders unaffected).
- Web: settings card with ↑/↓ reorder dialog + radio for the active store; "aisles for [store ▾]" switcher on the shopping page for mid-shop store changes.
- MCP: `list_supermarkets`, `switch_supermarket`, `save_supermarket`; skill/prompt-pack updated → playbook v12 (stamp, prose, PLAYBOOK_VERSION, pinned digest all bumped together).

## Testing

- 525 backend + 55 MCP tests pass (16 new: CRUD, single-active, /aisles + list-sort follow the active store, partial-order completion, household scoping, deletion wipe).
- Fresh-SQLite `alembic upgrade head` verified; migration is expand-only so the rollout overlap window is safe.
- Verified live in the browser: created "Big Tesco", moved Frozen/Drinks to the front, list re-sorted 🧊 🥤 🥬 🥩 🥫; switched back to default from the shopping page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)