### PR TITLE
Port the MCP server to SDK 2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,13 @@ do instead (see the 409 in `routers/shopping.py` for the shape).
 The MCP server (`mcp/meals_mcp/server.py`) runs in two modes: **stdio** with
 `MEALS_API_TOKEN` from the env, and **http** (deployed at `/mcp`) which holds
 no credentials and forwards each request's `Authorization` header to the API
-verbatim — never add a server-side token fallback in http mode.
+verbatim — never add a server-side token fallback in http mode. That header
+reaches the tools through the `_capture_caller_headers` middleware, which
+publishes them in a contextvar for the life of the request: SDK 2.0 only hands
+the request context to a handler that declares a `Context` parameter, and the
+alternative is threading one through all 27 tools and their helpers. Keep the
+middleware registered — without it every remote call silently drops to the
+stdio env-token path.
 
 `skill/` is shipped inside the backend image (hence `docker build` uses the
 **repo root** as context, not `backend/`) and served unauthenticated with

--- a/mcp/meals_mcp/server.py
+++ b/mcp/meals_mcp/server.py
@@ -21,10 +21,12 @@ Config (env):
 
 import os
 import uuid
+from collections.abc import Awaitable, Callable, Mapping
+from contextvars import ContextVar
 from typing import Any
 
 import httpx
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer, ServerRequestContext
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
 
@@ -34,8 +36,35 @@ from starlette.responses import PlainTextResponse, Response
 # tell an assistant its installed skill snapshot has gone stale.
 PLAYBOOK_VERSION = 12
 
