### PR TITLE
provision.py: the account it makes leads its household

### DIFF
--- a/backend/app/provision.py
+++ b/backend/app/provision.py
@@ -73,14 +73,19 @@ async def provision(
         household = Household(name=household_name)
         db.add(household)
         await db.flush()
-        db.add(
-            User(
-                household_id=household.id,
-                email=email,
-                password_hash=hash_password(password),
-                display_name=display_name,
-            )
+        user = User(
+            household_id=household.id,
+            email=email,
+            password_hash=hash_password(password),
+            display_name=display_name,
         )
+        db.add(user)
+        await db.flush()
+        # The same rule registration follows (Q23): whoever starts a household
+        # leads it. Without this the account lands in a household with no lead
+        # and cannot invite anybody into it — which for the Apple Review account
+        # means a reviewer meeting a 403 on a button the app still offers.
+        household.lead_user_id = user.id
         await db.commit()
         return password, True
 

--- a/backend/tests/integration/test_provision.py
+++ b/backend/tests/integration/test_provision.py
@@ -41,6 +41,20 @@ class TestProvision:
         assert me.status_code == 200
         assert me.json()["household_name"] == "Apple Review"
 
+    async def test_the_account_leads_the_household_it_is_given(self, client, sessions):
+        """Q23: a household always has a lead, and here there is only one
+        candidate. Without it the reviewer meets a 403 on a button the app
+        still offers them, which is exactly the kind of thing that comes back
+        as a rejection rather than a bug report."""
+        password, _ = await provision("review@example.com", "s3cret-passphrase", "Review", "Apple Review", sessions)
+        token = await sign_in(client, "review@example.com", password)
+        headers = {"Authorization": f"Bearer {token}"}
+
+        me = await client.get("/auth/me", headers=headers)
+        assert me.json()["household_lead_user_id"] == me.json()["id"]
+        # The thing the lead is for: they can actually invite someone.
+        assert (await client.post("/auth/invites", json={}, headers=headers)).status_code == 201
+
     async def test_the_new_household_sees_none_of_the_existing_one(self, client, auth_client, sessions):
         """The reason this script exists rather than an invite: an invite would
         put the reviewer *inside* the household they're meant to be isolated from."""


### PR DESCRIPTION
Q23 gave every household a lead and gated inviting, revoking, removing and renaming on it. Two of the three places a `Household` is constructed set one:

| Where | Sets a lead? |
|---|---|
| `POST /auth/register` | ✅ whoever starts the household |
| `DELETE /auth/household/members/{id}` (the new empty household) | ✅ the person being moved |
| `python -m app.provision` | ❌ **missed** |

So the account `provision.py` creates landed in a household with **no lead**, and could never invite anybody into it.

That lands hardest on the one case the script exists for. iOS decides whether to offer the invite button by comparing `household_lead_user_id` with the user's own id, and a *missing* lead is deliberately read as "this server predates Q23, so everyone can invite" — that's what keeps build 26 working against an older server. The consequence here is the opposite of the intent: **an Apple reviewer is shown the button and meets a 403 on it.** That comes back as a rejection, not a bug report.

One line to fix, plus the test that would have caught it: the provisioned account leads its household, and can actually mint an invite.

Found while setting up the 1.1 submission, which needs that account to exist.