### PR TITLE
Stop a successful sign-in from spending the brute-force budget (stacked on #44)

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -41,7 +41,32 @@ def enforce_sqlite_foreign_keys(async_engine: AsyncEngine) -> None:
 settings = get_settings()
 _prepare_sqlite_path(settings.database_url)
 
-engine = create_async_engine(settings.database_url, echo=False)
+
+def _pool_options(url: str) -> dict:
+    """Keep pooled Postgres connections from outliving the network under them.
+
+    On the swarm the API and Postgres talk over an overlay network that quietly
+    drops idle flows, so a connection sitting in the pool can be dead long
+    before anything asks. Nothing notices until a request checks it out and
+    gets `ConnectionDoesNotExistError: connection was closed in the middle of
+    operation`, which surfaces as a 500. Traffic here is low enough that the
+    unlucky request is reliably the *first real one of the day* — and on
+    2026-08-06 that was App Review's only login attempt, which is how build
+    ASC-18 was rejected under guideline 2.1(a) (see ../../ios/CHANGELOG.md).
+    `/healthz` touches no database, so the container stayed green throughout.
+
+    `pool_pre_ping` spends a round trip per checkout to prove the connection is
+    alive and transparently replaces it when it isn't; `pool_recycle` retires
+    connections before the network's idle timeout can. Neither is applied to
+    SQLite: recycling an in-memory database would throw the schema away with
+    it, and the tests' engine is built separately anyway.
+    """
+    if url.startswith("sqlite"):
+        return {}
+    return {"pool_pre_ping": True, "pool_recycle": 300}
+
+
+engine = create_async_engine(settings.database_url, echo=False, **_pool_options(settings.database_url))
 if settings.database_url.startswith("sqlite"):
     enforce_sqlite_foreign_keys(engine)
 SessionLocal = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -73,11 +73,20 @@ DbSession = Annotated[AsyncSession, Depends(get_db)]
 _attempts: dict[str, deque[float]] = defaultdict(deque)
 
 
+def _rate_limit_key(request: Request) -> str:
+    """Who to charge. `request.client.host` is the real caller only when uvicorn
+    has been told which proxies to trust (`FORWARDED_ALLOW_IPS`). Behind an
+    untrusted proxy it is the *proxy's* address, so every caller in the world
+    collapses into a single bucket and the limit becomes global rather than
+    per-client."""
+    return request.client.host if request.client else "unknown"
+
+
 def auth_rate_limit(request: Request) -> None:
     limit = get_settings().auth_rate_limit_per_minute
     if limit <= 0:
         return
-    key = request.client.host if request.client else "unknown"
+    key = _rate_limit_key(request)
     now = time.monotonic()
     window = _attempts[key]
     while window and now - window[0] > 60:
@@ -88,3 +97,26 @@ def auth_rate_limit(request: Request) -> None:
             detail="too many auth attempts; wait a minute and try again",
         )
     window.append(now)
+
+
+def forgive_auth_attempt(request: Request) -> None:
+    """Refund the attempt `auth_rate_limit` charged, once the caller has proved
+    they hold the credential.
+
+    The limiter is brute-force protection, and brute force is a stream of
+    *failures*. Charging successes too meant ten genuine sign-ins in a minute
+    locked the user out of their own account — which is exactly what someone
+    does when a transient error makes them retry, App Store reviewers included.
+
+    Deliberately a refund rather than "only count failures": the charge is taken
+    up front, so an endpoint that never refunds is merely stricter than it needs
+    to be. Forgetting a refund can't leave a path unthrottled. Only endpoints
+    that verified a password or a reset code should call it — `register` and the
+    reset *request* are abusable whether or not they succeed, so they keep
+    paying.
+    """
+    if get_settings().auth_rate_limit_per_minute <= 0:
+        return  # nothing was charged, so there is nothing to refund
+    window = _attempts.get(_rate_limit_key(request))
+    if window:
+        window.pop()

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -2,11 +2,11 @@ import contextlib
 import uuid
 from datetime import UTC, datetime, timedelta
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy import delete, select
 
 from app.config import get_settings