-mcp = FastMCP(
+# The caller's HTTP headers for the request being served, or None over stdio
+# (and in direct tool-function calls), where env-token auth applies.
+#
+# The SDK used to expose the live request through a contextvar of its own
+# (mcp.server.lowlevel.server.request_ctx, read via FastMCP.get_context());
+# since SDK 2.0 a handler only sees the request context if it declares a
+# Context parameter, which every tool and every helper below would have to
+# thread through. _capture_caller_headers puts it back in one place, and the
+# contextvar is now ours rather than an SDK internal that can move again.
+_caller_headers_var: ContextVar[Mapping[str, str] | None] = ContextVar("meals_caller_headers", default=None)
+
+
+async def _capture_caller_headers(
+    context: ServerRequestContext[Any, Any],
+    call_next: Callable[[ServerRequestContext[Any, Any]], Awaitable[Any]],
+) -> Any:
+    """Server middleware: publish this request's headers for the duration of
+    the handler. `context.request` is the Starlette request over streamable
+    HTTP and None over stdio."""
+    token = _caller_headers_var.set(getattr(context.request, "headers", None))
+    try:
+        return await call_next(context)
+    finally:
+        _caller_headers_var.reset(token)
+
+
+mcp = MCPServer(
     "meals",
+    middleware=[_capture_caller_headers],
     instructions=(
         f"Meal planning and shopping tools. Playbook v{PLAYBOOK_VERSION} is current: if "
         "an installed meal-planner skill or prompt pack states a lower version, it is "
@@ -51,22 +80,20 @@ class ApiError(Exception):
     """Raised with the backend's rich error text so the assistant can act on it."""
 
 
-def _http_request() -> Request | None:
-    """The live HTTP request when serving streamable HTTP; None over stdio
-    (and in direct tool-function calls), where env-token auth applies."""
-    try:
-        return mcp.get_context().request_context.request
-    except ValueError:
-        return None
+def _caller_headers() -> Mapping[str, str] | None:
+    """The connecting client's HTTP headers when serving streamable HTTP; None
+    over stdio (and in direct tool-function calls), where env-token auth
+    applies."""
+    return _caller_headers_var.get()
 
 
 def _client() -> httpx.AsyncClient:
-    request = _http_request()
-    if request is not None:
+    caller_headers = _caller_headers()
+    if caller_headers is not None:
         # Remote mode: act as the connecting user. Forward their bearer header
         # verbatim and never fall back to a server-side token — a baked-in
         # token would make every client act as that token's owner.
-        auth = request.headers.get("authorization")
+        auth = caller_headers.get("authorization")
         headers = {"Authorization": auth} if auth else {}
     else:
         token = os.environ.get("MEALS_API_TOKEN", "")
@@ -82,7 +109,7 @@ async def _call(method: str, path: str, **kwargs: Any) -> Any:
     async with _client() as client:
         response = await client.request(method, path, **kwargs)
     if response.status_code == 401:
-        if _http_request() is not None:
+        if _caller_headers() is not None:
             raise ApiError(
                 "authentication failed: connect to this MCP server with an "
                 "'Authorization: Bearer <token>' header — create a personal API "
@@ -833,21 +860,32 @@ async def healthz(request: Request) -> Response:
     return PlainTextResponse("ok")
 
 
-def _configure_http_mode() -> None:
-    """Remote-mode settings. Bind beyond loopback (Traefik fronts us), drop the
-    SDK's localhost-only DNS-rebinding allowlist (the Host header is the public
-    domain), and go stateless so restarts and replicas never strand a session."""
-    mcp.settings.host = os.environ.get("MEALS_MCP_HOST", "0.0.0.0")
-    mcp.settings.port = int(os.environ.get("MEALS_MCP_PORT", "8000"))
-    mcp.settings.stateless_http = True
-    mcp.settings.transport_security = None
+def http_app_settings() -> dict[str, Any]:
+    """Remote-mode settings for the streamable-HTTP app. Bind beyond loopback
+    (Traefik fronts us), and go stateless so restarts and replicas never strand
+    a session.
+
+    transport_security=None drops the SDK's DNS-rebinding allowlist, which it
+    would otherwise auto-enable — but only for a loopback host, so passing the
+    real bind address is what disables it. Our Host header is the public domain,
+    not localhost. Since SDK 2.0 these are per-app arguments rather than
+    mutations of a settings object, so the tests build the app through this
+    same function to get the deployed configuration."""
+    return {
+        "host": os.environ.get("MEALS_MCP_HOST", "0.0.0.0"),
+        "stateless_http": True,
+        "transport_security": None,
+    }
 
 
 def main() -> None:
     transport = os.environ.get("MEALS_MCP_TRANSPORT", "stdio")
     if transport == "http":
-        _configure_http_mode()
-        mcp.run(transport="streamable-http")
+        mcp.run(
+            transport="streamable-http",
+            port=int(os.environ.get("MEALS_MCP_PORT", "8000")),
+            **http_app_settings(),
+        )
     else:
         mcp.run()
 

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,12 +4,13 @@ version = "0.1.0"
 description = "MCP server wrapping the Meals REST API with task-level tools for AI assistants"
 requires-python = ">=3.12"
 dependencies = [
-    "mcp>=1.2",
+    "mcp>=2.0",
     "httpx>=0.27",
 ]
 
 [dependency-groups]
 dev = [
+    "httpx2>=2.5",
     "pytest>=8.2",
     "pytest-asyncio>=0.23",
     "respx>=0.21",

--- a/mcp/tests/test_remote.py
+++ b/mcp/tests/test_remote.py
@@ -6,15 +6,15 @@ themselves. stdio mode (no HTTP request context) keeps the env-token path —
 covered by test_tools.py.
 """
 
-from contextlib import asynccontextmanager, contextmanager
+from contextlib import asynccontextmanager
 
 import httpx
+import httpx2
 import pytest
 import respx
 from mcp import ClientSession
 from mcp.client.streamable_http import streamable_http_client
-from mcp.server.lowlevel.server import request_ctx
-from mcp.shared.context import RequestContext
+from mcp.server import ServerRequestContext
 
 from meals_mcp import server
 
@@ -39,55 +39,65 @@ class _FakeRequest:
         self.headers = httpx.Headers(headers)
 
 
-@contextmanager
-def _fake_http_request(headers: dict[str, str]):
-    token = request_ctx.set(
-        RequestContext(
-            request_id="t1",
-            meta=None,
-            session=None,
-            lifespan_context=None,
-            request=_FakeRequest(headers),
-        )
+async def _call_over_http(headers: dict[str, str], tool):
+    """Invoke a tool the way a streamable-HTTP request does: inside the
+    middleware that publishes the caller's headers. Since SDK 2.0 there is no
+    ambient request contextvar to set directly, so this drives the real
+    middleware over a request context carrying a fake request."""
+    context = ServerRequestContext(
+        # The handler never touches these; only `request` matters here.
+        session=None,
+        lifespan_context=None,
+        protocol_version="2025-06-18",
+        method="tools/call",
+        request_id="t1",
+        request=_FakeRequest(headers),
     )
-    try:
-        yield
-    finally:
-        request_ctx.reset(token)
+    return await server._capture_caller_headers(context, lambda _context: tool())
 
 
 class TestBearerForwarding:
     @respx.mock
     async def test_callers_bearer_is_forwarded_verbatim(self):
         route = respx.get(f"{API}/plans/current").mock(return_value=httpx.Response(200, json=PLAN))
-        with _fake_http_request({"Authorization": "Bearer meals_alices-pat"}):
-            result = await server.get_plan()
+        result = await _call_over_http({"Authorization": "Bearer meals_alices-pat"}, server.get_plan)
         assert "w/c 27 July" in result
         assert route.calls.last.request.headers["authorization"] == "Bearer meals_alices-pat"
 
     @respx.mock
     async def test_no_header_means_no_auth_sent_and_connect_hint(self):
         route = respx.get(f"{API}/plans/current").mock(return_value=httpx.Response(401, json={"detail": "nope"}))
-        with _fake_http_request({}):
-            result = await server.get_plan()
+        result = await _call_over_http({}, server.get_plan)
         assert "authorization" not in route.calls.last.request.headers
         assert "'Authorization: Bearer <token>'" in result
         assert "MEALS_API_TOKEN" not in result
 
+    @respx.mock
+    async def test_headers_do_not_leak_past_the_request(self):
+        """The middleware must reset the contextvar: a stdio-style call after an
+        HTTP one has to fall back to the env token, not reuse a stale bearer."""
+        route = respx.get(f"{API}/plans/current").mock(return_value=httpx.Response(200, json=PLAN))
+        await _call_over_http({"Authorization": "Bearer meals_alices-pat"}, server.get_plan)
+        await server.get_plan()
+        assert route.calls.last.request.headers["authorization"] == "Bearer meals_server-token-must-not-leak"
+
 
 @asynccontextmanager
 async def _remote_server():
-    """The real streamable-HTTP app, configured exactly as main() does."""
-    server._configure_http_mode()
-    server.mcp._session_manager = None  # run() is single-use; fresh manager per test
-    app = server.mcp.streamable_http_app()
+    """The real streamable-HTTP app, configured exactly as main() does.
+    Each streamable_http_app() call mints a fresh session manager, so tests
+    don't share one."""
+    app = server.mcp.streamable_http_app(**server.http_app_settings())
     async with server.mcp.session_manager.run():
         yield app
 
 
-def _asgi_client(app, headers: dict[str, str] | None = None) -> httpx.AsyncClient:
-    return httpx.AsyncClient(
-        transport=httpx.ASGITransport(app=app),
+def _asgi_client(app, headers: dict[str, str] | None = None) -> httpx2.AsyncClient:
+    # httpx2, not httpx: SDK 2.0 moved to it, and streamable_http_client type-checks
+    # the client it is handed. The API calls under test are still httpx (respx mocks
+    # those); these two clients never meet.
+    return httpx2.AsyncClient(
+        transport=httpx2.ASGITransport(app=app),
         base_url=MCP_BASE,
         headers=headers,
         timeout=10,
@@ -102,16 +112,12 @@ class TestStreamableHttpEndToEnd:
         async with _remote_server() as app:
             client = _asgi_client(app, headers={"Authorization": "Bearer meals_bobs-pat"})
             async with (
-                streamable_http_client(f"{MCP_BASE}/mcp", http_client=client) as (
-                    read,
-                    write,
-                    _get_session_id,
-                ),
+                streamable_http_client(f"{MCP_BASE}/mcp", http_client=client) as (read, write),
                 ClientSession(read, write) as session,
             ):
                 await session.initialize()
                 result = await session.call_tool("get_plan", {})
-        assert result.isError is False
+        assert result.is_error is False
         assert "w/c 27 July" in result.content[0].text
         assert route.calls.last.request.headers["authorization"] == "Bearer meals_bobs-pat"
 
@@ -121,11 +127,7 @@ class TestStreamableHttpEndToEnd:
         async with _remote_server() as app:
             client = _asgi_client(app)
             async with (
-                streamable_http_client(f"{MCP_BASE}/mcp", http_client=client) as (
-                    read,
-                    write,
-                    _get_session_id,
-                ),
+                streamable_http_client(f"{MCP_BASE}/mcp", http_client=client) as (read, write),
                 ClientSession(read, write) as session,
             ):
                 await session.initialize()

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -227,6 +227,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/4f/d149104195a35e2853a2fc203a8e3477747e58c80e17dda686dace174383/httpcore2-2.10.0-py3-none-any.whl", hash = "sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01", size = 83000, upload-time = "2026-08-09T09:11:29.555Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -242,12 +255,29 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/6d/a637d52449d98a6892d9a4dc0262587afdb6a66f201871842dce5a97b1c1/httpx2-2.10.0-py3-none-any.whl", hash = "sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18", size = 94355, upload-time = "2026-08-09T09:11:30.882Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -297,15 +327,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -315,9 +345,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -331,6 +374,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx2" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "respx" },
@@ -340,15 +384,28 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
-    { name = "mcp", specifier = ">=1.2" },
+    { name = "mcp", specifier = ">=2.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "httpx2", specifier = ">=2.5" },
     { name = "pytest", specifier = ">=8.2" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "respx", specifier = ">=0.21" },
     { name = "ruff", specifier = ">=0.16.2" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -469,20 +526,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic-settings"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -532,15 +575,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
-]
-
-[[package]]
-name = "python-dotenv"
-version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
@@ -742,6 +776,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Supersedes #36, which bumped `mcp` 1.28.1 → 2.0.0 and failed CI at import. This does the code port that a lockfile bump can't.

## What broke

| 1.x | 2.0 |
|---|---|
| `mcp.server.fastmcp.FastMCP` | `mcp.server.MCPServer` |
| `settings.host` / `port` / `stateless_http` / `transport_security` | per-app keyword arguments |
| `request_ctx` contextvar, read via `get_context()` | gone — a handler only sees the request context if it declares a `Context` parameter |

## Getting the caller's bearer back

The third one matters most: http mode exists to forward the connecting client's own `Authorization` header (Q15 / issue #6), and every tool reaches the API through helpers several frames below the handler. Threading a `Context` through all 27 tools plus `_find_meal` / `_resolve_recipes` / `_find_item` / `_find_ingredient` would be a large diff for no behaviour change, so a server middleware publishes the request's headers in a contextvar for the life of the request. The contextvar is ours now rather than an SDK internal that just moved, and the read sites are unchanged apart from taking headers instead of a request object.

`transport_security` is expressed differently but resolves to the same behaviour: 2.0 auto-enables the DNS-rebinding allowlist *only* for a loopback host, so binding `0.0.0.0` with `transport_security=None` is what disables it, exactly as before. `main()` and the tests now build the app through one `http_app_settings()`, so the tests exercise the deployed configuration.

## Verification

- **The wire contract is unchanged**, checked rather than assumed: the published tool list is byte-identical to 1.28.1 across all 27 tools — same descriptions, same input schemas, no output schemas introduced. 2.0 renames fields on the Python models (`isError` → `is_error`, `serverInfo` → `server_info`) but the JSON keeps its aliases, so clients see no difference.
- **Both transports smoke-tested for real**: a stdio handshake lists 27 tools; the built container answers `/healthz` and an `initialize` carrying a public `Host` header, which are the checks `deploy.sh` and the CI docker smoke run. The image is Python 3.13, so the lock resolves there too.
- `make lint` and `make test-fast` green — 532 backend, 56 mcp.

## Tests

The fake request context is rebuilt on `ServerRequestContext` and drives the real middleware instead of setting an SDK contextvar, with a new case pinning that headers don't leak past the request. The ASGI client moves to `httpx2` (2.0 depends on it and type-checks the client it's handed); the API calls under test stay on `httpx`, which is what respx mocks. The `_session_manager` reset hack is gone — `streamable_http_app()` mints a fresh manager per call.

Close #36 in favour of this once it's merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)