### PR TITLE
Docs: stop the backlog impersonating the issue tracker

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,13 +4,20 @@ What's *not* done, in rough priority order. The plan itself is fully built —
 see [planning/05-status.md](planning/05-status.md) — so this is the deferred
 tail plus engineering debt worth naming.
 
+**This file is not the tracker.** Anything actionable enough for someone else
+to pick up lives in
+[GitHub issues](https://github.com/marco308/meals/issues) and is linked from
+here, not restated. What stays in this file is the reasoning: what was
+deliberately *not* built, and why the debt that is still here is tolerable.
+An entry that grows a plan of attack has outgrown the file.
+
 ## Now
 
 - [x] ~~**Deploy to the homelab**~~ — ✅ live at `https://meals.marcuslab.uk` (2026-07-24; `make deploy`, stack in the gitignored local `deploy/`)
 - [x] ~~**Close registration**~~ — ✅ done twice over: decision Q19 means a registration creates its own household rather than joining this one, and `REGISTRATION_ENABLED=false` is set on the deployment as well, so new households are refused outright. Invite codes are still honoured, which is how the next household member gets in
-- [ ] **Postgres backups** — still no automation. A one-off `pg_dump` was taken before the Q19 deploy (2026-07-25) and sits in `~/backups` on the node running the database, which proves the command works but is not a backup strategy. Wants a nightly job plus a documented restore, and now that other people may self-host it's worth writing up rather than just doing
+- [ ] **Postgres backups** — [#9](https://github.com/marco308/meals/issues/9). Still no automation, no off-node copy, and no restore ever attempted
 - [x] ~~**Point the iOS app at the domain**~~ — ✅ `https://meals.marcuslab.uk` is now the default a fresh install starts on (build 16), not `localhost`. Offline sync over the real network still wants a proper walk round a supermarket
-- [ ] **First App Store submission** — everything is staged: [ios/AppStore/](ios/AppStore/) has the listing copy, review notes and privacy answers, `make ios-screenshots` produces the shots, and `python -m app.provision` makes the isolated Apple Review household. What's left is Marcus-only: deploy the server so `/privacy` and `/support` are live, ship build 16, rename the app record (it's still "Meal Options Planner"), and fill the form
+- [x] ~~**First App Store submission**~~ — ✅ **1.0 is live on the App Store**, carrying build 23, approved 2026-08-12. Submitted 2026-07-27, rejected 2026-08-06 under guideline 2.1(a) for a server fault (stale pooled connections), fixed, replied to in Resolution Center and resubmitted the same day. The record is renamed to "Yet Another Meal Planner". Full state in [ios/AppStore/README.md](ios/AppStore/README.md)
 - [x] ~~**Deploy Q19**~~ — ✅ deployed 2026-07-25; migration `d9e4b17c3a86` applied, and the existing account kept its household as intended (nothing migrated)
 - [ ] **Onboard the second household member** — no longer needs curl at either end: build 16 mints the code (Settings → Invite someone) and build 14 onwards can redeem it on the register screen. Both are on TestFlight, so this is now just a thing to do
 - [ ] **Clean the BBC misparse junk out of prod** — dual-measure lines left ingredients named "/3½oz vermicelli rice noodles", "/10½oz cooked" and friends behind (parser fixed + guarded `DELETE /ingredients/{id}` added 2026-07-29, Q22; summer_rolls_15105 is a known affected recipe). The recipe lines kept their raw text and correct metric quantities, so merging each junk row into the real food (`POST /ingredients/{keeper_id}/merge`) heals the recipes too; `DELETE /ingredients/{id}` mops up anything left unreferenced. An AI on the v9 playbook can do the whole sweep
@@ -28,8 +35,8 @@ what it deliberately doesn't do yet:
   per-recipe `scale` factor
 - [ ] **Re-ingest from the recipe page** — blocked on the same "Re-parse
   endpoint" item below
-- [ ] **Marketing site mention** — docs/ still sells "iPhone app + any AI";
-  the self-host pitch can now include the web app for free
+- [x] ~~**Marketing site mention**~~ — ✅ `docs/` sells it now ("Web ships in
+  the box: your server serves the web app itself at `/app`")
 
 ## Account lifecycle
 
@@ -49,7 +56,7 @@ what it deliberately doesn't do yet:
 - [ ] **Premium/budget browse screen in iOS** — `GET /ingredients?value_tier=premium` and the MCP `list_ingredients_by_value` read the tagged set back (Q17); the app only shows a tier on ingredients you happen to open
 - [ ] **iOS offline breadth** — plan and recipe library are online-only by design (Q11); cache read-only copies so the whole app opens signal-less
 - [x] ~~**Remote MCP multi-user auth**~~ — ✅ shipped (issue #6): the stack serves streamable HTTP at `https://meals.marcuslab.uk/mcp` and forwards each caller's own bearer PAT per request; stdio stays for local dev
-- [ ] **MCP OAuth** — claude.ai custom connectors authenticate via OAuth, not custom headers; the remote MCP is bearer-header-only today (Claude Code and header-capable clients work)
+- [ ] **MCP OAuth** — [#8](https://github.com/marco308/meals/issues/8). claude.ai custom connectors want OAuth; the remote MCP is bearer-header-only today
 
 ## Later (explicitly deferred in the plan)
 
@@ -68,5 +75,5 @@ what it deliberately doesn't do yet:
 - [ ] **Rate limiting is per-process in-memory** — fine for one replica; revisit if the API ever scales out
 - [x] ~~**Ingredient-line parser tail**~~ — ✅ the regex learned the `<n> <food> <unit>` shape (Q21): "3 garlic cloves" is now 3 cloves of garlic rather than ×3 of an ingredient called "garlic cloves", except where the last word is load-bearing ("2 bay leaves")
 - [ ] **Ingestion has no response-size cap** — `fetch_page` reads the whole body into memory with only the 15s timeout as a bound; a pathological page is a memory spike. Wants a streamed read with a byte ceiling (a few MB covers any real recipe page)
-- [ ] **Flaky provision password test** — `test_generated_passwords_are_typeable_and_not_guessable` asserts no `8` in the password while `_generate_password`'s alphabet contains one, so it fails roughly one run in four. Either drop `8` from the alphabet or from the ambiguous set; predates Q21 and is unrelated to it
-- [ ] **Demo/test data hygiene in prod** — if a smoke-test account was used during deploy verification, remove it (single shared household means it sees real data)
+- [x] ~~**Flaky provision password test**~~ — ✅ fixed by asserting on the alphabet rather than on one draw from it: `8` is gone from `PASSWORD_ALPHABET`, and the test now checks that `PASSWORD_ALPHABET` and `AMBIGUOUS_CHARACTERS` are disjoint, which a re-introduced look-alike can't slip past
+- [ ] **Demo/test data hygiene in prod** — if a smoke-test account was used during deploy verification, remove it. Since Q19 a stray registration lands in its own empty household rather than the family's, so this is now tidiness rather than exposure; the Apple Review account made by `python -m app.provision` is the deliberate version of the same thing

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -30,11 +30,11 @@ what it deliberately doesn't do yet:
 - [ ] **Offline** — it's online-only by design (the iPhone in the supermarket
   is the offline story; the web app is the kitchen/desk screen). If that ever
   changes, the `PendingOp` queue semantics from iOS (Q11) are the model
-- [ ] **Servings scaling UI** — same gap as iOS; the API has no first-class
-  support yet (see "Servings scaling" below), the meal editor only exposes the
-  per-recipe `scale` factor
-- [ ] **Re-ingest from the recipe page** — blocked on the same "Re-parse
-  endpoint" item below
+- [ ] **Servings scaling UI** — same gap as iOS, and blocked on the same
+  missing API ([#53](https://github.com/marco308/meals/issues/53)); the meal
+  editor only exposes the per-recipe `scale` factor
+- [ ] **Re-ingest from the recipe page** — blocked on the re-parse endpoint
+  ([#54](https://github.com/marco308/meals/issues/54))
 - [x] ~~**Marketing site mention**~~ — ✅ `docs/` sells it now ("Web ships in
   the box: your server serves the web app itself at `/app`")
 
@@ -42,18 +42,18 @@ what it deliberately doesn't do yet:
 
 - [x] ~~**Password reset**~~ — ✅ shipped (Q20): `POST /auth/password-reset` emails a typeable code, `POST /auth/password/reset-confirm` redeems it. Needs SMTP configured — `SMTP_HOST`, `SMTP_FROM`, and usually `SMTP_USERNAME`/`SMTP_PASSWORD` — or the endpoint returns 503 saying so, and `GET /client-config` reports which way it went as `password_reset_enabled`. **Live on the deployment since 13 Aug 2026**, relayed through Resend on the verified `marcuslab.uk` domain
 - [x] ~~**Account deletion**~~ — ✅ shipped (Q20): `DELETE /auth/me`, and in the app's account menu, which is what App Store review actually requires
-- [ ] **Household admin** — inviting someone is now a button (Settings → Invite someone), but that's still all: no rename after signup, no way to leave a household without deleting your account, no way to remove someone you invited by mistake, no list of who's in it, and the iOS register screen can't set `household_name` (it takes the "Home" default)
+- [ ] **Household admin** — [#52](https://github.com/marco308/meals/issues/52). Inviting is a button; renaming, leaving, removing a member and even listing who's in it are not. The tenancy is done (Q19), the product on top of it isn't
 
 ## Next (product tail from the plan)
 
 - [ ] **Cooked → release ingredients** (F2 nice-to-have): marking a meal cooked optionally checks off / removes its outstanding list items
-- [ ] **Un-cook** — no way to undo a mistaken "cooked" today (v1 accepted this; it already bit us once). Now also wrong in the cooked history: a mis-tap permanently inflates `times_cooked`. The fix is to delete the `cooked_events` rows for that plan-meal and re-derive the counters (`app/services/cooking.py` already recomputes rather than increments)
-- [ ] **Servings scaling** — scale a recipe's quantities when adding to a meal ("×2 for batch cooking"); skill/prompt pack tells AIs to confirm scaling, the API has no first-class support
-- [ ] **Archived shopping lists in iOS** — API has `GET /shopping-list/archived`; no screen for "what did we buy last week"
-- [ ] **Re-parse endpoint** — refresh a cached recipe from its URL on demand (edits win; needs an explicit force flag)
-- [ ] **Duplicate ingredients in iOS** — `GET /ingredients/duplicates` and the merge endpoint clean the catalogue up (Q21), and the MCP exposes both, but the app has no screen for it: today the tidy-up only happens if you ask an AI
+- [ ] **Un-cook** — [#51](https://github.com/marco308/meals/issues/51). No way to undo a mistaken "cooked", so a mis-tap permanently inflates `times_cooked`. v1 accepted this; the cooked history made it a correctness problem
+- [ ] **Servings scaling** — [#53](https://github.com/marco308/meals/issues/53). The skill tells AIs to confirm scaling, the API has no first-class support
+- [ ] **Archived shopping lists in iOS** — [#56](https://github.com/marco308/meals/issues/56). `GET /shopping-list/archived` exists, the screen doesn't
+- [ ] **Re-parse endpoint** — [#54](https://github.com/marco308/meals/issues/54). Refresh a cached recipe from its URL on demand; edits still win
+- [ ] **Duplicate ingredients in iOS** — [#57](https://github.com/marco308/meals/issues/57). API, MCP and web all have it (Q21); on the phone the tidy-up only happens if you ask an AI
 - [ ] **One ingredient, two units on the list** — folding names (Q21) makes "mint" one ingredient, but "1 bunch" and "10 g" are still two lines, because merging is exact-unit-only by design (Q2). Converting bunches to grams means guessing at densities, which is the wrong fix; grouping an ingredient's lines together in the iOS list is the right one
-- [ ] **Premium/budget browse screen in iOS** — `GET /ingredients?value_tier=premium` and the MCP `list_ingredients_by_value` read the tagged set back (Q17); the app only shows a tier on ingredients you happen to open
+- [ ] **Premium/budget browse screen in iOS** — [#58](https://github.com/marco308/meals/issues/58). The verdicts (Q17) are readable through the API and the MCP, but write-only in practice on the client you'd use in the shop
 - [ ] **iOS offline breadth** — plan and recipe library are online-only by design (Q11); cache read-only copies so the whole app opens signal-less
 - [x] ~~**Remote MCP multi-user auth**~~ — ✅ shipped (issue #6): the stack serves streamable HTTP at `https://meals.marcuslab.uk/mcp` and forwards each caller's own bearer PAT per request; stdio stays for local dev
 - [ ] **MCP OAuth** — [#8](https://github.com/marco308/meals/issues/8). claude.ai custom connectors want OAuth; the remote MCP is bearer-header-only today
@@ -74,6 +74,6 @@ what it deliberately doesn't do yet:
 - [ ] **Image pipeline** — images are built on the swarm node by hand; a registry (or at least a pinned tag scheme) would make rollbacks sane
 - [ ] **Rate limiting is per-process in-memory** — fine for one replica; revisit if the API ever scales out
 - [x] ~~**Ingredient-line parser tail**~~ — ✅ the regex learned the `<n> <food> <unit>` shape (Q21): "3 garlic cloves" is now 3 cloves of garlic rather than ×3 of an ingredient called "garlic cloves", except where the last word is load-bearing ("2 bay leaves")
-- [ ] **Ingestion has no response-size cap** — `fetch_page` reads the whole body into memory with only the 15s timeout as a bound; a pathological page is a memory spike. Wants a streamed read with a byte ceiling (a few MB covers any real recipe page)
+- [ ] **Ingestion has no response-size cap** — [#55](https://github.com/marco308/meals/issues/55). `fetch_page` reads the whole body into memory with only the timeout as a bound; the last unbounded input on a path that takes a user-supplied URL
 - [x] ~~**Flaky provision password test**~~ — ✅ fixed by asserting on the alphabet rather than on one draw from it: `8` is gone from `PASSWORD_ALPHABET`, and the test now checks that `PASSWORD_ALPHABET` and `AMBIGUOUS_CHARACTERS` are disjoint, which a re-introduced look-alike can't slip past
 - [ ] **Demo/test data hygiene in prod** — if a smoke-test account was used during deploy verification, remove it. Since Q19 a stray registration lands in its own empty household rather than the family's, so this is now tidiness rather than exposure; the Apple Review account made by `python -m app.provision` is the deliberate version of the same thing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,32 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 
 ## Unreleased
 
+Nothing merged since the last deploy.
+
+## 2026-08-13 — password reset, live
+
+Deployed to `meals.marcuslab.uk`. No migration.
+
+### Added
+
+- `GET /client-config` now publishes `password_reset_enabled`, so a client can
+  tell whether the server it is pointed at can send email at all rather than
+  offering a "Forgot password?" link that always 503s. Self-hosted servers
+  without SMTP are the normal case, not the broken one.
+
+### Changed
+
+- **Password reset works on the deployment.** `SMTP_*` is configured against
+  Resend on the verified `marcuslab.uk` domain, so `POST /auth/password-reset`
+  emails a code instead of returning 503. Closes
+  [#7](https://github.com/marco308/meals/issues/7).
+
+## 2026-08-06 — the web app, policy pages, and the 2.1(a) fix
+
+Deployed to `meals.marcuslab.uk`. No migration. This is the deploy that App
+Review's second look landed on, and the one that carried everything merged
+since 25 July.
+
 ### Added
 
 - **A web app**, served by the API itself at `/app` (`web/` in the repo) — the
@@ -59,9 +85,35 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 - CI now checks `/privacy` and `/support` against the built image. They render
   markdown that is COPYed into the image separately from `app/`, so forgetting
   them is a live App Store listing pointing at a 404.
+- **Per-store aisle orders** (`/supermarkets`). A household can save a walking
+  order per shop and pick the active one in settings; that order drives the
+  shopping-list sort and `GET /aisles`, which is how iOS learns a new order
+  without an app update. The emoji vocabulary itself stays central. An order
+  saved before an aisle existed gains it at the end, so adding an aisle can
+  never invalidate a saved supermarket.
+- **❄️ Chilled**, walking between meat & fish and dairy: houmous, fresh dips
+  and fresh pasta had no shelf and fell to ❓, or worse, mis-filed under dry
+  goods on the bare "pasta" keyword. A data migration re-files ❓ rows with
+  those exact names and never touches a tag a person set.
+- **Ingredient rename** in both clients. A name is the identity key (every
+  write finds-or-creates by its folded form, Q21), so this resolves what the
+  typed name folds to rather than PATCHing the column: same row, existing row
+  (a merge, which asks first), or a free name (created carrying this row's
+  aisle, staple flag and verdict). References follow in every case, so recipes,
+  meals and old shops never dangle. No API change; both clients orchestrate the
+  lookup, POST and merge the skill already teaches.
+- Sorting the ingredient catalogue by aisle or by value verdict, not just name.
 
 ### Changed
 
+- **The duplicates dialog lets you pick the keeper** instead of fixing one per
+  group: every spelling gets a radio with the suggested keeper pre-selected,
+  per-row curation shown, and a warning when the pick isn't the canonical name
+  (new writes would quietly recreate the row you just merged away). Each
+  catalogue row also gains a manual "merge…" picker for the pairs the finder
+  deliberately won't claim (Q21).
+- 🥛 is now plain **Dairy**, not "Dairy & eggs". UK stores don't chill eggs.
+- The staples check shows only staples, which is what it says on the button.
 - The iOS app now defaults to `https://meals.marcuslab.uk` rather than
   `http://localhost:8000`. A public download that opens on a dead localhost URL
   looks broken; the field is still editable, which is the whole point of a
@@ -71,13 +123,32 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 - Account settings (password, sign-out, deletion) moved out of the Plan tab's
   overflow menu into a Settings tab. App Review expects account deletion to be
   findable, and buried in a plan menu it was findable by neither them nor a user.
-- iOS marketing version 0.1 → **1.0**, build 15 → **17**, and
-  `current_ios_build` with it. A build can only attach to an App Store version
-  record whose version string it matches, which makes every 0.1 build
-  TestFlight-only forever.
+- iOS marketing version 0.1 → **1.0**, build 15 → **23** over the course of
+  this window, and `current_ios_build` with it. A build can only attach to an
+  App Store version record whose version string it matches, which makes every
+  0.1 build TestFlight-only forever. Per-build detail is in
+  [ios/CHANGELOG.md](ios/CHANGELOG.md); **1.0 carrying build 23 was approved
+  2026-08-12** and is on the App Store.
 
 ### Fixed
 
+- **The stale-connection 500 that got 1.0 rejected under guideline 2.1(a).**
+  The engine was built with no `pool_pre_ping` and no `pool_recycle`, so the
+  pool kept Postgres connections the swarm's overlay network had already
+  dropped as idle, and the first request after a quiet spell got one. On a
+  low-traffic server that is a real category of user, and one morning it was
+  App Review. `/healthz` touches no database, so the healthcheck gating the
+  zero-downtime rollout stayed green through four of these in 24 hours.
+  Postgres only: recycling in-memory SQLite would discard the tests' schema.
+  Full diagnosis at
+  [ios/CHANGELOG.md](ios/CHANGELOG.md#the-21a-rejection).
+- **A successful sign-in no longer spends the brute-force budget.** The other
+  half of the same incident: the reviewer's retries after the 500 hit
+  `auth_rate_limit_per_minute`, so they locked themselves out of their own
+  account purely by trying again. Brute force is a stream of failures, so a
+  success now refunds its attempt. Per-IP keying would not have helped, since
+  one person retrying ten times exhausts their own bucket however precisely
+  you identify them.
 - **The app claimed to support iPad.** `TARGETED_DEVICE_FAMILY: "1"` was set at
   the project level in `ios/Meals/project.yml`, but xcodegen writes `"1,2"`
   onto every iOS target and a target setting beats a project one — so every

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ is what keeps the API complete and the views consistent.
 | `ios/Meals/` | SwiftUI app (Swift 6, strict concurrency). Offline-first shopping list |
 | `mcp/` | MCP server: a thin task-level wrapper over the REST API, no DB access |
 | `skill/` | `SKILL.md` + `prompt-pack.md` — served live by the backend at `/skill` and `/prompt-pack` |
-| `planning/` | Product plan and the **decisions log** (`04-open-questions.md`) that code comments cite as Q1–Q20 |
+| `planning/` | The **decisions log** (`04-open-questions.md`) that code comments cite as Q1–Q22, kept live. The rest is the original plan, kept as history, not a roadmap |
 | `docs/` | Public marketing site for **YAMP** (GitHub Pages: hand-written HTML + CSS plus real screenshots from `make ios-screenshots`, no build step, no external requests). Strategy in `planning/06-marketing.md`; public name is YAMP but code identifiers and the `X-Meals-Client` header never change |
 
 Backend layering: `routers/` (HTTP + auth + commit boundaries) → `services/`

--- a/planning/05-status.md
+++ b/planning/05-status.md
@@ -1,5 +1,13 @@
 # 05 — Build Status (2026-07-24)
 
+> **A snapshot, deliberately not maintained.** This records that the plan in
+> `01`–`03` was actually built, as it stood at the first deployment. It is
+> evidence, not a status page, so the numbers below are the numbers of that
+> day and are left alone. For what the thing does *now*: shipped work is in
+> [../CHANGELOG.md](../CHANGELOG.md), what's left is in
+> [../BACKLOG.md](../BACKLOG.md) and
+> [GitHub issues](https://github.com/marco308/meals/issues).
+
 Traceability from the plan to what's built. Evidence: 201 backend tests (98%
 coverage), 34 iOS tests, 11 MCP tests — all green — plus live verification in
 the iPhone simulator against the Docker stack (including an offline round-trip
@@ -64,7 +72,7 @@ explicitly so multi-tenancy stays cheap later).
 | FastAPI + async SQLAlchemy + Alembic, one container (Q9) | ✅ | `make dev` (Docker: Postgres+API), `make run` (SQLite, zero deps) |
 | Postgres (Q10) | ✅ | compose stack; full flows verified live on Postgres |
 | Native SwiftUI iOS, offline list hard requirement (Q11) | ✅ | queued ops, disk persistence, relaunch survival, ordered replay w/ id-remapping — proven with the API stopped |
-| Public exposure via Swarm+Traefik on `*.marcuslab.uk` (Q12) | ✅ | **deployed 2026-07-24**: `https://meals.marcuslab.uk` (swarm stack behind Traefik, Postgres 17, Cloudflare-resolved TLS); `make deploy` redeploys. Registration is open and safe to leave open since Q19 — a signup creates its own household |
+| Public exposure via Swarm+Traefik on `*.marcuslab.uk` (Q12) | ✅ | **deployed 2026-07-24**: `https://meals.marcuslab.uk` (swarm stack behind Traefik, Postgres 17, Cloudflare-resolved TLS); `make deploy` redeploys. Q19 made open registration *safe* (a signup creates its own household), though this deployment sets `REGISTRATION_ENABLED=false` anyway and admits people by invite |
 | Remote MCP over HTTPS (Q15) | ✅ | the public API is live, so MCP works remotely today with `MEALS_API_URL=https://meals.marcuslab.uk` + a PAT (stdio or streamable-HTTP per instance); a single hosted multi-user MCP endpoint stays on the backlog |
 | Open-source readiness | ✅ | AGPL-3.0 with an `ios/` carve-out for the App Store, CONTRIBUTING + SECURITY policies, permissive deps, env config, no machine-specific config in the repo (see Q19 for the tenancy fix that made publishing safe) |
 
@@ -77,7 +85,7 @@ sharing, imports.
 
 `https://meals.marcuslab.uk` — swarm stack behind Traefik, deployed with
 `make deploy` (the stack file is local-only and gitignored; `docker-compose.yml`
-is the public reference). Verified live: health, docs, auth guard, TLS.
-Post-deploy tail (see BACKLOG.md): deploy the Q19 tenancy change; point the iOS
-app at the domain; add a pg_dump backup. The plan is now fully implemented and
-live.
+is the public reference). Verified live: health, docs, auth guard, TLS. The
+plan is now fully implemented and live. The post-deploy tail as it stood that
+day (Q19 tenancy, pointing iOS at the domain, backups) has since been worked
+through or moved to the tracker — see [../BACKLOG.md](../BACKLOG.md).

--- a/planning/README.md
+++ b/planning/README.md
@@ -1,11 +1,20 @@
 # Meal Planning & Shopping List App — Planning
 
-Planning docs for the app described in `../init.md`.
+The planning docs this app was built from. The brief they were written against
+(`init.md`) is not in this repo; the principles it set out are restated below.
 
-> ✅ **BUILT & DEPLOYED (2026-07-24).** The MVP cut is implemented, tested,
-> verified, and live at `https://meals.marcuslab.uk` (swarm stack behind
-> Traefik). Item-by-item traceability in [05-status.md](05-status.md);
-> remaining tail in [../BACKLOG.md](../BACKLOG.md).
+> ✅ **BUILT, DEPLOYED, AND SHIPPED.** The MVP cut is implemented, tested and
+> live at `https://meals.marcuslab.uk` (swarm stack behind Traefik), and the
+> iPhone app has been on the App Store as 1.0 since 2026-08-12. Item-by-item
+> traceability as of the first deploy in [05-status.md](05-status.md); what
+> has shipped since in [../CHANGELOG.md](../CHANGELOG.md); what's left in
+> [../BACKLOG.md](../BACKLOG.md) and
+> [GitHub issues](https://github.com/marco308/meals/issues).
+>
+> These files are **history, not a roadmap**, with one exception:
+> [04-open-questions.md](04-open-questions.md) is the live decisions log that
+> code comments cite by number (Q1–Q22), so it is maintained and must never
+> be turned into issues.
 
 ## Documents
 
@@ -15,14 +24,14 @@ Planning docs for the app described in `../init.md`.
 | [02-architecture.md](02-architecture.md) | High-level architecture: backend, API, data model concepts, hosting, frontend |
 | [03-ai-integration.md](03-ai-integration.md) | The BYO-AI strategy: MCP vs skill vs plain API, recipe parsing ownership |
 | [04-open-questions.md](04-open-questions.md) | **Decisions log** — all questions answered; Q16 implemented as assumed |
-| [05-status.md](05-status.md) | **Build status** — plan→implementation traceability with evidence |
+| [05-status.md](05-status.md) | **Build status** — plan→implementation traceability with evidence, frozen at the first deploy |
 | [06-marketing.md](06-marketing.md) | **Marketing & monetisation** — YAMP positioning, pricing, launch plan; the strategy behind the landing page in `docs/` |
 
 ## Product one-liner
 
 A meal *options* planner (not a rigid Mon–Sun grid) with a recipe library and an aisle-sorted shopping list, exposed through an AI-friendly API so users can drive it with their own AI assistant.
 
-## Guiding principles (from init.md)
+## Guiding principles (from the original brief)
 
 1. **Flexible plans, not schedules.** The plan is a pool of meal options ("dinners this week: spag bol, cottage pie"), not a calendar. Plans changing (e.g. an unexpected London trip) must not require any re-planning work.
 2. **Parse a recipe once, reuse forever.** Recipe URLs are ingested, structured, and cached.
@@ -40,9 +49,15 @@ A meal *options* planner (not a rigid Mon–Sun grid) with a recipe library and 
 - **AI layer:** OpenAPI REST API + remote MCP (HTTPS, per-user tokens) + skill/prompt pack; works with any LLM
 - Full record in [04-open-questions.md](04-open-questions.md)
 
-## Next steps
+## How the plan closed out
 
-1. ✅ ~~Marcus confirms **Q16**~~ — implemented as assumed (users share one household; household modelled explicitly so multi-tenancy stayed cheap). Amended by **Q19**: registration now creates a new household and joining one needs an invite.
-2. ✅ ~~Design doc: data model + API spec~~ — superseded by the implementation; the OpenAPI spec at `/openapi.json` is the API contract, and the offline-sync contract (client ids, LWW, idempotent adds) is implemented and tested.
-3. ✅ ~~Repo scaffolding (`backend/`, `ios/`, `mcp/`, `skill/`) and build~~ — all four built and verified; see [05-status.md](05-status.md).
-4. ✅ ~~Deploy to the homelab~~ — live at `https://meals.marcuslab.uk` (`make deploy`). Remaining: deploy the Q19 tenancy change.
+Every step this section once tracked is done, and is recorded here rather than
+deleted so the plan can be read end to end.
+
+1. **Q16** — implemented as assumed (users share one household; household modelled explicitly so multi-tenancy stayed cheap). Amended by **Q19**: registration now creates a new household and joining one needs an invite.
+2. **Design doc: data model + API spec** — superseded by the implementation. The OpenAPI spec at `/openapi.json` is the API contract, and the offline-sync contract (client ids, LWW, idempotent adds) is implemented and tested.
+3. **Repo scaffolding (`backend/`, `ios/`, `mcp/`, `skill/`) and build** — all four built and verified; see [05-status.md](05-status.md). `web/` joined them later.
+4. **Deploy to the homelab** — live at `https://meals.marcuslab.uk` (`make deploy`), Q19 tenancy included.
+
+New work does not get added here. It goes to
+[GitHub issues](https://github.com/marco308/meals/issues).


### PR DESCRIPTION
## What and why

A review of the repo's markdown for entries that had gone stale or were doing the issue tracker's job. Docs only, no code.

BACKLOG.md held roughly 25 open checkboxes against 4 open issues. Two of those issues were restated in the backlog at greater length than the issue itself, and three backlog lines described work that was already finished, including the App Store submission that has been live since 2026-08-12. A file that is wrong about the past does not get consulted about the future.

**Filed as issues** and reduced to one linked sentence each: #51 un-cook, #52 household admin, #53 servings scaling, #54 re-parse endpoint, #55 ingestion size cap, #56 archived lists in iOS, #57 duplicate cleanup in iOS, #58 value-verdict browse in iOS. Postgres backups and MCP OAuth now link to #9 and #8 instead of duplicating them.

**Deliberately not filed**, and still described in full in the backlog: the deferred product tail (imports, notifications, F5), and the debt entries that exist to explain why the current state is intended rather than to request work (no iOS CI because macOS runners bill per minute; deploys from a laptop because GitHub runners can't reach the homelab).

**CHANGELOG.md had missed two deploys.** The web app, the policy pages, per-store aisle orders, ingredient rename and the 2.1(a) connection-pool fix were all sitting under Unreleased while serving production traffic, which inverts the file's own rule that released means live on the deployment. They now have dated 2026-08-06 and 2026-08-13 sections, along with the six merges between 1 and 6 August that never got an entry at all. Both dates are backed by evidence rather than guessed: the 08-06 cut from the deploy recorded in `ios/AppStore/resolution-center.md`, the 08-13 one from `password_reset_enabled` being true on the live `/client-config`; and the deployed OpenAPI carries `/supermarkets` and `/ingredients/{id}/merge`, so the tree those sections describe really is the running one.

**planning/ is labelled history, not a roadmap**, with `04-open-questions.md` called out as the exception that stays live because code cites it by number. `05-status.md` is now explicitly a snapshot, so its "201 backend tests" reads as evidence of that day rather than a number to chase (it is 362 now), and it no longer claims registration is open on a deployment that has `REGISTRATION_ENABLED=false`.

Also fixed: a dead link to an `init.md` this repo has never contained, and CLAUDE.md citing Q1–Q20 when the decisions log runs to Q22.

## Checklist

Docs only. No API, model, query, skill or error-string changes, so every invariant on the template is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)