### PR TITLE
iOS: hide "Forgot password?" when the server cannot send email

### DIFF
--- a/ios/Meals/Meals/App/Session.swift
+++ b/ios/Meals/Meals/App/Session.swift
@@ -13,6 +13,7 @@ final class Session {
             // A verdict belongs to the server that gave it — pointing the app
             // at localhost must not inherit the homelab's floor, or vice versa.
             upgrade = .ok
+            passwordResetEnabled = true
             Task { await checkClientCompatibility() }
         }
     }
@@ -49,6 +50,12 @@ final class Session {
     }
 
     private(set) var upgrade: Upgrade = .ok
+
+    /// Whether this server can send a reset code at all (#49). Read from
+    /// `/client-config` alongside the build floor, and true until told
+    /// otherwise — unreachable or too old to answer both mean "offer it".
+    private(set) var passwordResetEnabled = true
+
     // Written once in init, read once in deinit (which is nonisolated), so it
     // steps outside the actor rather than dragging the rest of Session with it.
     @ObservationIgnored private nonisolated(unsafe) var upgradeObserver: (any NSObjectProtocol)?
@@ -129,12 +136,14 @@ final class Session {
     // MARK: - Version alignment
 
     /// Ask the server what it expects of this build. Called at launch and on
-    /// every foreground, so a deploy that raises the floor is noticed before
-    /// the user hits a wall mid-task. Silent when offline — a server we can't
-    /// reach can't refuse us either.
+    /// every foreground — logged out too, because the login screen is where
+    /// "Forgot password?" lives — so a deploy that raises the floor is noticed
+    /// before the user hits a wall mid-task. Silent when offline: a server we
+    /// can't reach can't refuse us either.
     func checkClientCompatibility() async {
         guard let config = try? await api.clientConfig() else { return }
         upgrade = Upgrade(config: config, build: ClientIdentity.buildNumber)
+        passwordResetEnabled = config.offersPasswordReset
     }
 
     func dismissUpgradeNudge() {

--- a/ios/Meals/Meals/Models/Models.swift
+++ b/ios/Meals/Meals/Models/Models.swift
@@ -127,6 +127,15 @@ struct ClientConfig: Codable, Equatable, Sendable {
     let minIosBuild: Int
     let currentIosBuild: Int
     let upgradeUrl: String?
+    /// Whether the server can send email at all, and so whether a reset code
+    /// can ever arrive. Optional because a server older than this build doesn't
+    /// send the key, and a missing key must not take the whole config down.
+    var passwordResetEnabled: Bool? = nil
+
+    /// Absent means a server that predates the flag, and the honest answer there
+    /// is "offer it": hiding the button on every un-upgraded server is a worse
+    /// mistake than the 503 it was meant to avoid.
+    var offersPasswordReset: Bool { passwordResetEnabled ?? true }
 }
 
 struct RecipeSummary: Codable, Identifiable, Equatable, Sendable {

--- a/ios/Meals/Meals/Views/LoginView.swift
+++ b/ios/Meals/Meals/Views/LoginView.swift
@@ -70,7 +70,11 @@ struct LoginView: View {
                     }
                     .font(.callout)
 
-                    if !isRegistering {
+                    // Hidden, not disabled, when the server can't send email:
+                    // there is nothing the person at this screen could do to
+                    // make it work, so explaining the door is worse than not
+                    // showing one (#49).
+                    if !isRegistering && session.passwordResetEnabled {
                         Button("Forgot password?") { showForgotPassword = true }
                             .font(.callout)
                     }

--- a/ios/Meals/MealsTests/ClientVersionTests.swift
+++ b/ios/Meals/MealsTests/ClientVersionTests.swift
@@ -85,6 +85,33 @@ final class ClientGateTests: XCTestCase {
         let config = try await client(protocolClass: StubProtocol.self).clientConfig()
         XCTAssertEqual(config, ClientConfig(apiVersion: "0.1.0", minIosBuild: 2, currentIosBuild: 4, upgradeUrl: nil))
     }
+
+    /// A server that can't send email says so, and the app hides the reset door
+    /// rather than leading people to a 503 they can do nothing about (#49).
+    func testClientConfigCarriesWhetherTheServerCanSendEmail() async throws {
+        let body = #"{"api_version": "0.1.0", "min_ios_build": 0, "current_ios_build": 4, "#
+            + #""upgrade_url": null, "password_reset_enabled": false}"#
+        StubProtocol.handler = { _ in (200, Data(body.utf8)) }
+        let config = try await client(protocolClass: StubProtocol.self).clientConfig()
+        XCTAssertEqual(config.passwordResetEnabled, false)
+        XCTAssertFalse(config.offersPasswordReset)
+    }
+
+    /// The whole config must survive a server that predates the flag — an
+    /// unknown answer is not a decode failure, and it is not a "no" either.
+    func testAServerTooOldToAnswerStillDecodesAndKeepsTheButton() async throws {
+        StubProtocol.handler = { _ in
+            (
+                200,
+                Data(
+                    #"{"api_version": "0.1.0", "min_ios_build": 0, "current_ios_build": 4, "upgrade_url": null}"#.utf8
+                )
+            )
+        }
+        let config = try await client(protocolClass: StubProtocol.self).clientConfig()
+        XCTAssertNil(config.passwordResetEnabled)
+        XCTAssertTrue(config.offersPasswordReset)
+    }
 }
 
 final class UpgradeStateTests: XCTestCase {


### PR DESCRIPTION
Closes #49.

`LoginView` showed "Forgot password?" unconditionally, so on a self-hosted server with no SMTP the button led to a 503 that nobody at the login screen could do anything about. The flag needed has shipped since #47: `GET /client-config` carries `password_reset_enabled`.

## What changed

- `ClientConfig` gains `passwordResetEnabled` as an **optional** Bool, plus `offersPasswordReset` which reads `nil` as yes. A server older than this build doesn't send the key, and absent has to mean "assume it works" rather than a decode failure taking the whole config down.
- `Session` keeps the verdict from the `/client-config` check it already runs at launch and on every foreground — logged out included, which is where the button lives — and resets it to yes when `serverURL` changes, for the same reason the upgrade verdict resets.
- `LoginView` hides the button when the flag is explicitly false. Hidden rather than disabled-with-an-explanation: there is no action the person at that screen could take.

## Verified

`make ios-test`: 137 tests, 0 failures, including two new ones for the false and absent cases.

In the simulator against a local API, both directions:

| No SMTP configured | SMTP configured |
|---|---|
| button absent | button back on the next foreground |

## Not shipped yet

No `CFBundleVersion` bump, so this is code-only until it rides along with the next build going up for another reason — the four-step ritual at the top of [ios/CHANGELOG.md](ios/CHANGELOG.md). Nothing here needs a server change; every deployed API already publishes the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)