### PR TITLE
Give the release workflow a read-only default token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
+# The default for any job that doesn't say otherwise: a read-only token. The
+# jobs that push images or cut the release declare their own wider grants.
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
 


### PR DESCRIPTION
Closes out code scanning alert #6 (`actions/missing-workflow-permissions`): the `version` job in `release.yml` ran with the default `GITHUB_TOKEN` grants because only the other three jobs declared `permissions` blocks. A top-level `permissions: contents: read` makes read-only the default for it and for any job added later; `images` (packages: write), `verify` (packages: read) and `release` (contents: write) keep their own explicit blocks, which override the workflow default. `ci.yml` already had a top-level block.

The other open alert, #5 (`py/full-ssrf` on `fetch_page`), is being dismissed as a false positive rather than "fixed": fetching a caller-supplied URL is the ingestion feature, and every hop already goes through the scheme allowlist + public-address judgement + DNS-pinned dial in `recipe_parser.py`, covered by `backend/tests/unit/test_fetch_page.py`. CodeQL can't model the custom guard as a sanitizer, so the alert would never close on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)