### PR TITLE
Advertise the published image on the site

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,10 +98,10 @@ jobs:
     # nothing but the image, no database service, no environment. If the
     # single-container story is broken, it breaks here rather than in an issue.
     steps:
-      # A package pushed by GITHUB_TOKEN starts private, and stays private
-      # until someone flips it in the package settings by hand (there is no
-      # API for it). Log in so this job verifies the image either way, rather
-      # than failing on a permission the release does not depend on.
+      # These packages are public (inherited from the repo), so this login is
+      # not strictly needed today. It stays because package visibility is a
+      # setting with no API behind it, and a job that can only verify a public
+      # image is a job that breaks the day somebody changes that setting.
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,10 +358,13 @@ prove the one-container story still holds, then cuts the GitHub release. A
 failure in that verify job means the tag is public but the release is not, so
 fix forward with a new tag rather than deleting one people may have pulled.
 
-**One manual step, once, ever:** a package pushed by `GITHUB_TOKEN` is private
-no matter how public the repo is, and GitHub exposes no API to change that.
-After the first release, set both packages to public in their package settings,
-or nobody outside this account can pull the image the README advertises.
+Both packages came out **public** and anonymously pullable, inherited from the
+repo (checked against the GHCR API on the 1.0.0 tag, `linux/amd64` and
+`linux/arm64`, tags `1.0.0`, `1.0` and `latest`). That is worth re-checking if
+a release ever publishes under a different account or a private repo, because
+package visibility is a package setting with no REST endpoint behind it: the
+fix would be a manual flip in the package's settings. The release's verify job
+logs in to GHCR so it passes either way.
 
 Two properties of the image are part of the contract now, because a host may
 depend on either and neither is visible from the API:

--- a/docs/index.html
+++ b/docs/index.html
@@ -350,6 +350,13 @@
 
   <div class="run-notes">
     <p>
+      <b>No checkout? One container.</b> Every release publishes an image that
+      is the whole thing at once: the API, the web app, the skill it publishes
+      about itself, and the MCP endpoint. It defaults to SQLite, runs as an
+      ordinary user, and takes no arguments.
+    </p>
+    <p class="s-cmd">docker run -d -p 8000:8000 -v yamp-data:/data ghcr.io/marco308/meals</p>
+    <p>
       No Docker? <span class="mono">make run</span> starts the API on SQLite
       with no services at all. It runs happily on a Pi-class box or the
       cheapest VPS money rents.

--- a/planning/07-pikapods.md
+++ b/planning/07-pikapods.md
@@ -118,10 +118,12 @@ why the post above can be short about the packaging:
    answers everything. Its own image still exists for split deployments, and
    `MCP_ENABLED=false` removes the built-in one.
 
+**v1.0.0 is published**, so every claim above is checkable:
+`ghcr.io/marco308/meals:1.0.0` (also `1.0` and `latest`), amd64 and arm64,
+public, with the release at
+https://github.com/marco308/meals/releases/tag/v1.0.0.
+
 ## Still worth doing, whether or not they answer
 
-- The marketing site's "Run it" section still teaches `make up`, which needs a
-  checkout. Add the `docker run` line **after** the first release is published
-  and pullable, not before.
 - `deploy/` still builds images on the swarm node. It could pull the published
   digest instead, which is the other half of the BACKLOG's image-pipeline item.


### PR DESCRIPTION
Follow-up to #86, now that `v1.0.0` is published and pullable.

- The site's **Run it** section offers the one-container `docker run` next to the existing two-command checkout flow. Held back from #86 on purpose: no point advertising an image that did not exist yet.
- `CLAUDE.md`'s claim that a `GITHUB_TOKEN`-pushed package starts private is **wrong for this repo**. Both packages published public and pull anonymously: verified against the GHCR API on the tag (linux/amd64 + linux/arm64, tags `1.0.0`, `1.0`, `latest`). The verify job keeps its GHCR login, and the comment now says why (visibility is a setting with no API behind it).
- `planning/07-pikapods.md` points at the published image instead of a promise.

`assets/site.css` is unchanged, so the `?v=` cache-buster does not need bumping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)