### PR TITLE
Turn on GitHub Sponsors, and say the app is out

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,10 +1,8 @@
 # Funding links shown on the repo's Sponsor button.
-# Both lines are commented until the accounts exist; uncommenting a line
-# whose account is not set up shows visitors a broken destination.
-# Activation steps (planning/06-marketing.md, Phase 0):
-#   1. Enroll at https://github.com/sponsors (0% platform fee for personal
-#      accounts), then uncomment the github line.
-#   2. Create the Buy Me a Coffee page, then uncomment with its slug.
-#
-# github: [marco308]
+# GitHub Sponsors is enrolled (0% platform fee for personal accounts) and the
+# profile is live at https://github.com/sponsors/marco308, so the github line
+# is active. Buy Me a Coffee stays commented until that account exists,
+# because uncommenting a line whose account is not set up shows visitors a
+# broken destination. See planning/06-marketing.md, Route 3.
+github: [marco308]
 # buy_me_a_coffee: marco308

--- a/docs/index.html
+++ b/docs/index.html
@@ -246,7 +246,7 @@
         <li>Aisle order matches how you walk the shop, produce to freezer.</li>
         <li>"Already have it" hides a line without deleting why it exists.</li>
         <li>Premium or budget is your household's own verdict per ingredient, shown at the shelf, never guessed by a keyword table.</li>
-        <li>In the repo today, built from source; App Store release on the way.</li>
+        <li>On the <a href="https://apps.apple.com/gb/app/yet-another-meal-planner/id6794266229">App&nbsp;Store</a> today, or build it from source.</li>
       </ul>
     </div>
 
@@ -318,8 +318,6 @@
         <li>First crack at TestFlight builds</li>
         <li>Warm glow, genuine gratitude</li>
       </ul>
-      <!-- Goes live once GitHub Sponsors is enabled for the account.
-           See planning/06-marketing.md, launch checklist. -->
       <a class="btn" href="https://github.com/sponsors/marco308">Sponsor on GitHub</a>
     </article>
   </div>


### PR DESCRIPTION
## What and why

Two of the three phase-0 items in #23, both of which were waiting on the account owner rather than on code.

**GitHub Sponsors is enrolled** and the profile is live (verified: `https://github.com/sponsors/marco308` returns 200), so `.github/FUNDING.yml` uncomments the `github` line and the repo grows a Sponsor button. Buy Me a Coffee stays commented because that account still does not exist. The site's Supporter card already pointed at the profile, so only its now-stale "goes live once Sponsors is enabled" comment needed removing.

**The site claimed the App Store release was "on the way"** a week after 1.0 went live (approved 2026-08-12, confirmed via the iTunes lookup API as "Yet Another Meal Planner"). That is the one claim on the page a visitor can check in a single tap, so it now links the listing.

The third item, the App Store rename, turns out to have been done on 2026-07-27 already, to "Yet Another Meal Planner" rather than the issue's "YAMP: Yet Another Meal Planner". Noted on #23; no code involved either way. PikaPods is being handled by email.

## Checklist

No API, model or client surface is touched. `docs/` and `.github/` only, so every invariant above is untouched by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)