### PR TITLE
Disclose Apple's opt-in App Store analytics in the privacy policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,13 @@ since 25 July.
   0.1 build TestFlight-only forever. Per-build detail is in
   [ios/CHANGELOG.md](ios/CHANGELOG.md); **1.0 carrying build 23 was approved
   2026-08-12** and is on the App Store.
+- **Privacy policy** (13 Aug 2026): disclosed that the developer reads the
+  aggregated, opt-in usage statistics and crash reports Apple provides through
+  App Store Connect and Xcode. Nothing changed in the app: it still ships no
+  analytics, crash-reporting or third-party code, and the App Store privacy
+  questionnaire answers are unchanged. The policy previously implied the
+  developer saw nothing at all, which would have stopped being true the moment
+  those free Apple dashboards were opened.
 
 ### Fixed
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy policy
 
-**Last updated: 26 July 2026**
+**Last updated: 13 August 2026**
 
 Meals is a meal planner you run on your own server. The iOS app is a client:
 it talks to whichever server you point it at, and to nothing else. There is no
@@ -10,9 +10,11 @@ That shape is the whole privacy story, so it is worth being precise about it.
 
 ## The short version
 
-- The app contains **no analytics, no advertising, no tracking, no crash
-  reporting, and no third-party SDKs of any kind**. Nothing is collected about
-  you by the app's developer.
+- The app contains **no advertising, no tracking, and no third-party SDKs of
+  any kind**: no analytics or crash-reporting code ships in it. The only
+  usage information the developer ever sees is the aggregated, opt-in
+  statistics Apple offers every App Store developer, described
+  [below](#app-store-analytics-and-crash-reports).
 - Everything you enter goes to **the server you chose**, and stays there.
 - If you run that server, you hold the data and nobody else can read it.
 - You can delete your account, and everything belonging to it, from inside the
@@ -70,6 +72,27 @@ asked for:
 If you connect an AI assistant to the API with a personal token, that assistant
 sees whatever it asks for. That connection is yours to make and yours to revoke
 — delete the token and it stops working immediately.
+
+## App Store analytics and crash reports
+
+If you installed the app through the App Store or TestFlight, Apple offers its
+developer the same opt-in statistics it offers every developer: aggregated
+usage figures (installs, sessions, active devices, retention) and crash
+reports. To be clear about what that is and is not:
+
+- **It is Apple's collection, not the app's.** The app ships no analytics or
+  crash-reporting code; iOS itself gathers this for every app on the phone.
+- **It is opt-in.** Apple only shares it if you enabled *Share with App
+  Developers* when setting up your device. You can check or change this any
+  time in Settings → Privacy & Security → Analytics & Improvements.
+- **It is aggregated and anonymous.** The developer sees counts and crash
+  traces, never your identity, your Meals account, or any of your content:
+  no recipes, no lists, no plans.
+- **It never involves your server.** A self-built or sideloaded install, or an
+  opted-out device, shares nothing at all.
+
+The developer uses it for exactly what you'd hope: knowing whether the app
+crashes and roughly how many people use it.
 
 ## Who is responsible for your data
 

--- a/ios/AppStore/app-privacy.md
+++ b/ios/AppStore/app-privacy.md
@@ -60,7 +60,7 @@ app.
 Explicitly not, and worth being able to say so:
 
 - No Identifiers (no device id, no advertising id, no user id beyond the account)
-- No Usage Data (no analytics of any kind — no first-party telemetry either)
+- No Usage Data (no analytics code in the app, first- or third-party)
 - No Diagnostics (no crash reporting SDK)
 - No Location, Contacts, Health, Financial Info, Purchases, Search History,
   Browsing History, Sensitive Info, Photos, Audio
@@ -71,6 +71,21 @@ Explicitly not, and worth being able to say so:
 Nothing is combined with data from other companies' apps or sites, and nothing
 is shared with data brokers. The app never calls `ATTrackingManager`, has no
 `NSUserTrackingUsageDescription`, and needs neither.
+
+## Apple's own analytics don't change these answers
+
+The developer does read what App Store Connect offers for free: App Analytics
+(installs, sessions, active devices, retention), TestFlight metrics, and the
+opt-in crash reports that surface in Xcode's Organizer. None of it is declared
+above, deliberately: the questionnaire covers data *you or your third-party
+partners* collect, and this is Apple's own OS-level collection under Apple's
+own consent prompt ("Share with App Developers"). Apple's guidance is explicit
+that data collected by Apple is not yours to declare. The app still ships no
+analytics or crash-reporting code, so the answers stay "not collected".
+
+[PRIVACY.md](../../PRIVACY.md) discloses this to users anyway (the "App Store
+analytics and crash reports" section), because the policy speaks for the
+developer, not just the binary. Keep the two in step if either changes.
 
 ## Privacy Policy URL
 


### PR DESCRIPTION
## What and why

The privacy policy claimed the developer collects nothing at all, which would stop being true the moment the free App Store Connect dashboards (App Analytics, TestFlight metrics, Organizer crash reports) were opened. This loosens the wording honestly: the app still ships no analytics, crash-reporting or third-party code, and a new "App Store analytics and crash reports" section explains that Apple's collection is OS-level, opt-in via "Share with App Developers", aggregated, and never touches the user's server. The App Store privacy questionnaire answers are unchanged, with the reasoning recorded in `ios/AppStore/app-privacy.md`, and the change is noted in the changelog as the policy promises.

Markdown only, no code changes. Already deployed and live at https://meals.marcuslab.uk/privacy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)