### PR TITLE
iOS: hide "Forgot password?" when the server can't send email

### DIFF
--- a/ios/Meals/Meals/App/Session.swift
+++ b/ios/Meals/Meals/App/Session.swift
@@ -11,8 +11,10 @@ final class Session {
         didSet {
             UserDefaults.standard.set(serverURL, forKey: "serverURL")
             // A verdict belongs to the server that gave it — pointing the app
-            // at localhost must not inherit the homelab's floor, or vice versa.
+            // at localhost must not inherit the homelab's floor, or its ability
+            // to send email, or vice versa.
             upgrade = .ok
+            canResetPassword = true
             Task { await checkClientCompatibility() }
         }
     }
@@ -49,6 +51,13 @@ final class Session {
     }
 
     private(set) var upgrade: Upgrade = .ok
+
+    /// Whether this server can send a reset code. Optimistic until told
+    /// otherwise: the login screen is drawn before `/client-config` answers,
+    /// and offering a button that turns out to be unavailable is a better
+    /// failure than hiding one that would have worked.
+    private(set) var canResetPassword = true
+
     // Written once in init, read once in deinit (which is nonisolated), so it
     // steps outside the actor rather than dragging the rest of Session with it.
     @ObservationIgnored private nonisolated(unsafe) var upgradeObserver: (any NSObjectProtocol)?
@@ -135,6 +144,9 @@ final class Session {
     func checkClientCompatibility() async {
         guard let config = try? await api.clientConfig() else { return }
         upgrade = Upgrade(config: config, build: ClientIdentity.buildNumber)
+        // Absent means an older server that never published the key, and those
+        // do send reset codes — so only an explicit false takes the button away.
+        canResetPassword = config.passwordResetEnabled ?? true
     }
 
     func dismissUpgradeNudge() {

--- a/ios/Meals/Meals/Models/Models.swift
+++ b/ios/Meals/Meals/Models/Models.swift
@@ -127,6 +127,11 @@ struct ClientConfig: Codable, Equatable, Sendable {
     let minIosBuild: Int
     let currentIosBuild: Int
     let upgradeUrl: String?
+    /// Whether this server can send email at all. Optional is load-bearing: a
+    /// server older than this build doesn't send the key, and absent has to
+    /// mean "assume it works" rather than a decode failure that would take the
+    /// whole config — including the upgrade floor — down with it.
+    let passwordResetEnabled: Bool?
 }
 
 struct RecipeSummary: Codable, Identifiable, Equatable, Sendable {

--- a/ios/Meals/Meals/Views/LoginView.swift
+++ b/ios/Meals/Meals/Views/LoginView.swift
@@ -70,7 +70,11 @@ struct LoginView: View {
                     }
                     .font(.callout)
 
-                    if !isRegistering {
+                    // Hidden on a server with no SMTP configured, which is the
+                    // normal state of a fresh self-hosted one: the endpoint
+                    // 503s there, and a button that cannot work is better
+                    // hidden than explained.
+                    if !isRegistering && session.canResetPassword {
                         Button("Forgot password?") { showForgotPassword = true }
                             .font(.callout)
                     }

--- a/ios/Meals/MealsTests/ClientVersionTests.swift
+++ b/ios/Meals/MealsTests/ClientVersionTests.swift
@@ -83,13 +83,52 @@ final class ClientGateTests: XCTestCase {
             )
         }
         let config = try await client(protocolClass: StubProtocol.self).clientConfig()
-        XCTAssertEqual(config, ClientConfig(apiVersion: "0.1.0", minIosBuild: 2, currentIosBuild: 4, upgradeUrl: nil))
+        XCTAssertEqual(
+            config,
+            ClientConfig(
+                apiVersion: "0.1.0", minIosBuild: 2, currentIosBuild: 4, upgradeUrl: nil,
+                passwordResetEnabled: nil
+            )
+        )
+    }
+
+    /// A server older than the field must decode, not throw: the config also
+    /// carries the upgrade floor, so a strict decode here would blind the app
+    /// to a hard block rather than merely to a button.
+    func testClientConfigDecodesWithoutPasswordResetFlag() async throws {
+        StubProtocol.handler = { _ in
+            (
+                200,
+                Data(
+                    #"{"api_version": "0.1.0", "min_ios_build": 2, "current_ios_build": 4, "upgrade_url": null}"#.utf8
+                )
+            )
+        }
+        let config = try await client(protocolClass: StubProtocol.self).clientConfig()
+        XCTAssertNil(config.passwordResetEnabled)
+    }
+
+    func testClientConfigCarriesPasswordResetFlag() async throws {
+        StubProtocol.handler = { _ in
+            (
+                200,
+                Data(
+                    #"{"api_version": "0.1.0", "min_ios_build": 0, "current_ios_build": 0, "upgrade_url": null, "password_reset_enabled": false}"#
+                        .utf8
+                )
+            )
+        }
+        let config = try await client(protocolClass: StubProtocol.self).clientConfig()
+        XCTAssertEqual(config.passwordResetEnabled, false)
     }
 }
 
 final class UpgradeStateTests: XCTestCase {
     private func config(min: Int, current: Int, url: String? = nil) -> ClientConfig {
-        ClientConfig(apiVersion: "0.1.0", minIosBuild: min, currentIosBuild: current, upgradeUrl: url)
+        ClientConfig(
+            apiVersion: "0.1.0", minIosBuild: min, currentIosBuild: current, upgradeUrl: url,
+            passwordResetEnabled: nil
+        )
     }
 
     func testBuildBelowTheFloorIsBlocked() {


### PR DESCRIPTION
## What and why

#49. `LoginView` offered "Forgot password?" unconditionally, so on a self-hosted server with no SMTP configured it led to a 503. The string had already been softened to explain itself, but a button that cannot work is better hidden than explained.

The flag has shipped since #47. Three small pieces:

- `ClientConfig` gains `passwordResetEnabled` as an **optional** Bool. Optional is load-bearing: a server older than this build doesn't send the key, and a strict decode would fail the whole config — which also carries the upgrade floor — rather than merely lose a button. Absent means yes.
- `Session.canResetPassword` keeps it, and starts `true` for the same reason: the login screen is drawn before `/client-config` answers, and offering a button that turns out to be unavailable is a better failure than hiding one that would have worked. It is cleared alongside `upgrade` in the `serverURL` `didSet`, because a verdict belongs to the server that gave it.
- `LoginView` hides the button only on an explicit `false`.

`checkClientCompatibility()` already ran while logged out (it is a `.task` on the `WindowGroup`, outside the `isAuthenticated` branch), so no change was needed there.

## Verification

`make ios-test`: 137 pass. Three tests cover the decode: the flag present and false, the flag absent (an older server, which must decode rather than throw), and the existing equality test.

Checked in the simulator both ways, since "the button disappears" is the whole deliverable:

- against a local API with no SMTP (`"password_reset_enabled": false`) the button is absent
- against `meals.marcuslab.uk` (`true`) it is there

## Not in this PR

No `CFBundleVersion` bump. As #49 notes, this isn't worth a TestFlight build on its own and should ride the next one going up for another reason, so there is no ledger row in `ios/CHANGELOG.md` yet and **#49 stays open until it actually ships**. Worth knowing when you next bump: this change is merged and waiting, so it belongs in that build's "what's in it".

## Checklist

- [x] **API contract stayed additive** — no server change at all. The client now reads a field the server has published since #47, and tolerates its absence.

Not applicable: no model change, no shopping-list quantities touched, no new queries, no skill or 4xx string changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)