### PR TITLE
Settle the store name, and put the acronym where search can find it

### DIFF
--- a/ios/AppStore/metadata.md
+++ b/ios/AppStore/metadata.md
@@ -15,6 +15,17 @@ Yet Another Meal Planner
 on 2026-07-27 and App Store Connect accepted it, so the name was free. "Meals"
 is taken by someone else and can't be used.
 
+**This is the YAMP name already; don't "finish" it.** The store name *is* the
+acronym, spelled out, which is the whole joke. `planning/06-marketing.md` once
+called for the redundant "YAMP: Yet Another Meal Planner" and that prefix is
+deliberately not here: the name is only editable on a version in Prepare for
+Submission, and 1.0 and 1.1 are both `READY_FOR_SALE`, so it would cost a review
+pass to buy five characters that the name already says.
+
+The one thing the expansion does not buy is the literal string, and Apple
+indexes strings: a search for "yamp" does not match "Yet Another Meal Planner".
+That belongs in **keywords** below, not in the name.
+
 The home-screen name stays **Meals** (`CFBundleName`), which is allowed — the
 store name and the icon name don't have to match, they only have to be
 plausibly the same app.
@@ -109,12 +120,20 @@ Roughly 2,700 characters.
 ## Keywords — 100 characters max, comma separated, no spaces after commas
 
 ```
-meal,planner,recipe,shopping,list,groceries,grocery,selfhosted,offline,pantry,cooking,aisle,mealprep
+meal,planner,recipe,shopping,list,groceries,selfhosted,offline,pantry,cooking,aisle,mealprep,yamp
 ```
 
-99 characters. Don't repeat words from the name or subtitle — Apple indexes
-those already, so "meal" and "planner" earn nothing here beyond the phrase
-matches, and the rest is spent on searches this app can actually win.
+96 characters. **`yamp` is pending, not applied** — keywords are versioned
+metadata like the name, so this rides along with the next submission at no extra
+cost. It earns its slot precisely because it is *not* a word in the name: Apple
+indexes "Yet Another Meal Planner" as those four words, so anyone who heard the
+name as an acronym and searched "yamp" found nothing. `grocery` was dropped to
+pay for it; the live string was at exactly 100 of 100, not the 99 this file
+claimed, so there was no headroom. `groceries` still covers the search.
+
+Don't repeat words from the name or subtitle — Apple indexes those already, so
+"meal" and "planner" earn nothing here beyond the phrase matches, and the rest
+is spent on searches this app can actually win.
 
 ## URLs
 

--- a/planning/06-marketing.md
+++ b/planning/06-marketing.md
@@ -240,7 +240,7 @@ that outcome down as acceptable now so it never feels like failure later.
 
 | Item | Action | Cost |
 |---|---|---|
-| App Store record | Rename to "YAMP: Yet Another Meal Planner" **before** first submission (record is unsubmitted, so this is free; afterwards it is a versioned change) | Trivial, do now |
+| App Store record | **Done 2026-07-27, settled 2026-08-19.** The record reads "Yet Another Meal Planner", which *is* YAMP spelled out, so the listing already carries the name. The "YAMP:" prefix this row used to ask for is redundant and is not happening: the name is only editable on a version in Prepare for Submission, and 1.0 and 1.1 are both `READY_FOR_SALE`. What the expansion misses is the literal search token, so `yamp` goes in **keywords** with the next submission ([ios/AppStore/metadata.md](../ios/AppStore/metadata.md)) | Zero, deliberately |
 | GitHub repo | `marco308/meals` → `marco308/yamp` if wanted; GitHub redirects old URLs. Decide **before** Show HN, never after | Small |
 | Domain | Candidates to check: `yamp.app`, `yamp.dev`, `yamp.cooking`, `getyamp.com`, `yamp.uk`. GitHub Pages CNAME once chosen; until then `marco308.github.io` is fine | ~£10/yr |
 | Landing page, README title | This branch does the landing page; README retitle rides the repo rename | Trivial |


### PR DESCRIPTION
The App Store record has read **Yet Another Meal Planner** since 2026-07-27, which *is* YAMP spelled out. Verified against the App Store Connect API rather than the ledger:

| Field | Live value |
|---|---|
| App record name | `Yet Another Meal Planner` |
| en-GB name / subtitle | `Yet Another Meal Planner` / `Self-hosted meal planning` |
| Versions | 1.0 and 1.1, both `READY_FOR_SALE` |

The rename checklist in `planning/06-marketing.md` still asked for a `YAMP:` prefix on top of that. It buys five redundant characters, and with no version in Prepare for Submission the name is not editable, so it would now cost a review pass. Closed as settled rather than left looking like unfinished work.

What the expansion genuinely misses is the literal string: Apple indexes strings, so a search for `yamp` does not match "Yet Another Meal Planner". That is a keywords problem, not a name problem. `yamp` is staged in the keywords block **marked pending, not applied** — keywords are versioned metadata too, so it rides along free with the next submission.

Paying for the slot needed one: the live keyword string was at exactly 100 of 100 characters, not the 99 the file claimed. `grocery` is dropped and `groceries` keeps the search.

Docs only. Nothing was changed on App Store Connect, and no code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)