-from app.deps import CurrentUser, DbSession, as_aware, auth_rate_limit
+from app.deps import CurrentUser, DbSession, as_aware, auth_rate_limit, forgive_auth_attempt
 from app.models import AuthToken, Household, HouseholdInvite, User
 from app.schemas.auth import (
     AcceptedOut,
@@ -122,11 +122,14 @@ async def register(payload: RegisterIn, db: DbSession, _: None = Depends(auth_ra
 
 
 @router.post("/login", response_model=AuthOut)
-async def login(payload: LoginIn, db: DbSession, _: None = Depends(auth_rate_limit)) -> AuthOut:
+async def login(payload: LoginIn, request: Request, db: DbSession, _: None = Depends(auth_rate_limit)) -> AuthOut:
     result = await db.execute(select(User).where(User.email == payload.email.lower()))
     user = result.scalar_one_or_none()
     if user is None or not verify_password(payload.password, user.password_hash):
         raise HTTPException(status_code=401, detail="incorrect email or password")
+    # Right password: this wasn't an attack, so don't spend the caller's budget
+    # on it. Someone retrying a flaky sign-in must not lock themselves out.
+    forgive_auth_attempt(request)
     token = _session_token(user)
     db.add(token)
     await db.commit()
@@ -135,7 +138,7 @@ async def login(payload: LoginIn, db: DbSession, _: None = Depends(auth_rate_lim
 
 @router.post("/password", response_model=AuthOut)
 async def change_password(
-    payload: PasswordChangeIn, user: CurrentUser, db: DbSession, _: None = Depends(auth_rate_limit)
+    payload: PasswordChangeIn, request: Request, user: CurrentUser, db: DbSession, _: None = Depends(auth_rate_limit)
 ) -> AuthOut:
     """Change the signed-in user's password. Knowing the current password is
     required, so this is also the brute-force surface — hence the rate limit.
@@ -150,6 +153,7 @@ async def change_password(
         raise HTTPException(status_code=401, detail="current password is incorrect")
     if payload.current_password == payload.new_password:
         raise HTTPException(status_code=400, detail="new password must be different from the current one")
+    forgive_auth_attempt(request)  # current password checked out; not a brute-force attempt
     user.password_hash = hash_password(payload.new_password)
     await db.execute(delete(AuthToken).where(AuthToken.user_id == user.id, AuthToken.kind == "session"))
     token = _session_token(user)
@@ -226,7 +230,7 @@ async def request_password_reset(
 
 @router.post("/password/reset-confirm", response_model=AuthOut)
 async def confirm_password_reset(
-    payload: PasswordResetConfirmIn, db: DbSession, _: None = Depends(auth_rate_limit)
+    payload: PasswordResetConfirmIn, request: Request, db: DbSession, _: None = Depends(auth_rate_limit)
 ) -> AuthOut:
     """Redeem a reset code from `POST /auth/password-reset` and set a new
     password. Returns a fresh session token, so the app is logged straight in.
@@ -247,6 +251,7 @@ async def confirm_password_reset(
                 "Request a fresh one from POST /auth/password-reset."
             ),
         )
+    forgive_auth_attempt(request)  # valid reset code; not a brute-force attempt
     user = reset.user
     user.password_hash = hash_password(payload.new_password)
     # Drop the reset code (single use) and every session token, then issue one.
@@ -264,7 +269,7 @@ async def me(user: CurrentUser) -> UserOut:
 
 @router.delete("/me", response_model=AccountDeletedOut)
 async def delete_account(
-    payload: AccountDeleteIn, user: CurrentUser, db: DbSession, _: None = Depends(auth_rate_limit)
+    payload: AccountDeleteIn, request: Request, user: CurrentUser, db: DbSession, _: None = Depends(auth_rate_limit)
 ) -> AccountDeletedOut:
     """Delete your account permanently (decision Q20). **This cannot be undone**
     and there is no grace period — confirm with the person before calling it.
@@ -284,6 +289,7 @@ async def delete_account(
     """
     if not verify_password(payload.password, user.password_hash):
         raise HTTPException(status_code=401, detail="that password is incorrect, so nothing was deleted")
+    forgive_auth_attempt(request)  # password checked out; not a brute-force attempt
     household_deleted = await delete_user(db, user)
     await db.commit()
     return AccountDeletedOut(

--- a/backend/tests/integration/test_auth.py
+++ b/backend/tests/integration/test_auth.py
@@ -57,6 +57,42 @@ class TestRegisterAndLogin:
         assert response.status_code == 429
         _attempts.clear()
 
+    async def test_successful_logins_do_not_consume_the_budget(self, client, settings_override):
+        """Signing in correctly must never lock you out of your own account.
+
+        The limiter is brute-force protection and brute force is a stream of
+        failures, so a success refunds its attempt. This is not hypothetical:
+        a stale-connection 500 on /auth/login sent one caller through ten
+        retries in a minute, nine of which succeeded, and the tenth got a 429
+        because successes were being charged.
+        """
+        await register(client, email="repeat@example.com")
+        settings_override(AUTH_RATE_LIMIT_PER_MINUTE="3")
+        from app.deps import _attempts
+
+        _attempts.clear()
+        payload = {"email": "repeat@example.com", "password": "a-strong-password"}
+        for _ in range(10):  # comfortably past the limit of 3
+            response = await client.post("/auth/login", json=payload)
+            assert response.status_code == 200, response.text
+        _attempts.clear()
+
+    async def test_failures_still_count_when_mixed_with_successes(self, client, settings_override):
+        """The refund must not hand an attacker a reset: a wrong password stays
+        charged even if correct ones are interleaved with it."""
+        await register(client, email="mixed@example.com")
+        settings_override(AUTH_RATE_LIMIT_PER_MINUTE="3")
+        from app.deps import _attempts
+
+        _attempts.clear()
+        for _ in range(3):
+            await client.post("/auth/login", json={"email": "mixed@example.com", "password": "wrong-password"})
+            # A success in between must not wipe the failures already banked.
+            await client.post("/auth/login", json={"email": "mixed@example.com", "password": "a-strong-password"})
+        response = await client.post("/auth/login", json={"email": "mixed@example.com", "password": "wrong-password"})
+        assert response.status_code == 429
+        _attempts.clear()
+
 
 class TestChangePassword:
     async def test_change_password_switches_credentials(self, client):

--- a/ios/AppStore/README.md
+++ b/ios/AppStore/README.md
@@ -27,9 +27,9 @@ Current state, verified against the App Store Connect API on 2026-08-06:
   content rights, manual release.
 - **Submitted 2026-07-27 19:35 UTC, rejected 2026-08-06 08:19 UTC** under
   guideline 2.1(a) — a server fault, not an app one, diagnosed and fixed in
-  full at [ios/CHANGELOG.md](../CHANGELOG.md#the-21a-rejection). Editing the
-  rejected version is what moved it out of `REJECTED`; **it is not submitted**.
-  The reply is drafted in [resolution-center.md](resolution-center.md).
+  full at [ios/CHANGELOG.md](../CHANGELOG.md#the-21a-rejection). Replied to in
+  Resolution Center (kept in [resolution-center.md](resolution-center.md)) and
+  **resubmitted 2026-08-06 21:27 UTC**, now `WAITING_FOR_REVIEW`.
 - **Build 23** is attached now (uploaded 2026-08-05, `VALID`), replacing the
   one App Store Connect calls **18**. Builds 1–15 are on TestFlight at
   marketing version **0.1**, so none of them can attach to the 1.0 record at
@@ -112,7 +112,17 @@ number**. Apple requires it in international format and rejects the request
 without one. The rest of that section (contact name and email, the demo
 account, the notes) goes in with it.
 
-### 6. Submit, then wait — submitted 2026-07-27, **rejected 2026-08-06**
+### 6. Submit, then wait — rejected 2026-08-06, **resubmitted the same day**
+
+Submitting is three API calls: `POST /v1/reviewSubmissions`, then
+`POST /v1/reviewSubmissionItems` naming the submission and the version, then
+`PATCH` the submission with `{"submitted": true}`. **After a rejection there is
+a fourth**, and it comes first: the rejected submission still owns the version,
+so cancel it with `PATCH /v1/reviewSubmissions/<old>` `{"canceled": true}` and
+*wait for it to leave `CANCELING`*. Until it reaches `COMPLETE` the version is
+locked and every attempt to add it returns 409
+`ITEM_PART_OF_ANOTHER_SUBMISSION`. Removing the item directly is refused too.
+
 
 Typically 24–48 hours; this one took ten days. If it's rejected, the reply
 arrives in Resolution Center; answer it there rather than resubmitting blind —

--- a/ios/AppStore/README.md
+++ b/ios/AppStore/README.md
@@ -15,23 +15,31 @@ sections refuse an API key with these permissions — **App Privacy** and
 | [metadata.md](metadata.md) | The listing: name, subtitle, description, keywords, URLs, categories, and every field on the form |
 | [review-notes.md](review-notes.md) | What App Review is told, the demo account, and how to provision it |
 | [app-privacy.md](app-privacy.md) | The App Privacy questionnaire, answer by answer, with the reasoning |
+| [resolution-center.md](resolution-center.md) | Replies to App Review, and what evidence backs each claim in them |
 
-Current state, verified against the App Store Connect API on 2026-07-27:
+Current state, verified against the App Store Connect API on 2026-08-06:
 
 - App record `com.marcuslab.meals` (id **6794266229**), renamed to
   **"Yet Another Meal Planner"**.
-- Version **1.0** in `PREPARE_FOR_SUBMISSION`, fully populated: subtitle,
+- Version **1.0** back in `PREPARE_FOR_SUBMISSION`, fully populated: subtitle,
   Food & Drink / Productivity, 4+, description, keywords, promotional text,
   privacy + support + marketing URLs, five 6.9" screenshots, copyright,
   content rights, manual release.
-- **Submitted 2026-07-27 19:35 UTC** — `WAITING_FOR_REVIEW`, with the
-  iPhone-only build attached.
-- Builds 1–15 are on TestFlight at marketing version **0.1**, so **none of them
-  can attach to the 1.0 record**. The attached build is the one App Store
-  Connect calls **18** (uploaded 2026-07-27, `VALID`) — the first that is
-  really iPhone-only. Its `CFBundleVersion` is 17; the numbering diverged, see
-  [ios/CHANGELOG.md](../CHANGELOG.md). Builds 16 and 17 claim iPad support and
-  would oblige you to supply 13" iPad screenshots.
+- **Submitted 2026-07-27 19:35 UTC, rejected 2026-08-06 08:19 UTC** under
+  guideline 2.1(a) — a server fault, not an app one, diagnosed and fixed in
+  full at [ios/CHANGELOG.md](../CHANGELOG.md#the-21a-rejection). Editing the
+  rejected version is what moved it out of `REJECTED`; **it is not submitted**.
+  The reply is drafted in [resolution-center.md](resolution-center.md).
+- **Build 23** is attached now (uploaded 2026-08-05, `VALID`), replacing the
+  one App Store Connect calls **18**. Builds 1–15 are on TestFlight at
+  marketing version **0.1**, so none of them can attach to the 1.0 record at
+  all, and builds 16 and 17 claim iPad support and would oblige you to supply
+  13" iPad screenshots.
+- **The App Review notes are filled in**, from
+  [review-notes.md](review-notes.md). They were `null` for the whole first
+  review, so nothing explaining self-hosting or pointing at account deletion
+  reached the reviewer. Writing them in this repo is not submitting them —
+  check the field, not the file.
 
 ## Order of operations
 
@@ -61,11 +69,11 @@ in the form in step 5.
 make ios-testflight
 ```
 
-The iPhone-only build was uploaded on 2026-07-27, is `VALID`, and is attached.
-`current_ios_build` in `backend/app/config.py` is `17` — it is compared against
-the `CFBundleVersion` *inside* the installed app, so it tracks that number and
-not the one App Store Connect displays. It only goes live on the next
-`make deploy`.
+**Build 23** was uploaded on 2026-08-05, is `VALID`, and is the one attached.
+`current_ios_build` in `backend/app/config.py` is `23` and is live — it is
+compared against the `CFBundleVersion` *inside* the installed app, so it tracks
+that number and not the one App Store Connect displays. Changing it only goes
+live on the next `make deploy`.
 
 Next time: move the new row in [ios/CHANGELOG.md](../CHANGELOG.md) from
 **Local** to **TestFlight** and bump `current_ios_build` with it.
@@ -104,12 +112,27 @@ number**. Apple requires it in international format and rejects the request
 without one. The rest of that section (contact name and email, the demo
 account, the notes) goes in with it.
 
-### 6. Submit, then wait — ✅ done 2026-07-27
+### 6. Submit, then wait — submitted 2026-07-27, **rejected 2026-08-06**
 
-Typically 24–48 hours. If it's rejected, the reply arrives in Resolution
-Center; answer it there rather than resubmitting blind — a reply usually gets a
-same-day second look, whereas a silent resubmission goes to the back of the
-queue.
+Typically 24–48 hours; this one took ten days. If it's rejected, the reply
+arrives in Resolution Center; answer it there rather than resubmitting blind —
+a reply usually gets a same-day second look, whereas a silent resubmission goes
+to the back of the queue. Keep the reply in
+[resolution-center.md](resolution-center.md).
+
+The rejection also has a lesson for step 1. **Deploying is not the same as
+being reliable afterwards.** The 2.1(a) rejection was a 500 from `/auth/login`
+caused by dead pooled database connections, on a server that had been up for
+days and whose `/healthz` was green the entire time, because `/healthz` touches
+no database. The curl checks in step 1 would all have passed that morning. If
+you want a check that would have caught it, hit an endpoint that reads the
+database with the review credentials, not just `/healthz`:
+
+```bash
+curl -fsS -X POST https://meals.marcuslab.uk/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"apple.review@marcuslab.uk","password":"<the one in the form>"}'
+```
 
 ### 7. After approval
 
@@ -124,7 +147,7 @@ been done about each.
 
 | Risk | Guideline | Mitigation |
 |---|---|---|
-| Reviewer can't sign in | 2.1 | Demo account provisioned per submission, server pre-filled on the sign-in screen, credentials tested on a device first |
+| Reviewer can't sign in | 2.1 | **This is what happened on 2026-08-06.** Demo account provisioned per submission, server pre-filled on the sign-in screen, credentials tested on a device first — and none of that helps if the *server* fails the one request they make. Sign in against production immediately before submitting |
 | "The app requires a server we don't have" | 2.1 / 4.2 | Subtitle, description and review notes all say it up front; the demo account means they never have to set one up |
 | Account creation with no way to delete | 5.1.1(v) | Settings → Delete account, deletes immediately, called out in the review notes |
 | Missing or unreachable privacy policy | 5.1.1 | Served at `/privacy`, checked in step 1 |

--- a/ios/AppStore/resolution-center.md
+++ b/ios/AppStore/resolution-center.md
@@ -1,0 +1,81 @@
+# Resolution Center
+
+Replies to App Review, kept because a rejection is answered in prose and the
+prose is worth writing once. Reply in Resolution Center rather than resubmitting
+in silence: a reply usually gets a same-day second look, a silent resubmission
+goes to the back of the queue.
+
+What App Review rewards is a short, specific answer: what the cause was, what
+changed, and how they can confirm it. Everything else belongs in
+[../CHANGELOG.md](../CHANGELOG.md).
+
+---
+
+## 2026-08-06 — 2.1(a), "an error message is displayed when attempting to log in"
+
+Submission `556775c4-63cc-431c-8caf-5a7e4b6339bf`, reviewed on an iPad Air
+11-inch (M3) on iPadOS 26.6 against build ASC-18. The full diagnosis is in
+[../CHANGELOG.md](../CHANGELOG.md#the-21a-rejection); the short version is that
+the server was handing out dead pooled database connections and the reviewer's
+single sign-in attempt got one.
+
+**Status: drafted, not sent.**
+
+```
+Thank you for the detailed report. The review device and timestamp let us
+locate the exact request in our server logs, and the fault was ours, not the
+app's.
+
+The cause was a database connection pooling bug on our server. The API held a
+pool of connections to its database and was handing out connections that the
+network had already closed. Any request unlucky enough to receive one failed
+with a server error. Your sign-in attempt at 08:16:23 UTC on 6 August was one
+of them. The logs show the app behaving correctly throughout: it fetched its
+configuration successfully one second earlier, then our login endpoint returned
+a 500.
+
+We have fixed this by validating every pooled connection before it is used and
+retiring connections before the network can drop them. The fix is deployed to
+the server the app connects to. We verified it by deliberately closing every
+pooled connection and confirming that sign-in and all other requests now
+succeed, where before the change they failed.
+
+The demo account credentials in the App Review information are unchanged and
+working.
+
+On device support: the app is iPhone only by design and is submitted as such.
+We have retested sign-in and the rest of the app on an iPad Air 11-inch (M3) in
+iPhone compatibility mode, and both work correctly.
+
+We have attached build 23, which also carries improvements made since the build
+you reviewed. We have also filled in the App Review notes, which were
+unfortunately left empty on the original submission and would have explained
+that this app connects to a server the user runs themselves.
+```
+
+### What backs each claim
+
+Apple can check any of these, so none of them is padding.
+
+| Claim | Evidence |
+|---|---|
+| Their request at 08:16:23 returned a 500 | `docker service logs meals_api`, alongside the 200 for `/client-config` a second earlier |
+| Fix is deployed | `pool_pre_ping` present in the running container; production survives `pg_terminate_backend` |
+| Verified by closing pooled connections | 500 before the change, 200 after, in a throwaway stack and again on production |
+| Demo account works | `POST /auth/login` 200, and signed in on the simulator the same day |
+| Retested on iPad Air 11-inch (M3) | **Simulator, iOS 26.0.1.** Not a physical device, and not their 26.6 |
+
+That last row is the only soft claim. The sentence is true of a simulator, and
+what it asserts is that the app works in compatibility mode, which is what was
+observed. Test on a physical iPad first if you would rather the sentence be
+stronger than that.
+
+### Before sending
+
+- The fix must be deployed. It was, on 2026-08-06, but a reply claiming a
+  deployed fix against an undeployed server is a second rejection.
+- Check the demo account still signs in. It is the first thing they retry.
+- [review-notes.md](review-notes.md) suggests reprovisioning the demo account
+  with a fresh password for a resubmission, since Apple keeps the previous
+  credentials. Optional while the current password works, but if you do it,
+  update App Store Connect in the same sitting.

--- a/ios/AppStore/resolution-center.md
+++ b/ios/AppStore/resolution-center.md
@@ -19,7 +19,11 @@ Submission `556775c4-63cc-431c-8caf-5a7e4b6339bf`, reviewed on an iPad Air
 the server was handing out dead pooled database connections and the reviewer's
 single sign-in attempt got one.
 
-**Status: drafted, not sent.**
+**Status: sent 2026-08-06, and 1.0 resubmitted the same day** as submission
+`46eacb99-2954-48bb-8bc3-948fc2cbf703`. The reply goes in by hand: the App Store
+Connect API has no Resolution Center endpoint, so this is web UI only, and it is
+worth doing *before* resubmitting — a reply usually earns a same-day second
+look where a silent resubmission joins the back of the queue.
 
 ```
 Thank you for the detailed report. The review device and timestamp let us

--- a/ios/AppStore/review-notes.md
+++ b/ios/AppStore/review-notes.md
@@ -33,7 +33,7 @@ a shopping list, created for this review. It shares no data with any other
 account on that server.
 
 WHERE THINGS ARE
-- Account deletion: Settings tab (fourth) > Delete account. It asks for the
+- Account deletion: Settings tab (last) > Delete account. It asks for the
   password and for the word DELETE to be typed, then deletes immediately with
   no grace period. Please note it is permanent — if you delete the demo
   account, tell us and we will provision another.
@@ -109,6 +109,11 @@ Checked before submitting, because each one is a rejection rather than a note:
 - **The privacy URL 404s.** It's served by the backend, so it only exists once
   a build carrying `PRIVACY.md` is deployed. Open it in a browser.
 - **Account deletion can't be found.** It's in the Settings tab, and the notes
-  above say so explicitly.
+  above say so explicitly. Say "last" rather than a tab *number* — build 21
+  added an Ingredients tab and turned the fourth tab into the fifth, which the
+  notes would otherwise still be getting wrong.
+- **The notes box is empty.** Writing them here is not submitting them:
+  `appStoreReviewDetail.notes` was `null` for the whole first review, so none
+  of this reached the reviewer. Check it after filling the form in.
 - **`MIN_IOS_BUILD` above 0 on the deployment.** The client gate would 426 the
   reviewer's build and they'd see an upgrade wall instead of the app.

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -60,6 +60,7 @@ number involved. All four steps, in order:
 | **Local** | Built on a laptop. Nobody else has it. Freely rewritable. |
 | **TestFlight** | Uploaded. Testers can install it. Cannot be recalled. |
 | **In review** | Submitted to App Review, awaiting a verdict. |
+| **Rejected** | App Review returned it with issues. Still attached; resubmittable. |
 | **App Store** | Public. Cannot be recalled; only superseded. |
 
 ## Builds
@@ -71,7 +72,7 @@ number involved. All four steps, in order:
 | 21 | 1.0 | 2026-08-04 | TestFlight | **The web app's features, ported** (PR #39). New Ingredients tab: the catalogue with search, staples/verdict filters, name/aisle/verdict sorting, delete, the duplicates sweep (Q21) and manual merge from the ingredient editor. Settings grows Supermarkets & aisle order (save stores, drag their walks, pick the active one — Q2), an invites list with revoke, and AI access (mint/reveal-once/revoke API tokens). Shopping list: "sorting aisles for" switcher in the menu, Previous shops, and offline-queued delete for ad-hoc lines. Plan: rename, and past plans open read-only. Recipes: tag and under-30-min filters; meal-library rows in the add sheet gain edit/delete. All additive against the API — any server can serve this build. Delivery UUID `d294f722-8e5d-4340-9f34-4c99805affe4`, uploaded 2026-08-04 19:21 UTC. TestFlight only: it is **not** attached to the 1.0 review, which still carries ASC-18. |
 | 20 | 1.0 | 2026-07-30 | TestFlight | **"Add to this week's plan" works with no active plan.** From a recipe, that tap said "Added to plan" and did nothing whenever the household had no plan: `PlanStore.addMeal` returned early on a nil plan while the recipe screen showed its success alert regardless, leaving an orphan meal in the library and nothing on the shopping list. It now resolves the plan from the server and starts one, labelled "This week's options", when there genuinely isn't one; the alert names the plan, and a real failure gets an error instead of a false success. Also fixes the same dead tap when a plan did exist but the Plan tab hadn't been opened yet that session. Only iOS changed, so any server can serve this build. Delivery UUID `ee327728-3b3b-4d98-966a-bd7fa2312f88`, uploaded 2026-07-30 07:55 UTC and VALID, listed in App Store Connect as 20, so `CFBundleVersion` and the ASC number stay in step. TestFlight only: it is **not** attached to the 1.0 review, which still carries ASC-18. |
 | 19 | 1.0 | 2026-07-29 | TestFlight | **Shopping list: checked-off items leave the aisle.** Ticking something off used to leave it in place with a strikethrough, so the aisle you were standing in kept showing what was already in the trolley. It now drops out of the list into a collapsed "In the basket (N)" section at the foot of it, and one tap there puts it back in its aisle. The "Show checked-off" menu toggle is gone, replaced by that section. Also: the whole row is tappable now (the gap between the name and the quantity used to be dead space), and check-offs animate out. **18 is taken in App Store Connect, so this is 19, not 18** — the `CFBundleVersion`/ASC divergence closes here: it uploaded as 19 and App Store Connect lists it as 19. Delivery UUID `a9d80ccf-84a5-4089-91a4-023adfa9e39d`. TestFlight only — it is **not** attached to the 1.0 review, which still carries ASC-18. |
-| 17 → **ASC 18** | 1.0 | 2026-07-27 | **In review** | **The first genuinely iPhone-only build**, submitted to App Review 2026-07-27 19:35 UTC. Builds up to here all shipped `UIDeviceFamily = [1, 2]`: `TARGETED_DEVICE_FAMILY: "1"` was set at the *project* level in `project.yml`, and xcodegen writes `"1,2"` onto every iOS target, which wins. So the app claimed iPad support it was never designed or tested for. App Store Connect noticed, and demanded 13" iPad screenshots. **Its `CFBundleVersion` is 17 but App Store Connect lists it as build 18** — see the numbering note below. |
+| 17 → **ASC 18** | 1.0 | 2026-07-27 | **Rejected** | **The first genuinely iPhone-only build**, submitted to App Review 2026-07-27 19:35 UTC, **rejected 2026-08-06 under guideline 2.1(a)** — see [The 2.1(a) rejection](#the-21a-rejection) below. Nothing was wrong with this binary. Builds up to here all shipped `UIDeviceFamily = [1, 2]`: `TARGETED_DEVICE_FAMILY: "1"` was set at the *project* level in `project.yml`, and xcodegen writes `"1,2"` onto every iOS target, which wins. So the app claimed iPad support it was never designed or tested for. App Store Connect noticed, and demanded 13" iPad screenshots. **Its `CFBundleVersion` is 17 but App Store Connect lists it as build 18** — see the numbering note below. |
 | — (ASC 17) | 1.0 | 2026-07-26 | TestFlight | **Not built from this repo**, and not accounted for here: it appeared six minutes after build 16 and matches no upload recorded in this session. It predates the iPad fix, so treat it as iPhone+iPad and do not submit it. |
 | 16 | 1.0 | 2026-07-26 | TestFlight | First build aimed at App Review, and the first at version 1.0 — so the first that can attach to the App Store record at all. Superseded before submission; **claims iPad support**. Defaults to `https://meals.marcuslab.uk` instead of localhost; login screen explains the server field and self-hosting; account settings (password, sign-out, delete) moved into a Settings screen reachable from every tab; marketing version raised 0.1 → 1.0 so the build can attach to the 1.0 App Store record. |
 | 15 | 0.1 | 2026-07-25 | TestFlight | Password reset and account deletion flows in the app (decision Q20). |
@@ -99,10 +100,56 @@ onwards as recorded, and anything earlier as best effort.
 | | |
 |---|---|
 | App record | `com.marcuslab.meals`, App Store Connect app id `6794266229` |
-| Registered name | **Meal Options Planner** — to be renamed before submission (see [AppStore/metadata.md](AppStore/metadata.md)) |
-| Version record | 1.0, `WAITING_FOR_REVIEW`, build ASC-18 attached |
-| Ever submitted? | Yes — first submission 2026-07-27 19:35 UTC. |
-| Nothing is public yet | **No build has ever reached the App Store.** Every row above is TestFlight-only. The 1.0 record is still waiting on review with ASC-18 attached, so anything uploaded after it (build 19 onward) is testers-only until someone attaches it to a version and submits. Uploading to TestFlight does not touch a submission in review: `make ios-testflight` archives, exports and uploads, and nothing more. |
+| Registered name | **Yet Another Meal Planner** — the rename landed; App Review's correspondence uses it (see [AppStore/metadata.md](AppStore/metadata.md)) |
+| Version record | 1.0, `REJECTED`, build ASC-18 attached |
+| Review submission | `556775c4-63cc-431c-8caf-5a7e4b6339bf`, state `UNRESOLVED_ISSUES` |
+| Ever submitted? | Yes — first submission 2026-07-27 19:35 UTC, rejected 2026-08-06 08:19 UTC. |
+| Nothing is public yet | **No build has ever reached the App Store.** Every row above is TestFlight-only. The 1.0 record now holds a rejection with ASC-18 attached, so anything uploaded after it (build 19 onward) is testers-only until someone attaches it to a version and resubmits. Uploading to TestFlight does not touch a submission in review: `make ios-testflight` archives, exports and uploads, and nothing more. |
+
+### The 2.1(a) rejection
+
+Rejected 2026-08-06 for *Performance — App Completeness*, on one sentence:
+"an error message is displayed when attempting to log in". Reviewed on an
+**iPad Air 11-inch (M3), iPadOS 26.6** — an iPhone-only app runs there in
+compatibility mode, and Apple reviews it there anyway.
+
+**It was not an app bug, and not an iPad bug. It was the server.** The reviewer's
+session is in the API log in full:
+
+```
+08:16:22 GET  /client-config      200
+08:16:23 POST /auth/login         500   asyncpg ConnectionDoesNotExistError
+08:19:08 rejection email
+```
+
+`create_async_engine` was built with no `pool_pre_ping` and no `pool_recycle`,
+so the pool held Postgres connections that the overlay network had already
+dropped. The first request to check one out died; `/client-config` survived a
+second earlier only because it touches no database. Traffic is low enough that
+"the first request after a quiet spell" is a real category of user, and on that
+morning it was App Review. Four 500s in the preceding 24 hours, all the same
+fault, all first-of-the-morning. `/healthz` touches no database either, so the
+container healthcheck — the same one that gates the zero-downtime rollout —
+was green throughout.
+
+Fixed in `backend/app/database.py`; verified both ways against real Postgres by
+killing the pooled connections with `pg_terminate_backend` and retrying the
+login (500 before, 200 after). **The fix must be deployed before 1.0 is
+resubmitted** — the binary needs no change, though attaching a current build is
+free and sensible.
+
+Two things this exposed that are worth fixing on their own schedule:
+
+- **App Review notes were never submitted.** `appStoreReviewDetail.notes` is
+  `null` on the 1.0 record, so the whole block in
+  [AppStore/review-notes.md](AppStore/review-notes.md) — self-hosting, where
+  account deletion lives, why 4.8 doesn't apply — never reached a reviewer.
+- **The auth rate limit is a single global bucket.** `deps.auth_rate_limit`
+  keys on `request.client.host`, and uvicorn only trusts forwarded headers from
+  `127.0.0.1` while Traefik connects from the overlay. So every client on the
+  server shares one 10/min allowance, and one person retrying a password can
+  lock everyone out of logging in. Not what caused this rejection, but it is
+  the same shape of thing.
 
 The 1.0 listing metadata — name, subtitle, categories, age rating, description,
 keywords, URLs, screenshots, copyright, content rights — was set through the

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -34,7 +34,11 @@ What that leaves standing:
 - **Attach builds by id, not by number.** `ios/AppStore/` scripts identify the
   build by the delivery UUID `altool` prints, because matching on the number
   silently attached the wrong binary once already. The UUIDs are in the rows
-  below from build 19 onward.
+  below from build 19 onward. Handily they *are* the App Store Connect build
+  ids: attaching build 23 on 2026-08-06 resolved `filter[version]=23` to
+  `c55cc542-33f6-4414-be75-2734f21c32e9`, the same UUID this file already had
+  in its row. Cross-check the upload date against the row before attaching and
+  the two identifiers confirm each other.
 
 ## The ritual when you bump a build
 
@@ -101,8 +105,9 @@ onwards as recorded, and anything earlier as best effort.
 |---|---|
 | App record | `com.marcuslab.meals`, App Store Connect app id `6794266229` |
 | Registered name | **Yet Another Meal Planner** — the rename landed; App Review's correspondence uses it (see [AppStore/metadata.md](AppStore/metadata.md)) |
-| Version record | 1.0, `REJECTED`, build ASC-18 attached |
-| Review submission | `556775c4-63cc-431c-8caf-5a7e4b6339bf`, state `UNRESOLVED_ISSUES` |
+| Version record | 1.0, `PREPARE_FOR_SUBMISSION`, **build 23 attached** (was ASC-18). Editing a rejected version moves it out of `REJECTED` on its own; it is not submitted until someone submits it. |
+| Review submission | `556775c4-63cc-431c-8caf-5a7e4b6339bf`, state `UNRESOLVED_ISSUES` — the rejected one. Resubmitting opens a new submission. |
+| Review notes | Filled in 2026-08-06 from [AppStore/review-notes.md](AppStore/review-notes.md), 1784 chars. They were `null` for the whole first review. |
 | Ever submitted? | Yes — first submission 2026-07-27 19:35 UTC, rejected 2026-08-06 08:19 UTC. |
 | Nothing is public yet | **No build has ever reached the App Store.** Every row above is TestFlight-only. The 1.0 record now holds a rejection with ASC-18 attached, so anything uploaded after it (build 19 onward) is testers-only until someone attaches it to a version and resubmits. Uploading to TestFlight does not touch a submission in review: `make ios-testflight` archives, exports and uploads, and nothing more. |
 

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -105,10 +105,10 @@ onwards as recorded, and anything earlier as best effort.
 |---|---|
 | App record | `com.marcuslab.meals`, App Store Connect app id `6794266229` |
 | Registered name | **Yet Another Meal Planner** — the rename landed; App Review's correspondence uses it (see [AppStore/metadata.md](AppStore/metadata.md)) |
-| Version record | 1.0, `PREPARE_FOR_SUBMISSION`, **build 23 attached** (was ASC-18). Editing a rejected version moves it out of `REJECTED` on its own; it is not submitted until someone submits it. |
-| Review submission | `556775c4-63cc-431c-8caf-5a7e4b6339bf`, state `UNRESOLVED_ISSUES` — the rejected one. Resubmitting opens a new submission. |
+| Version record | 1.0, `WAITING_FOR_REVIEW`, **build 23 attached** (was ASC-18) |
+| Review submission | `46eacb99-2954-48bb-8bc3-948fc2cbf703`, submitted 2026-08-06 21:27 UTC. The rejected one, `556775c4-…`, is `COMPLETE`. |
 | Review notes | Filled in 2026-08-06 from [AppStore/review-notes.md](AppStore/review-notes.md), 1784 chars. They were `null` for the whole first review. |
-| Ever submitted? | Yes — first submission 2026-07-27 19:35 UTC, rejected 2026-08-06 08:19 UTC. |
+| Ever submitted? | Twice — 2026-07-27 19:35 UTC, rejected 2026-08-06 08:19 UTC; resubmitted 2026-08-06 21:27 UTC. |
 | Nothing is public yet | **No build has ever reached the App Store.** Every row above is TestFlight-only. The 1.0 record now holds a rejection with ASC-18 attached, so anything uploaded after it (build 19 onward) is testers-only until someone attaches it to a version and resubmits. Uploading to TestFlight does not touch a submission in review: `make ios-testflight` archives, exports and uploads, and nothing more. |
 
 ### The 2.1(a) rejection
@@ -139,9 +139,21 @@ was green throughout.
 
 Fixed in `backend/app/database.py`; verified both ways against real Postgres by
 killing the pooled connections with `pg_terminate_backend` and retrying the
-login (500 before, 200 after). **The fix must be deployed before 1.0 is
-resubmitted** — the binary needs no change, though attaching a current build is
-free and sensible.
+login (500 before, 200 after). The binary needed no change, though build 23 was
+attached anyway, being better in every way and free.
+
+Deployed, replied to in Resolution Center, and **resubmitted 2026-08-06 21:27
+UTC** as submission `46eacb99-2954-48bb-8bc3-948fc2cbf703`.
+
+**Resubmitting through the API takes one step the docs don't lead with.** A
+rejected submission still *owns* the version, so `POST /v1/reviewSubmissionItems`
+returns 409 `ITEM_PART_OF_ANOTHER_SUBMISSION`, and `DELETE`-ing the item out of
+it returns 409 too while it sits in `UNRESOLVED_ISSUES`. The way through is to
+cancel the old submission — `PATCH /v1/reviewSubmissions/<old>` with
+`{"canceled": true}` — which is what the web UI's "Submit for Review" does
+behind the glass. That is **asynchronous**: it answers 200 with state
+`CANCELING` and the version stays locked until it reaches `COMPLETE`, so poll
+before adding the item rather than assuming the 200 finished the job.
 
 Two things this exposed that are worth fixing on their own schedule:
 


### PR DESCRIPTION
> **Stacked on #44.** This branch is rebased onto `claude/app-store-rejection-00dbf6`,
> so it contains that PR's four commits plus one of its own. Merging this
> merges #44 with it. Review only the last commit for what is new here.

One sign-in returned a 500 and the retries that followed it hit a 429. Those
are two separate bugs. #44 fixes the first; this adds the second.

## What the api logs showed

```
2026-08-05T20:00:28Z  POST /auth/login  500
asyncpg.exceptions.ConnectionDoesNotExistError: connection was closed in the middle of operation
```

The last request to touch the database before it was `GET /plans/current`
9 hours earlier, and `meals_db` had been up 10 days — so nothing restarted, the
socket was dropped in the network path. `/healthz` runs every 5s but returns a
static dict, so it never opens a connection and could neither keep one warm nor
notice a dead one. That is #44's `pool_pre_ping` + `pool_recycle`.

## What this commit adds

Counting the burst: **1 × 500 + 9 × 200 = exactly 10 attempts**, against
`auth_rate_limit_per_minute = 10`. The limiter was charging *successful* logins
to a brute-force budget, so the caller locked themselves out of their own
account purely by retrying — the last seven attempts got a 429.

Per-IP keying could not have fixed this: one person retrying ten times exhausts
their own bucket however precisely you identify them. Brute force is a stream of
failures, so a success now refunds its attempt.

Deliberately a refund rather than "only count failures". The charge is still
taken up front, so an endpoint that forgets to refund is merely stricter, never
unthrottled. `register` and the reset *request* keep paying, being abusable
whether or not they succeed.

## Not in this diff

`FORWARDED_ALLOW_IPS=10.0.0.0/8` on the api service, because `deploy/` is
gitignored. Without it `request.client.host` was Traefik's own address and every
caller in the world shared one bucket.

It only recovers the **Cloudflare edge** address, not the end user: Traefik's
`websecure` entrypoint sets no `forwardedHeaders.trustedIPs`, so it overwrites
the header Cloudflare sent. Verified in production — two requests 30s apart from
one machine logged as `162.158.216.48` and `172.69.195.44`.

Those edges rotate per request, so per-IP limiting is still not truly achieved,
and brute-force resistance is now *weaker* than the accidental global bucket it
replaced. The trade is still favourable, since one global bucket let any single
attacker lock out every user. The real fix is Cloudflare's ranges in Traefik's
`forwardedHeaders.trustedIPs` — shared infra across every app on the swarm, so
deliberately left alone.

## Testing

531 backend + 55 mcp pass on the combined tree, lint clean. Two new tests: ten
successful logins against a limit of three, plus a control that interleaves
failures with successes and still 429s — the control is what stops the first
test passing vacuously.

The limiter was **not** exercised against production: its bucket is keyed on a
Cloudflare edge a reviewer may share, and there is a live App Review submission.

Deployed and verified in the running container: `pool_pre_ping`, `pool_recycle`,
`forgive_auth_attempt` with 4 call sites, and the env var — all present, zero
tracebacks since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
