### PR TITLE
The MCP server has 29 tools, not 21

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ verbatim — never add a server-side token fallback in http mode. That header
 reaches the tools through the `_capture_caller_headers` middleware, which
 publishes them in a contextvar for the life of the request: SDK 2.0 only hands
 the request context to a handler that declares a `Context` parameter, and the
-alternative is threading one through all 27 tools and their helpers. Keep the
+alternative is threading one through all 29 tools and their helpers. Keep the
 middleware registered — without it every remote call silently drops to the
 stdio env-token path.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ drive it with their own AI assistant. POC implementation of the plan in
   item knows which meals need it), exact-unit merging, ad-hoc items, staples
   check, "already have it", and store-walking aisle order (🥬 → 🍞 → 🥩 → …).
 - **AI access layer** — the headline: a documented REST API, an MCP server
-  with 21 task-level tools, and a skill/prompt pack the server publishes
+  with 29 task-level tools, and a skill/prompt pack the server publishes
   itself at `/skill` + `/prompt-pack`. The app ships **no built-in LLM** —
   bring your own.
 - **Households** — a household is one recipe library, plan and shopping list,

--- a/docs/index.html
+++ b/docs/index.html
@@ -200,7 +200,7 @@
 
     <div class="facts">
       <div class="fact">
-        <h4>21 task-level MCP tools</h4>
+        <h4>29 task-level MCP tools</h4>
         <p>Shaped like the job, not the database: <span class="mono">ingest_recipe</span>, <span class="mono">check_off</span>, <span class="mono">plan_meals</span>.</p>
       </div>
       <div class="fact">
@@ -224,7 +224,7 @@
       <div>
         <p class="s-label">Connect your assistant, once</p>
         <p class="s-cmd">claude mcp add --transport http yamp https://your-server/mcp</p>
-        <p class="s-note"><span class="tag green">connected · 21 tools</span> and it fetches the playbook from /skill by itself.</p>
+        <p class="s-note"><span class="tag green">connected · 29 tools</span> and it fetches the playbook from /skill by itself.</p>
       </div>
     </div>
   </div>

--- a/planning/06-marketing.md
+++ b/planning/06-marketing.md
@@ -59,7 +59,7 @@ writes. Market the product, not the protocol.
 | # | Who | Where they live | What they need to hear |
 |---|---|---|---|
 | 1 | Self-hosters / homelab | r/selfhosted, awesome-selfhosted, HN, lobste.rs, fediverse | AGPL with no asterisk, two-command start, no LLM bill hiding inside |
-| 2 | AI tinkerers | MCP directories, r/ClaudeAI, r/LocalLLaMA, X/Mastodon AI crowd | `claude mcp add` one-liner, 21 task-level tools, server publishes its own manual |
+| 2 | AI tinkerers | MCP directories, r/ClaudeAI, r/LocalLLaMA, X/Mastodon AI crowd | `claude mcp add` one-liner, 29 task-level tools, server publishes its own manual |
 | 3 | Households who just want dinner sorted | App Store, word of mouth from 1 and 2 | The app is free, the hosted tier means never hearing the word Docker |
 
 Audience 3 is where hosted revenue lives, but they arrive through the first
@@ -252,7 +252,7 @@ that outcome down as acceptable now so it never feels like failure later.
 - Honest to the point of self-deprecation; the name sets the register.
 - Say what things cost and why. Never hide the AGPL, the bus factor, or the
   fact that hosted runs on a small operation.
-- Technical claims must be checkable in the repo ("21 tools" links to the
+- Technical claims must be checkable in the repo ("29 tools" links to the
   code, "98% coverage" to CI).
 - No hype vocabulary, no exclamation marks, no em dashes.
 - When comparing to competitors, be generous by name (Mealie, Tandoor) and


### PR DESCRIPTION
`grep -c "@mcp.tool" mcp/meals_mcp/server.py` says **29**. Five places said otherwise:

| Where | Said | Why it matters |
|---|---|---|
| `README.md` | 21 | The AI layer is the headline feature and this is its first number |
| `docs/index.html` ×2 | 21 | The public landing page — both the facts grid and the "connect your assistant" panel |
| `CLAUDE.md` | 27 | The note explaining why `Context` isn't threaded through every tool |
| `planning/06-marketing.md` ×2 | 21 | The audience table, and the worked example of the rule that *"technical claims must be checkable in the repo"* — which it was itself failing |

The count went 21 → 27 with the metrics work and 27 → 29 with un-cook and re-parse (#51, #54); the prose lagged both times.

**Deliberately not changed:**

- `planning/05-status.md` still says 16. Its header says it is a snapshot from 2026-07-24, "deliberately not maintained", and that its numbers "are the numbers of that day and are left alone".
- The `CHANGELOG.md` entry saying 27 was accurate on the day it was written.

Correcting either would be rewriting a record rather than fixing a claim.

Docs only — no code, no API change, no migration.