### PR TITLE
Make a release tag and the version the API reports agree

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,39 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
+  # The tag is what people pull; the version in the code is what the running
+  # API reports about itself, and the deploy checks the live one against the
+  # release it deployed. v1.0.1 shipped reporting 1.0.0 because nothing made
+  # those agree, so now nothing can be released until they do.
+  version:
+    name: the code says what the tag says
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Tag, both packages and the API all say the same version
+        # Not gated with `if:` — a skipped job skips everything that needs it,
+        # which would make the workflow_dispatch dry run do nothing at all.
+        run: |
+          if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
+            echo "not a tag, nothing to check"
+            exit 0
+          fi
+          python3 - "${GITHUB_REF_NAME#v}" <<'PY'
+          import re, sys, pathlib
+          want = sys.argv[1]
+          found = {
+              "backend/pyproject.toml": re.search(r'^version = "([^"]+)"', pathlib.Path("backend/pyproject.toml").read_text(), re.M),
+              "mcp/pyproject.toml": re.search(r'^version = "([^"]+)"', pathlib.Path("mcp/pyproject.toml").read_text(), re.M),
+              "backend/app/main.py": re.search(r'^    version="([^"]+)",', pathlib.Path("backend/app/main.py").read_text(), re.M),
+          }
+          bad = {f: (m.group(1) if m else None) for f, m in found.items() if not m or m.group(1) != want}
+          for f, got in bad.items():
+              print(f"::error file={f}::says {got}, tag says {want}")
+          sys.exit(1 if bad else 0)
+          PY
+
   images:
+    needs: version
     name: build and push ${{ matrix.name }}
     runs-on: ubuntu-latest
     permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,6 +316,11 @@ in step if either moves.
   correctly does nothing. The script then asserts each service is running the
   digest it asked for, so "reported success and rolled nothing" is now a
   failure rather than a thing to notice later. It can only ship released code.
+  **Verification waits for the rollout to converge** (`UpdateStatus.State`) and
+  then checks the live `api_version` against the release it deployed: with
+  start-first the outgoing container keeps serving, so checking early tests the
+  image being replaced. The first digest deploy did exactly that and printed
+  the old version while calling itself a pass.
 - **build** (`MEALS_DEPLOY_BUILD=1`). The old path: rsync this tree to the
   node, build all three images there, force the services. Keep it. It is the
   only way to ship a branch that has no tag, which is exactly what you want
@@ -368,7 +373,12 @@ have two tasks at once.
 
 ### Releases
 
-`git push origin v1.2.3` is the whole ritual: `.github/workflows/release.yml`
+`git push origin v1.2.3` is the ritual, and the **version in the code has to
+match the tag first** (`backend/pyproject.toml`, `mcp/pyproject.toml` and the
+FastAPI `version=` in `backend/app/main.py`). A release job checks all three
+and fails the release if any disagrees, because v1.0.1 shipped an API that
+reported 1.0.0 and the deploy compares the live `api_version` against the
+release it deployed. After that, `.github/workflows/release.yml`
 builds all three images for amd64 and arm64, pushes them to GHCR
 (`ghcr.io/marco308/meals` = the product, `…/meals-mcp` = the MCP server alone,
 `…/meals-backup` = the pg_dump sidecar the swarm runs), runs the published API

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -41,7 +41,7 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(
     lifespan=lifespan,
     title="Meals API",
-    version="1.0.0",
+    version="1.0.2",
     description=(
         "A meal *options* planner (not a rigid Mon–Sun grid) with a recipe library and an "
         "aisle-sorted shopping list. Designed to be driven by any AI assistant: every error "

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meals-backend"
-version = "1.0.0"
+version = "1.0.2"
 description = "Meal options planner backend — recipes, meals, plans, aisle-sorted shopping list, AI-friendly API"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "meals-backend"
-version = "1.0.0"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosmtplib" },
@@ -890,7 +890,7 @@ dev = [
 
 [[package]]
 name = "meals-mcp"
-version = "1.0.0"
+version = "1.0.2"
 source = { directory = "../mcp" }
 dependencies = [
     { name = "httpx" },

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meals-mcp"
-version = "1.0.0"
+version = "1.0.2"
 description = "MCP server wrapping the Meals REST API with task-level tools for AI assistants"
 requires-python = ">=3.12"
 dependencies = [

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -365,7 +365,7 @@ wheels = [
 
 [[package]]
 name = "meals-mcp"
-version = "1.0.0"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Found by deploying v1.0.1: the image reports `api_version: 1.0.0`, because the tag moved and the version in the code did not.

That is worth more than tidiness now, because `deploy/deploy.sh` compares the **live** `api_version` against the release it deployed. It is the one post-deploy check the outgoing container cannot satisfy, so it is what proves the new image is really serving — and it only works if an image reports its own tag.

- New `version` job in `release.yml` checks the tag against `backend/pyproject.toml`, `mcp/pyproject.toml` and the FastAPI `version=`, and everything else `needs:` it. It is not gated with `if:` (a skipped job skips its dependents, which would have made the `workflow_dispatch` dry run do nothing).
- Everything moves to **1.0.2**.

Also fixed in the gitignored `deploy/deploy.sh`: verification now waits for `UpdateStatus.State` to reach `completed` on each service, and treats any rollback state as a failed deploy. With start-first the old task serves until the new one is healthy, so the through-Traefik checks were testing the image being replaced. The v1.0.1 deploy printed `api_version: 0.1.0` from the outgoing container and called it a pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)