### PR TITLE
Publish password_reset_enabled on /client-config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,9 @@ SESSION_TOKEN_TTL_DAYS=30
 AUTH_RATE_LIMIT_PER_MINUTE=10
 
 # Password reset email (optional). Unset means POST /auth/password-reset
-# returns 503 rather than pretending to send; nothing else needs it.
+# returns 503 rather than pretending to send; nothing else needs it, and
+# GET /client-config publishes which way it went as password_reset_enabled.
+# Resend: host smtp.resend.com, username `resend`, password the API key.
 #SMTP_HOST=smtp.example.com
 #SMTP_FROM=meals@example.com
 #SMTP_USERNAME=

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ make help    # everything else: logs, lint, migrate, fmt, down, nuke…
 Only password reset sends any, and it's plain SMTP so any relay works. Leave it
 unset and `POST /auth/password-reset` returns a 503 explaining what's missing;
 everything else, including changing a password you *know*, works without it.
+`GET /client-config` reports which of the two you are as `password_reset_enabled`,
+so a client can hide the option rather than offer a door that doesn't open.
 
 ```bash
 SMTP_HOST=smtp.example.com
@@ -80,6 +82,26 @@ SMTP_USERNAME=...       # if your relay authenticates
 SMTP_PASSWORD=...
 SMTP_START_TLS=true     # default
 PASSWORD_RESET_TTL_MINUTES=30   # default
+```
+
+Two relays that need no server of your own. **Resend** — verify your domain,
+then the username is literally `resend` and the password is the API key:
+
+```bash
+SMTP_HOST=smtp.resend.com
+SMTP_USERNAME=resend
+SMTP_PASSWORD=re_...
+SMTP_FROM=meals@your-domain
+```
+
+**Gmail** — needs 2FA, then an app password from Google Account → Security → App
+passwords. `SMTP_FROM` must be the account itself; Google rejects any other From.
+
+```bash
+SMTP_HOST=smtp.gmail.com
+SMTP_USERNAME=you@gmail.com
+SMTP_PASSWORD=<16-character app password>
+SMTP_FROM=you@gmail.com
 ```
 
 ## Repo layout

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -144,11 +144,16 @@ async def client_config() -> dict:
     """What this deployment expects of native clients. The iOS app reads this
     at launch: below `min_ios_build` it is blocked (426 on everything except
     the offline-queue endpoints), below `current_ios_build` it shows a
-    dismissible nudge. Unauthenticated, and never gated itself."""
+    dismissible nudge. Unauthenticated, and never gated itself.
+
+    `password_reset_enabled` says whether this server can send email at all. A
+    client that shows "Forgot password?" regardless leads people to a 503 they
+    can do nothing about, so it can ask here first and hide the door instead."""
     config = get_settings()
     return {
         "api_version": app.version,
         "min_ios_build": config.min_ios_build,
         "current_ios_build": config.current_ios_build,
         "upgrade_url": config.ios_upgrade_url,
+        "password_reset_enabled": config.email_configured,
     }

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -177,16 +177,19 @@ async def request_password_reset(
 
     The exception is a server with no SMTP configured at all, which returns 503:
     that says something about the *server*, not about any account, and a
-    self-hoster needs to be told rather than left wondering.
+    self-hoster needs to be told rather than left wondering. `GET /client-config`
+    publishes the same fact as `password_reset_enabled`, so a client can avoid
+    offering the option on a server that can't honour it.
     """
     settings = get_settings()
     if not settings.email_configured:
         raise HTTPException(
             status_code=503,
             detail=(
-                "this server cannot send email, so password reset is unavailable — "
-                "the operator needs to set SMTP_HOST and SMTP_FROM (see README). "
-                "A signed-in user can still change their password with POST /auth/password."
+                "this server isn't set up to send email, so it can't send a reset code. "
+                "Whoever runs it can turn this on by setting SMTP_HOST and SMTP_FROM (see README); "
+                "GET /client-config reports it as password_reset_enabled. In the meantime a password "
+                "you do know can still be changed with POST /auth/password."
             ),
         )
 

--- a/backend/tests/integration/test_client_gate.py
+++ b/backend/tests/integration/test_client_gate.py
@@ -124,6 +124,13 @@ class TestClientConfig:
     async def test_needs_no_auth(self, client):
         assert (await client.get("/client-config")).status_code == 200
 
+    async def test_reports_whether_the_server_can_send_email(self, client, settings_override):
+        """So a client can hide "Forgot password?" rather than walk someone into
+        a 503 they can do nothing about."""
+        assert (await client.get("/client-config")).json()["password_reset_enabled"] is False
+        settings_override(SMTP_HOST="smtp.example.com", SMTP_FROM="meals@example.com")
+        assert (await client.get("/client-config")).json()["password_reset_enabled"] is True
+
     async def test_identified_clients_learn_the_floor_from_any_response(self, auth_client, min_build):
         """The advisory headers let the app nudge without a second round trip."""
         min_build(1, current=2)

--- a/backend/tests/integration/test_password_reset.py
+++ b/backend/tests/integration/test_password_reset.py
@@ -74,8 +74,13 @@ class TestRequestingAReset:
         await register(client)
         response = await request_reset(client)
         assert response.status_code == 503
-        assert "SMTP_HOST" in response.json()["detail"]
-        assert "POST /auth/password" in response.json()["detail"]
+        detail = response.json()["detail"]
+        assert "SMTP_HOST" in detail
+        assert "POST /auth/password" in detail
+        # The app shows this string verbatim, so it opens with what the person
+        # reading it can act on rather than with an env var.
+        assert detail.split(".")[0] == "this server isn't set up to send email, so it can't send a reset code"
+        assert "password_reset_enabled" in detail
 
     async def test_requesting_again_supersedes_the_first_code(self, client, outbox):
         await register(client)


### PR DESCRIPTION
Part of #7. The credentials themselves are a deploy-time change to `~/meals-deploy/.env`, not a code one; this is the "worth considering" half of that issue.

- `GET /client-config` gains `password_reset_enabled`, so a client can hide "Forgot password?" rather than offer a door that doesn't open. Additive: old iOS builds ignore the key.
- The 503 from `POST /auth/password-reset` now leads with what the person reading it can act on ("this server isn't set up to send email"), with the operator's `SMTP_HOST`/`SMTP_FROM` instructions after it. The app shows these strings verbatim.
- README and `.env.example` gain the two relays that need no mail server of your own: Resend (username is literally `resend`, password is the API key) and Gmail app passwords.

iOS is not changed here — gating the button in the app needs a build bump and a TestFlight upload, and the flag is what that would read.

`make lint` clean, 532 backend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)