### PR TITLE
iOS: login and settings fixes from a device report

### DIFF
--- a/ios/Meals/Meals/Views/LoginView.swift
+++ b/ios/Meals/Meals/Views/LoginView.swift
@@ -52,18 +52,31 @@ struct LoginView: View {
                     }
                 }
 
+                // The primary action gets to look like one: filled, full width,
+                // on the page rather than inside a grouped card. As a plain row
+                // it read as a label, and centring the text pushed the row
+                // separator's inset to the middle of the screen, which looked
+                // like a rendering fault.
                 Section {
                     Button(action: submit) {
                         if isWorking {
-                            ProgressView().frame(maxWidth: .infinity)
+                            ProgressView()
+                                .tint(.white)
+                                .frame(maxWidth: .infinity)
                         } else {
                             Text(isRegistering ? "Create account" : "Log in")
                                 .frame(maxWidth: .infinity)
                                 .fontWeight(.semibold)
                         }
                     }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
                     .disabled(isWorking || email.isEmpty || password.isEmpty || (isRegistering && displayName.isEmpty))
+                    .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+                    .listRowBackground(Color.clear)
+                }
 
+                Section {
                     Button(isRegistering ? "I already have an account" : "Create a new account") {
                         isRegistering.toggle()
                         errorMessage = nil

--- a/ios/Meals/Meals/Views/LoginView.swift
+++ b/ios/Meals/Meals/Views/LoginView.swift
@@ -98,11 +98,17 @@ struct LoginView: View {
                 // setting. But it is the one thing nobody can guess, so it
                 // explains itself rather than sitting there unlabelled.
                 Section {
+                    // Shrinks rather than truncates: at accessibility text
+                    // sizes a monospaced URL outgrows the row, and a server
+                    // address cut off mid-host ("https://meals.marcusla…") is
+                    // unreadable exactly when someone is trying to check it.
                     TextField("Server URL", text: $session.serverURL)
                         .keyboardType(.URL)
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled()
                         .font(.callout.monospaced())
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.5)
                     Link(destination: AppLinks.support(server: session.serverURL)) {
                         Label("How do I get a server?", systemImage: "questionmark.circle")
                             .font(.callout)

--- a/ios/Meals/Meals/Views/LoginView.swift
+++ b/ios/Meals/Meals/Views/LoginView.swift
@@ -110,8 +110,17 @@ struct LoginView: View {
                         .lineLimit(1)
                         .minimumScaleFactor(0.5)
                     Link(destination: AppLinks.support(server: session.serverURL)) {
-                        Label("How do I get a server?", systemImage: "questionmark.circle")
-                            .font(.callout)
+                        // Not a Label: at accessibility sizes its default
+                        // layout puts the icon alone on the first line and
+                        // wraps the text underneath it. Aligning to the first
+                        // baseline keeps the icon beside the text and lets the
+                        // text wrap in its own column.
+                        HStack(alignment: .firstTextBaseline, spacing: 8) {
+                            Image(systemName: "questionmark.circle")
+                            Text("How do I get a server?")
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                        .font(.callout)
                     }
                 } header: {
                     Text("Server")

--- a/ios/Meals/Meals/Views/SettingsView.swift
+++ b/ios/Meals/Meals/Views/SettingsView.swift
@@ -46,14 +46,21 @@ struct SettingsView: View {
                 // able to ask", not "you're signed out".
                 Text("Signed in").foregroundStyle(.secondary)
             }
-            Button("Change password…") { showChangePassword = true }
+            Button {
+                showChangePassword = true
+            } label: {
+                Label("Change password…", systemImage: "key")
+            }
         }
     }
 
     private var householdSection: some View {
+        // Headed like Account and Shopping either side of it, so the household
+        // name reads as this group's "Name" rather than a row that repeats the
+        // word the header already says.
         Section {
             if let name = session.user?.householdName {
-                LabeledContent("Household", value: name)
+                LabeledContent("Name", value: name)
             }
             Button {
                 showInvite = true
@@ -65,6 +72,8 @@ struct SettingsView: View {
             } label: {
                 Label("Invites", systemImage: "envelope")
             }
+        } header: {
+            Text("Household")
         } footer: {
             Text(
                 "Everyone in a household shares its recipes, plan and shopping list, "


### PR DESCRIPTION
Reported from a real device, with a screenshot showing what looked like characters missing from the server address and a "Log in" that didn't read as a button.

**The missing characters were a truncation, not corrupt data.** Worth stating because the alternative was alarming: `URL(string:)` parses `https:meals.marcuslab.uk` with **host = nil**, so a request to it cannot connect. Since login worked, the stored value had to be fine. Sweeping the app at accessibility text sizes found the real mechanism — the monospaced URL outgrows its row and the field cuts it, rendering as `http://127.0.0.1…`. That's the worst field in the app to truncate: the server address is the one thing nobody can guess, and it gets read precisely when someone is checking it. It now shrinks to fit.

**"Log in" was a bare `Button` inside a `Form`**, so it rendered as plain centred text, indistinguishable from "Create a new account" below it. Centring the label also pushed the row separator's inset to mid-screen, leaving a line starting under the "L" — which is what read as a rendering fault. It's now bordered-prominent, full width, on the page background, with the secondary actions in their own section.

Two smaller things from the same sweep: the "How do I get a server?" link no longer wraps its text under its own icon at large sizes, and Settings is consistent again (the Household group gets the header its neighbours have, and "Change password…" gets an icon like every other action row).

**One item deliberately not fixed.** Recipe tag chips truncate to "comf…". The row is one line and something has to give: making the chips rigid so they'd drop whole pushed the cooking times out instead, leaving bare icons with no numbers. The existing code comment had already reasoned this through — losing a tag's tail beats losing "80 min". A second line for tags would solve it properly if it's worth the row height.

Verified enabled and disabled, light and dark, at default and accessibility text sizes. 137 iOS tests pass.
