### PR TITLE
Hosted tier limits: config-driven, unlimited by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,13 @@ AUTH_RATE_LIMIT_PER_MINUTE=10
 #SMTP_FROM=meals@example.com
 #SMTP_USERNAME=
 #SMTP_PASSWORD=
+
+# Per-household limits (backend/app/limits.py). Unset, there are none: no cap,
+# no paywall, and nothing that says a hosted tier exists anywhere. Set
+# LIMITS_PROFILE=hosted to run the published table of numbers, and override any
+# single one — or add one to the unlimited profile — with LIMITS_OVERRIDES.
+# DEFAULT_HOUSEHOLD_TIER decides what a *new* registration starts on; existing
+# households keep whatever their row says, which is "unlimited".
+#LIMITS_PROFILE=hosted
+#DEFAULT_HOUSEHOLD_TIER=free
+#LIMITS_OVERRIDES={"free": {"recipes": 100}, "ceiling": {"ingredients": null}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,11 @@ this changes nothing about how the deployment behaves.
   up front and committed before the page is fetched — the bandwidth is spent
   whether or not the page turns out to be readable — and `POST
   /recipes/{id}/reparse` costs the same allowance as `POST /recipes/ingest`,
-  since it makes the same outbound request.
+  since it makes the same outbound request. A household whose library is
+  already full is refused before either, so a full library never costs a fetch. Archived plans are not counted
+  against the plans cap: there is no way to delete a plan — its cooked history
+  is the reason — so counting them would end the weekly loop at plan 21 with no
+  way back, and finishing a week is what frees the place for the next one.
 
 ### Unchanged on purpose
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,58 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 
 ## Unreleased
 
-Nothing merged since the last deploy.
+**One migration**, `b1d73e5c9a24`: six new columns on `households`, all
+additive, all safe under a start-first rollout. Every existing household
+backfills to `tier = 'unlimited'`, which means no limits at all — so applying
+this changes nothing about how the deployment behaves.
+
+### Added
+
+- **Per-household limits, and every one of them defaults to unlimited** (issue
+  [#94](https://github.com/marco308/meals/issues/94), `planning/08-freemium.md`).
+  `app/limits.py` holds one `Limits` set of numbers per tier and one
+  `enforce()` the service layer calls immediately before a row is inserted. A
+  server that sets nothing has no caps, no paywall, and nothing anywhere that
+  says a hosted tier exists — `enforce()` returns before it runs a single query,
+  which is both the promise and the implementation of it. `LIMITS_PROFILE=hosted`
+  runs the published table, `LIMITS_OVERRIDES` tunes any single number as JSON,
+  and `DEFAULT_HOUSEHOLD_TIER` decides what a new registration starts on.
+  Members, recipes, ingredients, meals, lines per meal, plans, meals per plan,
+  supermarkets, API tokens and monthly URL ingests all have a boundary; every
+  one is a plain `COUNT` with no locking, because two concurrent creates
+  overshooting by one is cheaper to tolerate than to prevent.
+- **Two refusals, because a caller has to act differently.** A tier cap a bigger
+  tier would lift answers **402** and says so only in the status code; the
+  sentence stays factual and points nowhere, so it reads the same on a
+  self-hosted box and the iPhone app can render it verbatim without becoming a
+  shop. A fair-use ceiling — or a cap the largest tier cannot lift — answers
+  **403** and says that no tier goes further. Both name the limit, the tier and
+  the number in use, and end with something to do instead, because an assistant
+  bulk-importing will meet these and that sentence is the whole of what it can
+  act on. Every block logs `limit.reached`; `outcome="ceiling"` on a paid
+  household is the one worth alerting on.
+- `households.tier`, plus the price snapshot the founding-price-for-life promise
+  needs (`price_pence`, `price_currency`, `price_set_at`) and the URL-ingest
+  counter (`ingest_period_started_at`, `ingests_used`). The ingest quota is the
+  one limit that cannot be a `COUNT`: counting rows would refund it every time a
+  recipe was deleted, which is exactly the loop it exists to stop. It is charged
+  up front and committed before the page is fetched — the bandwidth is spent
+  whether or not the page turns out to be readable — and `POST
+  /recipes/{id}/reparse` costs the same allowance as `POST /recipes/ingest`,
+  since it makes the same outbound request.
+
+### Unchanged on purpose
+
+- **`/shopping-list*` is exempt from every limit, in every tier**, exactly as it
+  is exempt from the client gate. iOS drains its offline queue through those
+  endpoints and drops any op the server refuses (Q11), so a cap there would
+  delete what somebody typed in a supermarket rather than reduce their features.
+  That is why an ad-hoc add can still create an ingredient after the ingredient
+  allowance is spent, and why items-per-list and archived-shops carry no
+  enforcement at all.
+- PATs, `/mcp`, `/skill` and `/prompt-pack` are never gated by a tier. Being over
+  a limit blocks only the writes that *grow* a household: nothing is deleted,
+  nobody is ejected, and everything already there stays readable and usable.
 
 ## 2026-08-18 — household admin
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,10 @@ instrumentation a new feature usually needs.
   `PendingOp` the server refuses (Q11) — a cap there deletes what somebody
   typed in a supermarket. The one limit that is not a `COUNT` is URL ingests,
   which carries a monotonic per-month counter on the household because a count
-  of rows would refund the quota every time a recipe was deleted.
+  of rows would refund the quota every time a recipe was deleted. And a cap has
+  to be one a household can get back under: **archived plans are not counted**,
+  because there is no `DELETE /plans/{id}` (a plan's cooked history is why), so
+  counting them would end the weekly loop at plan 21 with no way back.
 
 ### The web client (`web/`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,24 @@ instrumentation a new feature usually needs.
   household's own verdict — unlike an aisle it is **never guessed**, so no
   keyword table. It rides along on list items and recipe lines so it shows up
   at the shelf; the vocabulary is published in the skill.
+- **Limits are config, and every one of them defaults to unlimited**
+  (`app/limits.py`, `planning/08-freemium.md`). `LIMITS_PROFILE` is `unlimited`
+  unless a deployment says otherwise, `households.tier` backfills to
+  `unlimited`, and `enforce()` returns before it runs a single query when
+  nothing is set — so a self-hosted instance sees no cap, no paywall, and no
+  hint that a hosted tier exists. That is the whole feature, and three rules
+  keep it that way. **Never bake a number into a default**: if one is tempting
+  there, it has crossed the line into fencing off the tool. **Call `enforce`
+  from the service layer, next to the insert** — a router holds no number and
+  picks no status code; the module decides 402 (a tier cap a bigger tier would
+  lift) or 403 (a fair-use ceiling, or a cap the top tier cannot lift), and one
+  handler in `main.py` turns either into a response. And **never limit
+  `/shopping-list*`**, in any tier: it is exempt from every billing block
+  exactly as it is exempt from the client gate, because iOS drops any queued
+  `PendingOp` the server refuses (Q11) — a cap there deletes what somebody
+  typed in a supermarket. The one limit that is not a `COUNT` is URL ingests,
+  which carries a monotonic per-month counter on the household because a count
+  of rows would refund the quota every time a recipe was deleted.
 
 ### The web client (`web/`)
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,17 @@ existing one; `REGISTRATION_ENABLED=false` additionally stops new households
 being created while still honouring invite codes, so closing a server doesn't
 lock out your own family.
 
+Per-household limits exist and are **off**: `LIMITS_PROFILE` is `unlimited`
+unless you change it, every household's `tier` is `unlimited`, and the
+enforcement returns before it runs a query, so an install that sets nothing has
+no caps and no idea any exist. If you *want* them — a server you let friends
+onto, a box you'd rather not have somebody fill — `LIMITS_PROFILE=hosted` runs a
+published table of numbers, `LIMITS_OVERRIDES` tunes any single one as JSON, and
+`DEFAULT_HOUSEHOLD_TIER` says what a new registration starts on. Being over a
+limit blocks only the writes that grow a household; nothing is deleted, nothing
+becomes unreadable, and the shopping list is exempt in every case because the
+iPhone app drains its offline queue through it.
+
 `make deploy` runs `deploy/deploy.sh`, which is **not in this repo** — a swarm
 stack file is a description of somebody's specific hardware (node names, ingress
 labels, host aliases, which box has the free disk), so it's kept out and

--- a/backend/alembic/versions/b1d73e5c9a24_add_household_tier_and_limits.py
+++ b/backend/alembic/versions/b1d73e5c9a24_add_household_tier_and_limits.py
@@ -1,0 +1,73 @@
+"""add households.tier, its price snapshot and the ingest counter
+
+Revision ID: b1d73e5c9a24
+Revises: a2f61d38c095
+Create Date: 2026-08-21 18:10:00.000000
+
+Issue #94 / planning/08-freemium.md. A household now says which set of limits
+applies to it, and carries the two pieces of state those limits need that
+cannot be derived from the rest of the schema.
+
+Everything here is additive and every existing row keeps behaving exactly as it
+did: `tier` backfills to 'unlimited', which app/limits.py resolves to no caps
+at all, so the family instance and every self-hosted one notice nothing. A
+deployment that never sets `LIMITS_PROFILE` never reads these columns.
+
+- `tier` — 'unlimited' | 'free' | 'paid'. A plain string rather than an enum
+  because the client contract is additive-only and a new tier must never be a
+  decode error, on the server or in a client.
+- `price_pence` / `price_currency` / `price_set_at` — the founding-price-for-life
+  promise as a stored fact rather than a sentence in a document. Null until
+  somebody pays, which on a self-hosted instance is never.
+- `ingest_period_started_at` / `ingests_used` — the URL-ingest quota's counter.
+  It has to be stored rather than counted: recipes can be deleted, and counting
+  rows would refund the quota every time one was.
+
+Safe under the start-first rollout in CLAUDE.md: the outgoing container keeps
+serving while this runs, and adding nullable columns (plus two with constant
+server defaults) takes nothing away from the code still reading the table.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b1d73e5c9a24'
+down_revision: Union[str, Sequence[str], None] = 'a2f61d38c095'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # No foreign keys and constant defaults, so SQLite takes these with a plain
+    # ALTER TABLE and needs no batch rebuild.
+    op.add_column(
+        'households',
+        sa.Column('tier', sa.String(length=20), nullable=False, server_default='unlimited'),
+    )
+    op.add_column('households', sa.Column('price_pence', sa.Integer(), nullable=True))
+    op.add_column('households', sa.Column('price_currency', sa.String(length=3), nullable=True))
+    op.add_column('households', sa.Column('price_set_at', sa.DateTime(timezone=True), nullable=True))
+    op.add_column('households', sa.Column('ingest_period_started_at', sa.DateTime(timezone=True), nullable=True))
+    op.add_column(
+        'households',
+        sa.Column('ingests_used', sa.Integer(), nullable=False, server_default='0'),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Dropping these loses which tier a household was on and what it agreed to
+    pay — which is a support conversation, not a data loss, because no food is
+    stored here. Everything goes back to unlimited, which is where it started.
+    """
+    op.drop_column('households', 'ingests_used')
+    op.drop_column('households', 'ingest_period_started_at')
+    op.drop_column('households', 'price_set_at')
+    op.drop_column('households', 'price_currency')
+    op.drop_column('households', 'price_pence')
+    op.drop_column('households', 'tier')

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -68,6 +68,27 @@ class Settings(BaseSettings):
     current_ios_build: int = 26
     ios_upgrade_url: str | None = None
 
+    # Per-household limits (app/limits.py, planning/08-freemium.md). Every
+    # number defaults to unlimited, and these three settings are the only way
+    # any of them becomes a real limit — a self-hoster who sets nothing sees no
+    # cap, no paywall, and no mention that a hosted tier exists.
+    #
+    #   LIMITS_PROFILE          "unlimited" (default) or "hosted", which is the
+    #                           table from that document's §3.
+    #   LIMITS_OVERRIDES        JSON, applied on top of the profile, so a
+    #                           deployment can tune any single number without a
+    #                           code change or a whole profile of its own:
+    #                             {"free": {"recipes": 100},
+    #                              "ceiling": {"ingredients": null}}
+    #                           null means unlimited.
+    #   DEFAULT_HOUSEHOLD_TIER  which tier a newly registered household starts
+    #                           on. Existing households keep whatever their row
+    #                           says, which for every household that predates
+    #                           this is "unlimited".
+    limits_profile: str = "unlimited"
+    limits_overrides: dict[str, dict[str, int | None]] = {}
+    default_household_tier: str = "unlimited"
+
     # Timeout for fetching external recipe pages during ingestion.
     recipe_fetch_timeout_seconds: float = 15.0
     # And a ceiling on how much of one we'll read (issue #55). The URL is the

--- a/backend/app/limits.py
+++ b/backend/app/limits.py
@@ -1,0 +1,720 @@
+"""Per-household limits: config-driven, and unlimited unless a deployment says
+otherwise.
+
+This is the enforcement half of `planning/08-freemium.md`. The rule that shapes
+every line of it is §1: **a quota on one person's hosting, never a fence around
+the tool**. So:
+
+- every number here defaults to `None`, which means unlimited;
+- with nothing configured, `enforce()` returns before it runs a single query, so
+  a self-hosted instance pays nothing and behaves exactly as it did before;
+- nothing anywhere says a hosted tier exists. A 402 on a server that sells
+  nothing is unreachable, because the numbers that produce it are unset.
+
+There is no closed fork: the deployment at meals.marcuslab.uk sets
+`LIMITS_PROFILE=hosted` and gets the numbers from §3 of that document, and
+anyone else can set the same thing, or their own numbers, or nothing at all.
+
+Two kinds of limit, and they are not the same error (§4)
+--------------------------------------------------------
+
+- **A tier cap** is what a bigger tier would fix, so it answers **402**. The
+  status code carries that meaning for a web client; the *sentence* deliberately
+  does not, because iOS shows 4xx details verbatim and the app must stay free of
+  commerce (§6 — "an error string is a call to action if it points anywhere").
+  The sentence is equally true on a self-hosted box, which is the tell that the
+  framing is right.
+- **A fair-use ceiling** protects the box, so no tier fixes it and it answers
+  **403**. A *paid* household reaching one is usually a bug rather than a heavy
+  user, so every block emits `limit.reached`; alert on
+  `outcome="ceiling" AND tier="paid"`.
+
+A cap the top tier cannot lift is a ceiling wearing a cap's clothes, and answers
+403 too: sending 402 to someone already on the largest tier this server offers
+would be telling them to buy something that does not exist.
+
+What this module does *not* carry
+---------------------------------
+
+Four rows of §3's table are deliberately absent, and each absence is a decision
+rather than an omission:
+
+- **Items per list** and **archived shops**. Both live under `/shopping-list*`,
+  which §5 exempts from every billing block for the same reason the client gate
+  exempts it (Q11): iOS replays its offline queue through those endpoints and
+  drops any op the server rejects with anything but "offline" or "unauthorised"
+  (`ios/.../ShoppingListStore.swift`). A 402 there destroys the user's data
+  rather than reducing their features, and no unpaid invoice justifies that.
+- **Archived shops readable.** §3 would show a free household its last three
+  shops; §5 promises that "everything already there stays readable". The second
+  wins here: hiding rows someone already wrote is the one thing lapse semantics
+  say we do not do.
+- **Requests per token.** That is a rate limiter answering 429, not a count
+  answering 402 — a different mechanism with a different window, and it belongs
+  next to `deps.auth_rate_limit` rather than here.
+
+Counting
+--------
+
+Plain `COUNT`s on the existing `household_id` indexes, and **no locking**: two
+concurrent creates that overshoot a cap by one are cheaper to tolerate than to
+prevent, which is §3's own instruction.
+"""
+
+import json
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, fields, replace
+from datetime import UTC, datetime, timedelta
+from functools import lru_cache
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import get_settings
+from app.models import AuthToken, Household, Ingredient, Meal, Plan, PlanMeal, Recipe, Supermarket, User
+from app.observability import log_event
+
+# ---------------------------------------------------------------------- tiers
+
+#: The tier a household is on. `unlimited` is the default everywhere and is also
+#: how a hosted instance comps someone: it lifts every *cap*, though never the
+#: ceilings, which exist to protect the box rather than to sell anything.
+UNLIMITED = "unlimited"
+FREE = "free"
+PAID = "paid"
+TIERS = (UNLIMITED, FREE, PAID)
+
+#: The ceiling is not a tier — it applies whatever tier a household is on — but
+#: it is configured the same way, so it shares the table.
+CEILING = "ceiling"
+LIMIT_SETS = (*TIERS, CEILING)
+
+
+@dataclass(frozen=True)
+class Limits:
+    """One set of numbers. `None` means unlimited, which is every field's
+    default: an unconfigured server has no limits, not zero of everything.
+
+    Every field is a limit this module actually applies. Numbers we publish but
+    do not enforce would be a lie the moment `GET /limits` (#95) reads them.
+    """
+
+    members: int | None = None
+    recipes: int | None = None
+    ingredients: int | None = None
+    meals: int | None = None
+    meal_lines: int | None = None
+    plans: int | None = None
+    plan_meals: int | None = None
+    supermarkets: int | None = None
+    api_tokens: int | None = None
+    ingests_per_month: int | None = None
+
+
+UNLIMITED_LIMITS = Limits()
+
+#: `LIMITS_PROFILE` picks one of these. The numbers in `hosted` are §3 of
+#: planning/08-freemium.md, in this repo under the same licence as everything
+#: else — a self-hoster can read them, use them, or ignore them.
+PROFILES: dict[str, dict[str, Limits]] = {
+    UNLIMITED: {
+        UNLIMITED: UNLIMITED_LIMITS,
+        FREE: UNLIMITED_LIMITS,
+        PAID: UNLIMITED_LIMITS,
+        CEILING: UNLIMITED_LIMITS,
+    },
+    "hosted": {
+        UNLIMITED: UNLIMITED_LIMITS,
+        FREE: Limits(
+            members=1,
+            recipes=50,
+            ingredients=500,
+            meals=100,
+            meal_lines=50,
+            plans=20,
+            plan_meals=30,
+            supermarkets=2,
+            api_tokens=3,
+            ingests_per_month=20,
+        ),
+        PAID: Limits(
+            members=8,
+            recipes=2_000,
+            ingredients=5_000,
+            meals=2_000,
+            meal_lines=50,
+            plans=1_000,
+            plan_meals=30,
+            supermarkets=20,
+            api_tokens=10,
+            ingests_per_month=500,
+        ),
+        CEILING: Limits(
+            members=12,
+            recipes=5_000,
+            ingredients=10_000,
+            meals=5_000,
+            meal_lines=50,
+            plans=2_000,
+            plan_meals=30,
+            supermarkets=20,
+            api_tokens=10,
+            ingests_per_month=1_000,
+        ),
+    },
+}
+
+RESOURCE_NAMES = tuple(field.name for field in fields(Limits))
+
+
+# ------------------------------------------------------------------ resources
+
+Counter = Callable[[AsyncSession, uuid.UUID, uuid.UUID | None], Awaitable[int]]
+
+
+async def _count(db: AsyncSession, model: type, *where: object) -> int:
+    result = await db.execute(select(func.count()).select_from(model).where(*where))
+    return int(result.scalar_one())
+
+
+async def _count_members(db: AsyncSession, household_id: uuid.UUID, _within: uuid.UUID | None) -> int:
+    return await _count(db, User, User.household_id == household_id)
+
+
+async def _count_recipes(db: AsyncSession, household_id: uuid.UUID, _within: uuid.UUID | None) -> int:
+    return await _count(db, Recipe, Recipe.household_id == household_id)
+
+
+async def _count_ingredients(db: AsyncSession, household_id: uuid.UUID, _within: uuid.UUID | None) -> int:
+    return await _count(db, Ingredient, Ingredient.household_id == household_id)
+
+
+async def _count_meals(db: AsyncSession, household_id: uuid.UUID, _within: uuid.UUID | None) -> int:
+    return await _count(db, Meal, Meal.household_id == household_id)
+
+
+async def _count_plans(db: AsyncSession, household_id: uuid.UUID, _within: uuid.UUID | None) -> int:
+    return await _count(db, Plan, Plan.household_id == household_id)
+
+
+async def _count_plan_meals(db: AsyncSession, _household_id: uuid.UUID, within: uuid.UUID | None) -> int:
+    return await _count(db, PlanMeal, PlanMeal.plan_id == within)
+
+
+async def _count_supermarkets(db: AsyncSession, household_id: uuid.UUID, _within: uuid.UUID | None) -> int:
+    return await _count(db, Supermarket, Supermarket.household_id == household_id)
+
+
+async def _count_api_tokens(db: AsyncSession, household_id: uuid.UUID, _within: uuid.UUID | None) -> int:
+    """Per household, not per user: §3's table is per household throughout, and
+    the limit is credential hygiene, which is a property of the data the tokens
+    reach rather than of who minted them."""
+    result = await db.execute(
+        select(func.count())
+        .select_from(AuthToken)
+        .join(User, AuthToken.user_id == User.id)
+        .where(User.household_id == household_id, AuthToken.kind == "api")
+    )
+    return int(result.scalar_one())
+
+
+async def _count_ingests(db: AsyncSession, household_id: uuid.UUID, _within: uuid.UUID | None) -> int:
+    """Read off the household's own counter rather than counting rows.
+
+    Recipes can be deleted, and a count of rows would hand the quota back every
+    time one was — which is exactly the loop someone using this server as a
+    general-purpose fetcher would run. `reserve_ingest` only ever increments.
+    """
+    household = await db.get(Household, household_id)
+    if household is None:
+        return 0
+    return _ingests_this_month(household)
+
+
+@dataclass(frozen=True)
+class _Spec:
+    """How one resource counts itself and how it says no."""
+
+    singular: str
+    plural: str
+    #: Where the allowance applies: "per household", "in one meal", "a month".
+    scope: str
+    #: Who is holding the existing ones, and in what tense.
+    holder: str
+    #: How to find out how many there are. `None` for a limit whose answer is
+    #: always in the payload the caller is holding, which is `meal_lines`: a
+    #: PATCH *replaces* a meal's lines rather than adding to them, so counting
+    #: the rows that are there would refuse an edit that made the meal smaller.
+    count: Counter | None
+    #: What to do instead. Appended to the refusal, so it is the last thing an
+    #: assistant reads and the first thing it can act on.
+    hint: str = ""
+
+
+RESOURCES: dict[str, _Spec] = {
+    "members": _Spec(
+        singular="member",
+        plural="members",
+        scope="per household",
+        holder="this household has",
+        count=_count_members,
+        hint=(
+            "Everyone already in the household keeps full access to the recipes, plans and shopping list; "
+            "this only stops another person joining."
+        ),
+    ),
+    "recipes": _Spec(
+        singular="recipe",
+        plural="recipes",
+        scope="per household",
+        holder="this household has",
+        count=_count_recipes,
+        hint="Delete a recipe nobody cooks (DELETE /recipes/{recipe_id}) to make room for this one.",
+    ),
+    "ingredients": _Spec(
+        singular="ingredient",
+        plural="ingredients",
+        scope="per household",
+        holder="this household has",
+        count=_count_ingredients,
+        hint=(
+            "A library this size usually holds duplicates: GET /ingredients/duplicates finds them, and "
+            "POST /ingredients/{keeper_id}/merge folds each group into one of the ingredients you "
+            "already have, which frees rows without losing anything."
+        ),
+    ),
+    "meals": _Spec(
+        singular="meal",
+        plural="meals",
+        scope="per household",
+        holder="this household has",
+        count=_count_meals,
+        hint="Delete a meal you no longer plan (DELETE /meals/{meal_id}); its cooked history survives.",
+    ),
+    "meal_lines": _Spec(
+        singular="line",
+        plural="lines",
+        scope="in one meal",
+        holder="this one would have",
+        count=None,
+        hint=(
+            "A line is one recipe or one loose ingredient. Split this into two meals and put both on the "
+            "plan — a plan is a pool of options, so two entries cost nothing."
+        ),
+    ),
+    "plans": _Spec(
+        singular="plan",
+        plural="plans",
+        scope="per household",
+        holder="this household has",
+        count=_count_plans,
+        hint="Delete an old archived plan, or reuse one: POST /plans accepts copy_from_plan_id.",
+    ),
+    "plan_meals": _Spec(
+        singular="meal",
+        plural="meals",
+        scope="in one plan",
+        holder="this plan has",
+        count=_count_plan_meals,
+        hint=(
+            "A plan is a week's pool of options rather than a calendar, so this many is already more than "
+            "a week of choices — archive it (POST /plans/{plan_id}/archive) and start the next one."
+        ),
+    ),
+    "supermarkets": _Spec(
+        singular="supermarket",
+        plural="supermarkets",
+        scope="per household",
+        holder="this household has",
+        count=_count_supermarkets,
+        hint="Delete one you no longer shop at (DELETE /supermarkets/{supermarket_id}).",
+    ),
+    "api_tokens": _Spec(
+        singular="API token",
+        plural="API tokens",
+        scope="per household",
+        holder="this household has",
+        count=_count_api_tokens,
+        hint=(
+            "Revoke one you are no longer using (DELETE /auth/tokens/{token_id}) — an unused token is a "
+            "credential nobody is watching."
+        ),
+    ),
+    "ingests_per_month": _Spec(
+        singular="recipe URL ingest",
+        plural="recipe URL ingests",
+        scope="a month",
+        holder="this household has used",
+        count=_count_ingests,
+        hint=(
+            "Fetching a page is the only thing this counts, and both POST /recipes/ingest and "
+            "POST /recipes/{recipe_id}/reparse do it. Read the page yourself and send what it says "
+            "instead — POST /recipes with parse_source='ai' for a new recipe, PATCH /recipes/{recipe_id} "
+            "to correct one — exactly as a page with no JSON-LD already asks you to."
+        ),
+    ),
+}
+
+assert set(RESOURCES) == set(RESOURCE_NAMES), "every Limits field needs a _Spec, and vice versa"
+
+
+# ------------------------------------------------------------------ resolution
+
+
+@lru_cache(maxsize=8)
+def _table(profile: str, overrides_json: str) -> dict[str, Limits]:
+    """The four number sets this deployment runs, overrides applied.
+
+    Cached on its inputs rather than on nothing, so a test that changes the
+    environment gets a different table without having to know this cache exists.
+    """
+    table = dict(PROFILES[profile])
+    for name, changes in json.loads(overrides_json).items():
+        table[name] = replace(table[name], **changes)
+    return table
+
+
+def _current_table() -> dict[str, Limits]:
+    settings = get_settings()
+    return _table(settings.limits_profile, json.dumps(settings.limits_overrides, sort_keys=True))
+
+
+def limits_for(tier: str) -> Limits:
+    """The caps for a tier. An unrecognised tier resolves to unlimited rather
+    than raising: a household must never be locked out of its own data because a
+    column holds a value this build has not heard of."""
+    return _current_table().get(tier, UNLIMITED_LIMITS)
+
+
+def ceilings() -> Limits:
+    """The fair-use ceilings, which apply whatever tier a household is on."""
+    return _current_table()[CEILING]
+
+
+def default_tier() -> str:
+    return get_settings().default_household_tier
+
+
+def anything_configured() -> bool:
+    """Whether this deployment has set any limit at all.
+
+    The whole module hangs off this: unset, `enforce` returns before it looks at
+    the household, let alone counts anything.
+    """
+    settings = get_settings()
+    return settings.limits_profile != UNLIMITED or bool(settings.limits_overrides)
+
+
+def check_settings() -> None:
+    """Validate the `LIMITS_*` environment at startup.
+
+    Called from `app/main.py` at import, because a typo in a limit should stop
+    the container rather than surface as a 500 on somebody's fiftieth recipe.
+    """
+    settings = get_settings()
+    if settings.limits_profile not in PROFILES:
+        raise ValueError(
+            f"LIMITS_PROFILE={settings.limits_profile!r} is not a profile; choose one of {', '.join(sorted(PROFILES))}"
+        )
+    if settings.default_household_tier not in TIERS:
+        raise ValueError(
+            f"DEFAULT_HOUSEHOLD_TIER={settings.default_household_tier!r} is not a tier; "
+            f"choose one of {', '.join(TIERS)}"
+        )
+    for name, changes in settings.limits_overrides.items():
+        if name not in LIMIT_SETS:
+            raise ValueError(f"LIMITS_OVERRIDES has a '{name}' section; the sections are {', '.join(LIMIT_SETS)}")
+        for resource, value in changes.items():
+            if resource not in RESOURCE_NAMES:
+                raise ValueError(
+                    f"LIMITS_OVERRIDES['{name}'] sets '{resource}', which is not a limit; "
+                    f"the limits are {', '.join(RESOURCE_NAMES)}"
+                )
+            # Anything that isn't a whole number or null has already been
+            # refused by pydantic; what it can't know is that a limit is a
+            # count, so a negative one is meaningless rather than merely small.
+            if value is not None and value < 0:
+                raise ValueError(
+                    f"LIMITS_OVERRIDES['{name}']['{resource}'] is {value!r}; a limit is a "
+                    "non-negative whole number, or null for unlimited"
+                )
+    # Build the table once so a bad override value fails here rather than later.
+    _current_table()
+
+
+# ------------------------------------------------------------------- refusals
+
+
+class LimitExceeded(Exception):
+    """A write that would grow a household past one of its limits.
+
+    Deliberately not an `HTTPException`: this is raised from the service layer,
+    and `app/main.py` owns the one place it becomes a response.
+    """
+
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        resource: str,
+        tier: str,
+        limit: int,
+        used: int,
+        detail: str,
+    ) -> None:
+        super().__init__(detail)
+        self.status_code = status_code
+        self.resource = resource
+        self.tier = tier
+        self.limit = limit
+        self.used = used
+        self.detail = detail
+
+    @property
+    def kind(self) -> str:
+        return "cap" if self.status_code == 402 else "ceiling"
+
+    def payload(self) -> dict[str, object]:
+        """The response body. `detail` is what every client shows the user; the
+        rest is for a caller that wants to reason about it (and for `GET /limits`
+        to line up with)."""
+        return {
+            "detail": self.detail,
+            "resource": self.resource,
+            "limit": self.limit,
+            "used": self.used,
+            "tier": self.tier,
+        }
+
+
+def _quantity(count: int, spec: _Spec) -> str:
+    return f"{count:,} {spec.singular if count == 1 else spec.plural}"
+
+
+def _refusal(spec: _Spec, *, tier: str, limit: int, used: int, kind: str, upgradable: bool) -> str:
+    """The sentence a person and an assistant both read.
+
+    It names the limit, the tier and the number in use (§4), and it points
+    nowhere: no price, no upgrade, no address to write to. On a self-hosted
+    instance every word of it is still true, which is the test §6 sets for
+    anything the iPhone app might render.
+    """
+    allowance = (
+        f"This server's {tier} tier allows {_quantity(limit, spec)} {spec.scope}"
+        if kind == "cap"
+        else f"This server allows at most {_quantity(limit, spec)} {spec.scope}"
+    )
+    tail = (
+        "Nothing has been removed and everything already here still works, so this only stops it growing."
+        if upgradable
+        else (
+            "No tier on this server goes beyond that, so it is not something this household can change — "
+            "going further needs a word with whoever runs the server."
+        )
+    )
+    return f"{allowance}, and {spec.holder} {used:,}. {tail} {spec.hint}".strip()
+
+
+# ------------------------------------------------------------------ enforcement
+
+#: The tiers a household can actually move between. `unlimited` is a comp rather
+#: than a tier anyone buys, so it is not evidence that a bigger allowance exists:
+#: without this, every cap would look upgradable and answer 402.
+PURCHASABLE_TIERS = (FREE, PAID)
+
+
+def _best_purchasable_cap(resource: str) -> int | None:
+    """The largest cap any purchasable tier offers, or None if one of them is
+    unlimited. What decides whether a cap is worth a 402 at all."""
+    table = _current_table()
+    caps = [getattr(table[tier], resource) for tier in PURCHASABLE_TIERS]
+    if any(cap is None for cap in caps):
+        return None
+    return max(caps)  # type: ignore[type-var]
+
+
+def _verdict(household: Household, spec: _Spec, resource: str, *, used: int, adding: int) -> LimitExceeded | None:
+    """Whether this household may add `adding` more of `resource`, and if not,
+    the refusal to raise. The single place caps, ceilings and status codes meet.
+    """
+    tier = household.tier if household.tier in TIERS else UNLIMITED
+    cap = getattr(limits_for(tier), resource)
+    ceiling = getattr(ceilings(), resource)
+    after = used + adding
+
+    # The ceiling is checked first: it is the lower bound on what this server
+    # will do at all, and when both would refuse, "no tier fixes this" is the
+    # more useful thing to have been told.
+    if ceiling is not None and after > ceiling:
+        return _refuse(household, spec, resource, tier=tier, limit=ceiling, used=used, kind="ceiling")
+    if cap is not None and after > cap:
+        best = _best_purchasable_cap(resource)
+        upgradable = best is None or best > cap
+        return _refuse(household, spec, resource, tier=tier, limit=cap, used=used, kind="cap", upgradable=upgradable)
+    return None
+
+
+def _has_limit(household: Household, resource: str) -> bool:
+    """Whether either a cap or a ceiling applies here — the check that keeps an
+    unconfigured server from ever running a COUNT."""
+    tier = household.tier if household.tier in TIERS else UNLIMITED
+    return getattr(limits_for(tier), resource) is not None or getattr(ceilings(), resource) is not None
+
+
+def _refuse(
+    household: Household,
+    spec: _Spec,
+    resource: str,
+    *,
+    tier: str,
+    limit: int,
+    used: int,
+    kind: str,
+    upgradable: bool = False,
+) -> LimitExceeded:
+    error = LimitExceeded(
+        status_code=402 if upgradable else 403,
+        resource=resource,
+        tier=tier,
+        limit=limit,
+        used=used,
+        detail=_refusal(spec, tier=tier, limit=limit, used=used, kind=kind, upgradable=upgradable),
+    )
+    # The alert the issue asks for lives on this line: a *paid* household meeting
+    # a ceiling is usually a bug in what we let them do rather than a heavy user,
+    # so it is worth waking somebody rather than only telling them.
+    log_event(
+        "limit.reached",
+        outcome=error.kind,
+        household_id=household.id,
+        resource=resource,
+        tier=tier,
+        limit=limit,
+        used=used,
+    )
+    return error
+
+
+async def _resolve_household(db: AsyncSession, household: Household | uuid.UUID) -> Household | None:
+    if isinstance(household, Household):
+        return household
+    # Usually free: the caller's household was eagerly loaded with the user, so
+    # this is an identity-map hit rather than a query.
+    return await db.get(Household, household)
+
+
+async def enforce(
+    db: AsyncSession,
+    household: Household | uuid.UUID,
+    resource: str,
+    *,
+    adding: int = 1,
+    used: int | None = None,
+    within: uuid.UUID | None = None,
+) -> None:
+    """Refuse a write that would take `resource` past this household's limit.
+
+    Call it from the service layer, immediately before the row is added, and let
+    it decide everything: a router never holds a number and never chooses a
+    status code.
+
+    `used` short-circuits the count for a limit whose answer the caller already
+    has in front of it (a meal's lines are in the payload). `within` scopes the
+    count to a parent, for the per-meal and per-plan limits.
+
+    Raises `LimitExceeded`. It runs before the insert, so nothing of this write
+    has been staged when it does.
+    """
+    if not anything_configured():
+        return  # the self-hosted default: no queries, no behaviour, no cost
+
+    row = await _resolve_household(db, household)
+    if row is None:  # deleted underneath us; the write will fail on its own terms
+        return
+    if not _has_limit(row, resource):
+        return
+
+    spec = RESOURCES[resource]
+    if used is None:
+        assert spec.count is not None, f"{resource} has no counter and must be enforced with used="
+        used = await spec.count(db, row.id, within)
+    refusal = _verdict(row, spec, resource, used=used, adding=adding)
+    if refusal is not None:
+        raise refusal
+
+
+# ------------------------------------------------------------------ ingest quota
+
+# The one limit that costs real bandwidth (§3), and so the one that cannot be a
+# `COUNT`: deleting the recipe would hand the quota back, and delete-and-retry is
+# precisely the loop the limit exists to stop. The household carries a counter
+# for the calendar month instead, and it only ever goes up.
+
+
+def _month_start(moment: datetime) -> datetime:
+    return moment.astimezone(UTC).replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+
+def _next_month(start: datetime) -> datetime:
+    # Day 28 plus four days lands in the next month whatever its length, and
+    # snapping to the 1st finds the boundary without any calendar arithmetic.
+    return (start.replace(day=28) + timedelta(days=4)).replace(day=1)
+
+
+def _as_aware(value: datetime) -> datetime:
+    # SQLite round-trips datetimes naive; stored values are UTC (deps.as_aware).
+    return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+
+def _ingests_this_month(household: Household) -> int:
+    """This month's ingest count, without writing.
+
+    A counter left over from an earlier month reads as zero rather than being
+    reset here, so a caller that is only *looking* never dirties the row — and
+    a month nobody ingested in needs no job to roll it over.
+    """
+    started = household.ingest_period_started_at
+    if started is None or _as_aware(started) < _month_start(datetime.now(UTC)):
+        return 0
+    return household.ingests_used
+
+
+async def reserve_ingest(db: AsyncSession, household: Household) -> None:
+    """Charge one URL ingest against this household's month, or refuse.
+
+    Charged **up front and committed**, before the page is fetched, the same way
+    `deps.auth_rate_limit` charges an attempt before it is known to be good: a
+    fetch that turns out to be bot-blocked or to carry no JSON-LD has already
+    cost the bandwidth this limit protects, and a refund on failure would make
+    the limit free to evade. There is deliberately no refund to forget.
+
+    Committing here is safe because both callers have staged nothing at this
+    point — a URL already in the library is answered from it before anything is
+    fetched (Q3), which is the whole reason the number can be as small as it is.
+
+    Both callers: `POST /recipes/ingest` and `POST /recipes/{id}/reparse`. A
+    re-parse makes exactly the same outbound request for exactly the same
+    reason, and metering only the first would leave the limit one POST away
+    from being bypassed.
+    """
+    if not anything_configured():
+        return
+    if not _has_limit(household, "ingests_per_month"):
+        return
+
+    spec = RESOURCES["ingests_per_month"]
+    month = _month_start(datetime.now(UTC))
+    assert spec.count is not None
+    used = await spec.count(db, household.id, None)
+    # The reset date is the most useful thing an assistant that has just been
+    # refused can be told, and it is only knowable here.
+    dated = replace(spec, hint=f"The count resets on {_next_month(month).strftime('%-d %B %Y')}. {spec.hint}")
+
+    refusal = _verdict(household, dated, "ingests_per_month", used=used, adding=1)
+    if refusal is not None:
+        raise refusal
+
+    household.ingest_period_started_at = month
+    household.ingests_used = used + 1
+    await db.commit()

--- a/backend/app/limits.py
+++ b/backend/app/limits.py
@@ -29,9 +29,12 @@ Two kinds of limit, and they are not the same error (§4)
   user, so every block emits `limit.reached`; alert on
   `outcome="ceiling" AND tier="paid"`.
 
-A cap the top tier cannot lift is a ceiling wearing a cap's clothes, and answers
-403 too: sending 402 to someone already on the largest tier this server offers
-would be telling them to buy something that does not exist.
+A cap nothing can be bought to lift is a ceiling wearing a cap's clothes, and
+answers 403 too — sending 402 to a household already on the largest tier this
+server offers, or to a comped one, or on a self-hosted box that sells nothing at
+all, would be pointing at something that does not exist. `UPGRADE_PATH` is the
+whole of that judgement, and it is deliberately a path rather than "is some
+other tier bigger".
 
 What this module does *not* carry
 ---------------------------------
@@ -195,7 +198,20 @@ async def _count_meals(db: AsyncSession, household_id: uuid.UUID, _within: uuid.
 
 
 async def _count_plans(db: AsyncSession, household_id: uuid.UUID, _within: uuid.UUID | None) -> int:
-    return await _count(db, Plan, Plan.household_id == household_id)
+    """Archived plans don't count, and that is the difference between a cap and
+    a wall.
+
+    There is no `DELETE /plans/{id}` — a plan is archived rather than removed,
+    because its `cooked_events` are the record of what the household actually
+    ate. So counting every row would mean a cap nothing could ever bring a
+    household back under: on the free tier they would plan their twentieth week
+    and never plan another, with the iPhone app's "add to plan" dead behind it
+    (`PlanStore.planForWriting` creates the plan implicitly). §5 promises plans
+    stay usable, so what this bounds is how many pools a household is juggling,
+    and finishing a week — the action they already take — is what frees the
+    place for the next one.
+    """
+    return await _count(db, Plan, Plan.household_id == household_id, Plan.status != "archived")
 
 
 async def _count_plan_meals(db: AsyncSession, _household_id: uuid.UUID, within: uuid.UUID | None) -> int:
@@ -260,8 +276,8 @@ RESOURCES: dict[str, _Spec] = {
         holder="this household has",
         count=_count_members,
         hint=(
-            "Everyone already in the household keeps full access to the recipes, plans and shopping list; "
-            "this only stops another person joining."
+            "This counts everyone in the household, so a place frees up only when one of them leaves "
+            "(DELETE /auth/household/members/{user_id}) — and a household of one has nobody to remove."
         ),
     ),
     "recipes": _Spec(
@@ -309,7 +325,10 @@ RESOURCES: dict[str, _Spec] = {
         scope="per household",
         holder="this household has",
         count=_count_plans,
-        hint="Delete an old archived plan, or reuse one: POST /plans accepts copy_from_plan_id.",
+        hint=(
+            "Archived plans do not count, so finishing a week frees a place: "
+            "POST /plans/{plan_id}/archive on one you are done with, which keeps its cooked history."
+        ),
     ),
     "plan_meals": _Spec(
         singular="meal",
@@ -337,7 +356,8 @@ RESOURCES: dict[str, _Spec] = {
         holder="this household has",
         count=_count_api_tokens,
         hint=(
-            "Revoke one you are no longer using (DELETE /auth/tokens/{token_id}) — an unused token is a "
+            "This counts every member's tokens, and GET /auth/tokens lists your own — revoke one you "
+            "are no longer using (DELETE /auth/tokens/{token_id}), since an unused token is a "
             "credential nobody is watching."
         ),
     ),
@@ -500,9 +520,11 @@ def _refusal(spec: _Spec, *, tier: str, limit: int, used: int, kind: str, upgrad
     instance every word of it is still true, which is the test §6 sets for
     anything the iPhone app might render.
     """
+    # A ceiling belongs to the server rather than to a tier, and so does a cap
+    # met by a comped household, so neither names one.
     allowance = (
         f"This server's {tier} tier allows {_quantity(limit, spec)} {spec.scope}"
-        if kind == "cap"
+        if kind == "cap" and tier in NAMED_TIERS
         else f"This server allows at most {_quantity(limit, spec)} {spec.scope}"
     )
     tail = (
@@ -518,20 +540,27 @@ def _refusal(spec: _Spec, *, tier: str, limit: int, used: int, kind: str, upgrad
 
 # ------------------------------------------------------------------ enforcement
 
-#: The tiers a household can actually move between. `unlimited` is a comp rather
-#: than a tier anyone buys, so it is not evidence that a bigger allowance exists:
-#: without this, every cap would look upgradable and answer 402.
-PURCHASABLE_TIERS = (FREE, PAID)
+#: Where a tier can move *up* to, and the only thing that ever justifies a 402.
+#: Deliberately a path rather than "is any other tier bigger": `unlimited` is a
+#: comp, not something anyone buys, so a household on it — or on the largest
+#: tier this server offers — has nothing to be sold and must not be told
+#: otherwise. Without this, a self-hoster who capped one tier and left the rest
+#: alone would have their own server answer them 402 Payment Required.
+UPGRADE_PATH: dict[str, tuple[str, ...]] = {FREE: (PAID,)}
+
+#: The tiers a refusal will name. `unlimited` is not one of them: a household on
+#: it is comped, so "this server's unlimited tier allows 10 recipes" would be a
+#: sentence that contradicts itself.
+NAMED_TIERS = (FREE, PAID)
 
 
-def _best_purchasable_cap(resource: str) -> int | None:
-    """The largest cap any purchasable tier offers, or None if one of them is
-    unlimited. What decides whether a cap is worth a 402 at all."""
-    table = _current_table()
-    caps = [getattr(table[tier], resource) for tier in PURCHASABLE_TIERS]
-    if any(cap is None for cap in caps):
-        return None
-    return max(caps)  # type: ignore[type-var]
+def _upgradable(tier: str, resource: str, cap: int) -> bool:
+    """Whether a tier above this one would actually lift this cap."""
+    for better in UPGRADE_PATH.get(tier, ()):
+        allowance = getattr(limits_for(better), resource)
+        if allowance is None or allowance > cap:
+            return True
+    return False
 
 
 def _verdict(household: Household, spec: _Spec, resource: str, *, used: int, adding: int) -> LimitExceeded | None:
@@ -549,8 +578,7 @@ def _verdict(household: Household, spec: _Spec, resource: str, *, used: int, add
     if ceiling is not None and after > ceiling:
         return _refuse(household, spec, resource, tier=tier, limit=ceiling, used=used, kind="ceiling")
     if cap is not None and after > cap:
-        best = _best_purchasable_cap(resource)
-        upgradable = best is None or best > cap
+        upgradable = _upgradable(tier, resource, cap)
         return _refuse(household, spec, resource, tier=tier, limit=cap, used=used, kind="cap", upgradable=upgradable)
     return None
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 
-from app import client_gate, mcp_mount, metrics, observability
+from app import client_gate, limits, mcp_mount, metrics, observability
 from app.config import get_settings
 from app.observability import log_event
 from app.routers import auth, ingredients, meals, pages, plans, recipes, shopping, skill, supermarkets
@@ -17,6 +17,9 @@ from app.routers.skill import base_url, playbook_version
 
 settings = get_settings()
 observability.setup_logging()
+# A typo in a LIMITS_* value should stop the container here, not surface as a
+# 500 on somebody's fiftieth recipe.
+limits.check_settings()
 
 
 @contextlib.asynccontextmanager
@@ -97,6 +100,21 @@ async def client_compatibility(request: Request, call_next: Callable[[Request], 
     response.headers["X-Meals-Min-Client-Build"] = str(config.min_ios_build)
     response.headers["X-Meals-Current-Client-Build"] = str(config.current_ios_build)
     return response
+
+
+@app.exception_handler(limits.LimitExceeded)
+async def limit_exceeded_handler(_: Request, exc: Exception) -> Response:
+    """The one place a limit becomes a response.
+
+    `app/limits.py` raises a domain error from the service layer and chooses the
+    status code (402 for a tier cap, 403 for a fair-use ceiling — see that
+    module); this turns it into the same `{"detail": ...}` shape every other 4xx
+    uses, so the iOS app, the web app and an assistant reading through /mcp all
+    show the sentence verbatim without knowing limits exist. The extra fields
+    ride alongside for a caller that wants to reason about the numbers.
+    """
+    assert isinstance(exc, limits.LimitExceeded)
+    return JSONResponse(status_code=exc.status_code, content=exc.payload())
 
 
 # Registered last so it is the *outermost* middleware (Starlette builds the

--- a/backend/app/models/users.py
+++ b/backend/app/models/users.py
@@ -1,14 +1,24 @@
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import DateTime, ForeignKey, String, Uuid
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Uuid
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from app.config import get_settings
 from app.database import Base
 
 
 def utcnow() -> datetime:
     return datetime.now(UTC)
+
+
+def _default_tier() -> str:
+    """The tier a new household starts on, read at insert time rather than at
+    import: `DEFAULT_HOUSEHOLD_TIER` is a deployment's decision, and putting it
+    here means every path that creates a household — registration, the invite
+    flow, `app/provision.py`, the tests — honours it without knowing it exists.
+    """
+    return get_settings().default_household_tier
 
 
 class Household(Base):
@@ -39,6 +49,29 @@ class Household(Base):
         ForeignKey("users.id", ondelete="SET NULL", use_alter=True, name="households_lead_user_id_fkey"),
         default=None,
     )
+
+    # ------------------------------------------------------------- limits
+    # Which set of numbers in app/limits.py applies to this household. The
+    # default is "unlimited" and every household that predates the column has
+    # it, so a self-hosted instance — and the family one — notices nothing.
+    # `DEFAULT_HOUSEHOLD_TIER` decides what a *new* registration starts on,
+    # which is how one deployment can run a free tier while the code stays the
+    # same everywhere (planning/08-freemium.md §1).
+    tier: Mapped[str] = mapped_column(String(20), default=_default_tier, server_default="unlimited")
+    # The founding-price-for-life promise, stored rather than promised in a
+    # document: what this household agreed to pay, in the smallest unit of the
+    # currency, and when that was fixed. Unset until money is involved, which
+    # for every self-hosted instance is forever.
+    price_pence: Mapped[int | None] = mapped_column(Integer, default=None)
+    price_currency: Mapped[str | None] = mapped_column(String(3), default=None)
+    price_set_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
+    # The URL-ingest quota's counter (limits.reserve_ingest). It has to be
+    # stored rather than counted: recipes can be deleted, and a COUNT would
+    # refund the quota every time one was, which is the loop the limit exists
+    # to stop. `ingest_period_started_at` is the first instant of the calendar
+    # month the count belongs to; a stale one reads as zero.
+    ingest_period_started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
+    ingests_used: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
 
     # Two foreign keys now join these tables (a user's household, a household's
     # lead), so both relationships have to say which one they travel.

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime, timedelta
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy import delete, select
 
+from app import limits
 from app.config import get_settings
 from app.deps import CurrentUser, DbSession, as_aware, auth_rate_limit, forgive_auth_attempt
 from app.models import AuthToken, Household, HouseholdInvite, User
@@ -112,6 +113,9 @@ async def register(payload: RegisterIn, db: DbSession, _: None = Depends(auth_ra
 
     if invite is not None:
         household = invite.household
+        # An invite can outlive the headroom that justified it, so the check is
+        # here as well as at POST /auth/invites.
+        await limits.enforce(db, household, "members")
     else:
         household = Household(name=(payload.household_name or "Home").strip())
         db.add(household)
@@ -516,6 +520,9 @@ async def create_invite(payload: InviteCreateIn, user: CurrentUser, db: DbSessio
     it with `DELETE /auth/invites/{id}` and issue another. Anyone holding it can
     join, so send it the way you'd send a password."""
     await _require_lead(db, user, "invite people")
+    # The friendly place to say no: refusing here beats minting a code that
+    # fails on redemption, when a second person is already waiting for it.
+    await limits.enforce(db, user.household, "members")
     code, code_hash = generate_short_code()
     invite = HouseholdInvite(
         household_id=user.household_id,
@@ -596,6 +603,8 @@ async def redeem_invite(payload: InviteRedeemIn, user: CurrentUser, db: DbSessio
             ),
         )
 
+    await limits.enforce(db, invite.household_id, "members")
+
     invite.accepted_at = datetime.now(UTC)
     invite.accepted_by_user_id = user.id
     collected = await move_user_to_household(db, user, invite.household_id)
@@ -640,6 +649,7 @@ async def revoke_invite(invite_id: uuid.UUID, user: CurrentUser, db: DbSession) 
 async def create_api_token(payload: TokenCreateIn, user: CurrentUser, db: DbSession) -> TokenCreatedOut:
     """Create a personal API token for an AI client (MCP, scripts). The
     plaintext token is returned once and never stored."""
+    await limits.enforce(db, user.household, "api_tokens")
     plain, token_hash = generate_token()
     expires_at = None
     if payload.expires_in_days is not None:

--- a/backend/app/routers/meals.py
+++ b/backend/app/routers/meals.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app import limits
 from app.deps import CurrentUser, DbSession
 from app.models import Meal, MealIngredient, MealRecipe, Plan, PlanMeal
 from app.schemas.common import IngredientLineIn
@@ -78,6 +79,15 @@ async def create_meal(payload: MealCreate, user: CurrentUser, db: DbSession) -> 
     recipe that serves 4 is stored as scale 1.5 — and needs the recipe to say
     how many it serves. Send one or the other, never both. Each recipe comes
     back with its `scale` and the `scaled_servings` that follows from it."""
+    await limits.enforce(db, user.household, "meals")
+    # The lines are in the payload in front of us, so this needs no query.
+    await limits.enforce(
+        db,
+        user.household,
+        "meal_lines",
+        used=len(payload.resolved_recipes) + len(payload.loose_ingredients),
+        adding=0,
+    )
     meal = Meal(household_id=user.household_id, name=payload.name.strip(), slot=_clean_slot(payload.slot))
     db.add(meal)
     await db.flush()
@@ -131,6 +141,13 @@ async def update_meal(meal_id: uuid.UUID, payload: MealUpdate, user: CurrentUser
         meal.slot = _clean_slot(payload.slot)
     recipes = payload.resolved_recipes
     composition_changed = recipes is not None or payload.loose_ingredients is not None
+    if composition_changed:
+        # What the meal would hold once this PATCH lands: a half-sent payload
+        # leaves the other half of the composition where it is.
+        after = (len(recipes) if recipes is not None else len(meal.recipe_links)) + (
+            len(payload.loose_ingredients) if payload.loose_ingredients is not None else len(meal.ingredient_links)
+        )
+        await limits.enforce(db, user.household, "meal_lines", used=after, adding=0)
     if recipes is not None:
         await _set_recipes(db, user.household_id, meal, recipes)
     if payload.loose_ingredients is not None:

--- a/backend/app/routers/plans.py
+++ b/backend/app/routers/plans.py
@@ -28,15 +28,19 @@ async def get_plan(db: AsyncSession, household_id: uuid.UUID, plan_id: uuid.UUID
 
 
 async def _add_meal_to_plan(db: AsyncSession, household_id: uuid.UUID, plan: Plan, meal_id: uuid.UUID) -> None:
-    # Here rather than in the endpoint, because copying a plan (POST /plans with
-    # copy_from_plan_id) reaches this in a loop and has to stop at the same line.
-    await limits.enforce(db, household_id, "plan_meals", within=plan.id)
     meal = await get_meal(db, household_id, meal_id)
     if meal is None:
         raise HTTPException(status_code=422, detail=f"meal {meal_id} not found; list meals via GET /meals")
     duplicate = await db.execute(select(PlanMeal).where(PlanMeal.plan_id == plan.id, PlanMeal.meal_id == meal_id))
     if duplicate.first() is not None:
         raise HTTPException(status_code=409, detail=f"meal '{meal.name}' is already in plan '{plan.label}'")
+    # Last, and in this helper rather than in the endpoint. Last, because the
+    # two refusals above add no row and so cannot cross a limit — a retried add
+    # of a meal already on a full plan has to hear "it is already there", not be
+    # told to archive the plan. In the helper, because copying a plan (POST
+    # /plans with copy_from_plan_id) reaches this in a loop and has to stop at
+    # the same line.
+    await limits.enforce(db, household_id, "plan_meals", within=plan.id)
     plan_meal = PlanMeal(plan_id=plan.id, meal_id=meal_id)
     db.add(plan_meal)
     await db.flush()

--- a/backend/app/routers/plans.py
+++ b/backend/app/routers/plans.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app import limits
 from app.deps import CurrentUser, DbSession
 from app.models import Plan, PlanMeal
 from app.models.users import utcnow
@@ -27,6 +28,9 @@ async def get_plan(db: AsyncSession, household_id: uuid.UUID, plan_id: uuid.UUID
 
 
 async def _add_meal_to_plan(db: AsyncSession, household_id: uuid.UUID, plan: Plan, meal_id: uuid.UUID) -> None:
+    # Here rather than in the endpoint, because copying a plan (POST /plans with
+    # copy_from_plan_id) reaches this in a loop and has to stop at the same line.
+    await limits.enforce(db, household_id, "plan_meals", within=plan.id)
     meal = await get_meal(db, household_id, meal_id)
     if meal is None:
         raise HTTPException(status_code=422, detail=f"meal {meal_id} not found; list meals via GET /meals")
@@ -46,6 +50,7 @@ async def create_plan(payload: PlanCreate, user: CurrentUser, db: DbSession) -> 
     """Start a weekly-ish plan — a pool of meal options, never a calendar.
     Pass copy_from_plan_id to start from a previous week ('same as two weeks
     ago'); copied meals immediately contribute to the shopping list."""
+    await limits.enforce(db, user.household, "plans")
     plan = Plan(household_id=user.household_id, label=payload.label.strip(), starts_on=payload.starts_on)
     db.add(plan)
     await db.flush()

--- a/backend/app/routers/recipes.py
+++ b/backend/app/routers/recipes.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 from fastapi import APIRouter, HTTPException, Query, Response, status
 from sqlalchemy import nullsfirst, select
 
+from app import limits
 from app.deps import CurrentUser, DbSession
 from app.models import MealRecipe, Recipe
 from app.observability import log_event
@@ -72,6 +73,11 @@ async def ingest_recipe_url(payload: IngestIn, user: CurrentUser, db: DbSession)
     if cached is not None:
         log_event("recipe.ingested", outcome="cached", host=host, recipe_id=cached.id)
         return IngestOut(recipe=recipe_out(cached), cached=True)
+
+    # Charged before the fetch and committed, because the bandwidth is spent
+    # whether or not the page turns out to be readable — see limits.reserve_ingest.
+    # A cached URL never reaches here, which is why the allowance can be small.
+    await limits.reserve_ingest(db, user.household)
 
     try:
         html = await recipe_parser.fetch_page(url)
@@ -229,6 +235,11 @@ async def reparse_recipe(recipe_id: uuid.UUID, payload: ReparseIn, user: Current
         )
 
     host = urlparse(recipe.source_url).hostname
+    # A re-parse is the same outbound fetch as an ingest, so it costs the same
+    # allowance. Metering only /recipes/ingest would leave the limit one POST
+    # away from being bypassed: store any URL as a recipe, then re-parse it.
+    await limits.reserve_ingest(db, user.household)
+
     # Nothing is written until the parse succeeds, so a page that has gone
     # away or lost its JSON-LD leaves the stored recipe exactly as it was.
     try:

--- a/backend/app/routers/recipes.py
+++ b/backend/app/routers/recipes.py
@@ -74,9 +74,15 @@ async def ingest_recipe_url(payload: IngestIn, user: CurrentUser, db: DbSession)
         log_event("recipe.ingested", outcome="cached", host=host, recipe_id=cached.id)
         return IngestOut(recipe=recipe_out(cached), cached=True)
 
-    # Charged before the fetch and committed, because the bandwidth is spent
-    # whether or not the page turns out to be readable — see limits.reserve_ingest.
-    # A cached URL never reaches here, which is why the allowance can be small.
+    # The recipe allowance first, even though create_recipe_from_payload checks
+    # it again below: a household that could not store the result should hear
+    # that before this server spends a page fetch and a month's ingest on
+    # something it is going to refuse.
+    await limits.enforce(db, user.household, "recipes")
+    # Then the ingest itself — charged before the fetch and committed, because
+    # the bandwidth is spent whether or not the page turns out to be readable
+    # (see limits.reserve_ingest). A cached URL never reaches here, which is why
+    # the allowance can be as small as it is.
     await limits.reserve_ingest(db, user.household)
 
     try:

--- a/backend/app/routers/supermarkets.py
+++ b/backend/app/routers/supermarkets.py
@@ -12,6 +12,7 @@ import uuid
 from fastapi import APIRouter, HTTPException, status
 from sqlalchemy import select, update
 
+from app import limits
 from app.deps import CurrentUser, DbSession
 from app.models import Supermarket
 from app.schemas.shopping import SupermarketCreate, SupermarketOut, SupermarketUpdate
@@ -67,6 +68,7 @@ async def create_supermarket(payload: SupermarketCreate, user: CurrentUser, db: 
         problem = invalid_aisle_order_detail(payload.aisle_order)
         if problem is not None:
             raise HTTPException(status_code=422, detail=problem)
+    await limits.enforce(db, user.household, "supermarkets")
     market = Supermarket(
         household_id=user.household_id,
         name=name,

--- a/backend/app/services/catalog.py
+++ b/backend/app/services/catalog.py
@@ -5,6 +5,7 @@ import uuid
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app import limits
 from app.models import Ingredient, Recipe, RecipeIngredient
 from app.schemas.catalog import RecipeCreate
 from app.schemas.common import IngredientLineIn
@@ -13,7 +14,9 @@ from app.services.ingredient_names import canonical_ingredient_name
 from app.services.recipe_parser import ParsedRecipe
 
 
-async def get_or_create_ingredient(db: AsyncSession, household_id: uuid.UUID, name: str) -> Ingredient:
+async def get_or_create_ingredient(
+    db: AsyncSession, household_id: uuid.UUID, name: str, *, count_against_limits: bool = True
+) -> Ingredient:
     """Ingredient names are the canonical key: 'chopped tomatoes' from two
     recipes resolves to one ingredient. New ingredients get a best-effort
     aisle from the built-in lookup table.
@@ -21,7 +24,14 @@ async def get_or_create_ingredient(db: AsyncSession, household_id: uuid.UUID, na
     Every write path — JSON-LD ingest, an AI's POST /recipes, a loose meal
     ingredient, an ad-hoc list add — lands here, which is why the name folding
     (Q21) belongs here and nowhere else: 'mint leaves' and 'mint' resolve to
-    one ingredient however they arrived."""
+    one ingredient however they arrived.
+
+    It is also why the ingredient limit is applied here, and why the ad-hoc list
+    add is the one caller that passes `count_against_limits=False`: adding milk
+    to the shopping list must never be refused (planning/08-freemium.md §5). The
+    offline queue replays through that endpoint and iOS drops any op the server
+    rejects, so a limit there would delete what someone typed in a supermarket
+    rather than merely capping them (Q11)."""
     # The fallback matters for names that fold to nothing (","): a punctuation
     # ingredient is bad data, an unnamed one breaks every client that shows it.
     canonical = canonical_ingredient_name(name) or " ".join(name.lower().split())
@@ -30,6 +40,8 @@ async def get_or_create_ingredient(db: AsyncSession, household_id: uuid.UUID, na
     )
     ingredient = result.scalar_one_or_none()
     if ingredient is None:
+        if count_against_limits:
+            await limits.enforce(db, household_id, "ingredients")
         ingredient = Ingredient(household_id=household_id, name=canonical, aisle=guess_aisle(canonical))
         db.add(ingredient)
         await db.flush()
@@ -42,6 +54,7 @@ async def create_recipe_from_payload(
     user_id: uuid.UUID | None,
     payload: RecipeCreate,
 ) -> Recipe:
+    await limits.enforce(db, household_id, "recipes")
     recipe = Recipe(
         household_id=household_id,
         title=payload.title.strip(),

--- a/backend/app/services/shopping.py
+++ b/backend/app/services/shopping.py
@@ -115,7 +115,12 @@ async def add_adhoc_item(
             assert item is not None
             return item, False
 
-    ingredient = await get_or_create_ingredient(db, household_id, payload.name)
+    # Never limited, in any tier. `/shopping-list*` is exempt from every billing
+    # block exactly as it is exempt from the client gate (planning/08-freemium.md
+    # §5): this is the endpoint the offline queue drains through, and iOS drops
+    # any op the server refuses, so a cap here would destroy what someone typed
+    # in a supermarket rather than reduce their features (Q11).
+    ingredient = await get_or_create_ingredient(db, household_id, payload.name, count_against_limits=False)
     item = await _find_item(db, shopping_list.id, ingredient.id, payload.unit)
     if item is None:
         # Honour the client-generated id (offline-first sync) unless it is

--- a/backend/tests/integration/test_limits.py
+++ b/backend/tests/integration/test_limits.py
@@ -1,0 +1,548 @@
+"""Hosted-tier limits, end to end (issue #94, planning/08-freemium.md).
+
+Two things are being defended here, and the first matters more than the second:
+
+1. **An unconfigured server has no limits.** Every other test file in this suite
+   runs with nothing set, so the 600-odd tests around this one are the real
+   assertion — but the first class below says it out loud, because "a self-hoster
+   who sets nothing sees no change" is the promise the whole feature rests on.
+2. When a deployment *does* set numbers, growth writes stop and nothing else
+   does: what is already there stays readable, the shopping list keeps working,
+   and the sentence the caller reads says what to do next.
+
+The numbers are overridden down to two or three throughout. The point being
+tested is the boundary, and creating fifty recipes to find it would only make
+the suite slower.
+"""
+
+import json
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.models import Household, User
+from tests.conftest import create_meal, create_plan, create_recipe, register
+
+PASSWORD = "a-strong-password"
+
+
+def headers(auth: dict) -> dict:
+    return {"Authorization": f"Bearer {auth['token']}"}
+
+
+@pytest.fixture
+def hosted(settings_override):
+    """Turn the hosted profile on, with the numbers dialled down.
+
+    Call it *before* registering: `DEFAULT_HOUSEHOLD_TIER` is read when the
+    household row is inserted."""
+
+    def apply(**overrides):
+        settings_override(
+            LIMITS_PROFILE="hosted",
+            DEFAULT_HOUSEHOLD_TIER="free",
+            LIMITS_OVERRIDES=json.dumps(overrides),
+        )
+
+    return apply
+
+
+@pytest.fixture
+def set_tier(engine):
+    """Move a household onto another tier, which is the ops surface #99 will
+    build; here it is the only way to test what a paid household sees."""
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def apply(tier: str) -> None:
+        async with maker() as session:
+            for household in (await session.execute(select(Household))).scalars():
+                household.tier = tier
+            await session.commit()
+
+    return apply
+
+
+async def signed_in(client, **kwargs):
+    auth = await register(client, **kwargs)
+    client.headers["Authorization"] = f"Bearer {auth['token']}"
+    return auth
+
+
+class TestUnconfiguredServersAreUntouched:
+    async def test_a_new_household_is_unlimited(self, engine, auth_client):
+        maker = async_sessionmaker(engine, expire_on_commit=False)
+        async with maker() as session:
+            household = (await session.execute(select(Household))).scalars().one()
+            assert household.tier == "unlimited"
+            assert household.price_pence is None
+            assert household.ingests_used == 0
+
+    async def test_nothing_is_refused(self, auth_client):
+        """The same writes that a free tier would cap, with nothing configured."""
+        for index in range(3):
+            await create_recipe(auth_client, title=f"Recipe {index}")
+            await create_meal(auth_client, name=f"Meal {index}")
+            await create_plan(auth_client, label=f"Plan {index}")
+            response = await auth_client.post("/supermarkets", json={"name": f"Store {index}"})
+            assert response.status_code == 201
+            response = await auth_client.post("/auth/tokens", json={"label": f"Token {index}"})
+            assert response.status_code == 201
+        response = await auth_client.post("/auth/invites", json={})
+        assert response.status_code == 201
+
+    async def test_the_hosted_numbers_do_nothing_without_a_tier_to_apply_them_to(self, client, settings_override):
+        """Profile on, default tier left alone: an existing household predates
+        the column and stays unlimited, which is the family instance's case."""
+        settings_override(LIMITS_PROFILE="hosted", LIMITS_OVERRIDES=json.dumps({"free": {"recipes": 1}}))
+        await signed_in(client)
+        await create_recipe(client, title="One")
+        await create_recipe(client, title="Two")
+
+
+class TestATierCapAsksForNothing:
+    async def test_a_cap_is_402_and_says_the_limit_the_tier_and_the_usage(self, client, hosted):
+        hosted(free={"recipes": 2})
+        await signed_in(client)
+        await create_recipe(client, title="One")
+        await create_recipe(client, title="Two")
+
+        response = await client.post("/recipes", json={"title": "Three", "ingredients": []})
+        assert response.status_code == 402
+        body = response.json()
+        assert body["detail"] == (
+            "This server's free tier allows 2 recipes per household, and this household has 2. "
+            "Nothing has been removed and everything already here still works, so this only stops it growing. "
+            "Delete a recipe nobody cooks (DELETE /recipes/{recipe_id}) to make room for this one."
+        )
+        assert (body["resource"], body["limit"], body["used"], body["tier"]) == ("recipes", 2, 2, "free")
+
+    async def test_over_cap_blocks_only_growth(self, client, hosted):
+        """§5: nothing is deleted, nobody is ejected, everything already there
+        stays readable and usable."""
+        hosted(free={"recipes": 1})
+        await signed_in(client)
+        recipe = await create_recipe(client, title="The one we have")
+
+        assert (await client.post("/recipes", json={"title": "Another", "ingredients": []})).status_code == 402
+        assert (await client.get("/recipes")).status_code == 200
+        assert (await client.get(f"/recipes/{recipe['id']}")).status_code == 200
+        edit = await client.patch(f"/recipes/{recipe['id']}", json={"title": "Renamed"})
+        assert edit.status_code == 200
+        meal = await create_meal(client, name="Dinner", recipe_ids=[recipe["id"]])
+        plan = await create_plan(client)
+        assert (await client.post(f"/plans/{plan['id']}/meals", json={"meal_id": meal["id"]})).status_code == 201
+
+    async def test_deleting_something_makes_room_again(self, client, hosted):
+        hosted(free={"recipes": 1})
+        await signed_in(client)
+        recipe = await create_recipe(client, title="The one we have")
+        assert (await client.post("/recipes", json={"title": "Another", "ingredients": []})).status_code == 402
+
+        assert (await client.delete(f"/recipes/{recipe['id']}")).status_code == 204
+        assert (await client.post("/recipes", json={"title": "Another", "ingredients": []})).status_code == 201
+
+    async def test_a_cached_url_is_returned_rather_than_refused(self, client, hosted):
+        """Re-posting a known source_url is not a new recipe (Q3), so the cap
+        has nothing to say about it."""
+        hosted(free={"recipes": 1})
+        await signed_in(client)
+        url = "https://example.com/chilli"
+        first = await create_recipe(client, title="Chilli", source_url=url, parse_source="ai")
+        again = await client.post("/recipes", json={"title": "Chilli", "source_url": url, "parse_source": "ai"})
+        assert again.status_code == 200
+        assert again.json()["id"] == first["id"]
+
+
+class TestACeilingIsADifferentAnswer:
+    async def test_a_ceiling_is_403_and_says_no_tier_fixes_it(self, client, hosted):
+        hosted(free={"recipes": None}, paid={"recipes": None}, ceiling={"recipes": 1})
+        await signed_in(client)
+        await create_recipe(client, title="One")
+
+        response = await client.post("/recipes", json={"title": "Two", "ingredients": []})
+        assert response.status_code == 403
+        detail = response.json()["detail"]
+        assert "at most 1 recipe per household" in detail
+        assert "No tier on this server goes beyond that" in detail
+
+    async def test_a_cap_the_top_tier_cannot_lift_is_403_not_402(self, client, hosted, set_tier):
+        """Telling somebody already on the largest tier to buy a bigger one
+        would be pointing at something that does not exist."""
+        hosted(free={"recipes": 1}, paid={"recipes": 2})
+        await signed_in(client)
+        await set_tier("paid")
+        await create_recipe(client, title="One")
+        await create_recipe(client, title="Two")
+
+        response = await client.post("/recipes", json={"title": "Three", "ingredients": []})
+        assert response.status_code == 403
+        assert "paid tier allows 2 recipes" in response.json()["detail"]
+
+    async def test_a_paid_household_meeting_a_ceiling_is_worth_alerting_on(self, client, hosted, set_tier, caplog):
+        hosted(paid={"recipes": None}, ceiling={"recipes": 1})
+        await signed_in(client)
+        await set_tier("paid")
+        await create_recipe(client, title="One")
+
+        with caplog.at_level("INFO", logger="meals.events"):
+            assert (await client.post("/recipes", json={"title": "Two", "ingredients": []})).status_code == 403
+        record = next(r for r in caplog.records if r.getMessage() == "limit.reached")
+        assert (record.outcome, record.tier, record.resource) == ("ceiling", "paid", "recipes")
+        assert (record.limit, record.used) == (1, 1)
+
+    async def test_a_comped_household_keeps_the_ceiling(self, client, hosted, set_tier):
+        hosted(ceiling={"recipes": 1})
+        await signed_in(client)
+        await set_tier("unlimited")
+        await create_recipe(client, title="One")
+
+        response = await client.post("/recipes", json={"title": "Two", "ingredients": []})
+        assert response.status_code == 403
+        assert "This server allows at most 1 recipe" in response.json()["detail"]
+
+
+class TestTheShoppingListIsNeverBlocked:
+    """§5, and the reason it is not negotiable (Q11): iOS replays its offline
+    queue through these endpoints and drops any op the server refuses. A cap
+    here deletes what somebody typed in a supermarket."""
+
+    async def test_an_adhoc_add_survives_an_exhausted_ingredient_allowance(self, client, hosted):
+        hosted(free={"ingredients": 1})
+        await signed_in(client)
+        await client.post("/ingredients", json={"name": "milk"})
+        # The allowance really is spent: the same new ingredient through a
+        # growth path is refused.
+        assert (await client.post("/ingredients", json={"name": "bread"})).status_code == 402
+
+        response = await client.post("/shopping-list/items", json={"name": "bin bags", "quantity": 1, "unit": "item"})
+        assert response.status_code == 201
+        assert response.json()["name"] == "bin bags"
+
+    async def test_a_replayed_offline_op_still_lands(self, client, hosted):
+        hosted(free={"ingredients": 1})
+        await signed_in(client)
+        await client.post("/ingredients", json={"name": "milk"})
+
+        item_id = "11111111-2222-3333-4444-555555555555"
+        first = await client.post("/shopping-list/items", json={"id": item_id, "name": "washing up liquid"})
+        assert first.status_code == 201
+        replay = await client.post("/shopping-list/items", json={"id": item_id, "name": "washing up liquid"})
+        assert replay.status_code == 200  # idempotent, not refused
+
+    async def test_finishing_the_shop_is_never_refused(self, client, hosted):
+        hosted(free={"ingredients": 1, "recipes": 1})
+        await signed_in(client)
+        await client.post("/shopping-list/items", json={"name": "milk"})
+        assert (await client.post("/shopping-list/archive")).status_code == 200
+        assert (await client.get("/shopping-list/archived")).status_code == 200
+
+
+class TestEveryResourceHasABoundary:
+    async def test_ingredients(self, client, hosted):
+        hosted(free={"ingredients": 2})
+        await signed_in(client)
+        await client.post("/ingredients", json={"name": "milk"})
+        await client.post("/ingredients", json={"name": "bread"})
+        assert (await client.post("/ingredients", json={"name": "eggs"})).status_code == 402
+        # An ingredient that already exists is not growth.
+        assert (await client.post("/ingredients", json={"name": "milk"})).status_code == 201
+
+    async def test_a_recipes_ingredients_count_too(self, client, hosted):
+        hosted(free={"ingredients": 2})
+        await signed_in(client)
+        response = await client.post(
+            "/recipes",
+            json={
+                "title": "Too many things",
+                "ingredients": [{"name": "milk"}, {"name": "bread"}, {"name": "eggs"}],
+            },
+        )
+        assert response.status_code == 402
+        assert response.json()["resource"] == "ingredients"
+        assert (await client.get("/recipes")).json() == []  # the half-written recipe rolled back
+
+    async def test_meals(self, client, hosted):
+        hosted(free={"meals": 1})
+        await signed_in(client)
+        await create_meal(client, name="Spag bol")
+        response = await client.post("/meals", json={"name": "Chilli"})
+        assert response.status_code == 402
+        assert response.json()["resource"] == "meals"
+
+    async def test_lines_in_one_meal(self, client, hosted):
+        """The same in both tiers, so it is a sanity bound rather than a cap."""
+        hosted(free={"meal_lines": 2, "ingredients": None}, paid={"meal_lines": 2}, ceiling={"meal_lines": 2})
+        await signed_in(client)
+        lines = [{"name": "peas"}, {"name": "carrots"}, {"name": "gravy"}]
+        response = await client.post("/meals", json={"name": "Sunday dinner", "loose_ingredients": lines})
+        assert response.status_code == 403
+        assert "at most 2 lines in one meal" in response.json()["detail"]
+
+        meal = await create_meal(client, name="Sunday dinner", loose_ingredients=lines[:2])
+        grown = await client.patch(f"/meals/{meal['id']}", json={"loose_ingredients": lines})
+        assert grown.status_code == 403
+
+    async def test_a_patch_that_does_not_grow_a_meal_is_fine(self, client, hosted):
+        hosted(free={"meal_lines": 2, "ingredients": None}, paid={"meal_lines": 2}, ceiling={"meal_lines": 2})
+        await signed_in(client)
+        meal = await create_meal(
+            client, name="Sunday dinner", loose_ingredients=[{"name": "peas"}, {"name": "carrots"}]
+        )
+        assert (await client.patch(f"/meals/{meal['id']}", json={"name": "Sunday lunch"})).status_code == 200
+        swapped = await client.patch(f"/meals/{meal['id']}", json={"loose_ingredients": [{"name": "beans"}]})
+        assert swapped.status_code == 200
+
+    async def test_plans(self, client, hosted):
+        hosted(free={"plans": 1})
+        await signed_in(client)
+        await create_plan(client, label="This week")
+        response = await client.post("/plans", json={"label": "Next week"})
+        assert response.status_code == 402
+        assert response.json()["resource"] == "plans"
+
+    async def test_meals_in_one_plan(self, client, hosted):
+        hosted(free={"plan_meals": 1}, paid={"plan_meals": 1}, ceiling={"plan_meals": 1})
+        await signed_in(client)
+        plan = await create_plan(client)
+        first = await create_meal(client, name="Spag bol")
+        second = await create_meal(client, name="Chilli")
+        assert (await client.post(f"/plans/{plan['id']}/meals", json={"meal_id": first["id"]})).status_code == 201
+        response = await client.post(f"/plans/{plan['id']}/meals", json={"meal_id": second["id"]})
+        assert response.status_code == 403
+        assert "at most 1 meal in one plan" in response.json()["detail"]
+
+    async def test_copying_a_plan_stops_at_the_same_line(self, client, hosted):
+        """`copy_from_plan_id` reaches the same helper in a loop, so it has to
+        refuse rather than half-copy — which is why the check is in the helper
+        rather than in the endpoint."""
+        hosted(free={"plans": None, "plan_meals": 2}, paid={"plan_meals": 2}, ceiling={"plan_meals": 2})
+        await signed_in(client)
+        source = await create_plan(client, label="Two weeks ago")
+        for name in ("Spag bol", "Chilli"):
+            meal = await create_meal(client, name=name)
+            assert (await client.post(f"/plans/{source['id']}/meals", json={"meal_id": meal["id"]})).status_code == 201
+
+        # The plan was filled while two were allowed; now only one is.
+        hosted(free={"plans": None, "plan_meals": 1}, paid={"plan_meals": 1}, ceiling={"plan_meals": 1})
+        response = await client.post("/plans", json={"label": "This week", "copy_from_plan_id": source["id"]})
+        assert response.status_code == 403
+        labels = [plan["label"] for plan in (await client.get("/plans")).json()]
+        assert labels == ["Two weeks ago"]  # nothing half-copied survived
+
+    async def test_supermarkets(self, client, hosted):
+        hosted(free={"supermarkets": 1})
+        await signed_in(client)
+        assert (await client.post("/supermarkets", json={"name": "Aldi"})).status_code == 201
+        response = await client.post("/supermarkets", json={"name": "Tesco"})
+        assert response.status_code == 402
+        assert response.json()["resource"] == "supermarkets"
+
+    async def test_api_tokens(self, client, hosted):
+        """Credential hygiene rather than a paywall — but it is still per
+        household, so it counts everyone's."""
+        hosted(free={"api_tokens": 1})
+        await signed_in(client)
+        assert (await client.post("/auth/tokens", json={"label": "Claude"})).status_code == 201
+        response = await client.post("/auth/tokens", json={"label": "A script"})
+        assert response.status_code == 402
+        assert response.json()["resource"] == "api_tokens"
+
+    async def test_the_ai_layer_is_never_gated_by_a_spent_recipe_allowance(self, client, hosted):
+        """Pillar 1 of the positioning: PATs, /skill and /prompt-pack work on
+        every tier. Only *growth* stops."""
+        hosted(free={"recipes": 0})
+        await signed_in(client)
+        assert (await client.post("/auth/tokens", json={"label": "Claude"})).status_code == 201
+        assert (await client.get("/skill")).status_code == 200
+        assert (await client.get("/prompt-pack")).status_code == 200
+
+
+class TestMembersAreTheGate:
+    async def test_a_free_household_cannot_mint_a_usable_invite(self, client, hosted):
+        hosted()  # members: 1 on the free tier, straight from the table
+        await signed_in(client)
+        response = await client.post("/auth/invites", json={})
+        assert response.status_code == 402
+        body = response.json()
+        assert body["resource"] == "members"
+        assert "1 member per household" in body["detail"]
+        assert "keeps full access" in body["detail"]
+
+    async def test_an_invite_issued_before_the_headroom_went_is_refused_on_use(self, client, hosted, set_tier):
+        """The check at redemption is the authoritative one: an invite can
+        outlive the allowance that justified it."""
+        hosted(free={"members": 1}, paid={"members": 2})
+        auth = await signed_in(client)
+        await set_tier("paid")
+        invite = await client.post("/auth/invites", json={})
+        assert invite.status_code == 201
+        code = invite.json()["code"]
+        await set_tier("free")
+
+        response = await client.post(
+            "/auth/register",
+            json={
+                "email": "second@example.com",
+                "password": PASSWORD,
+                "display_name": "Second",
+                "invite_code": code,
+            },
+        )
+        assert response.status_code == 402
+        assert response.json()["resource"] == "members"
+        assert auth  # the existing member is untouched
+
+    async def test_redeeming_into_a_full_household_is_refused(self, client, hosted, set_tier):
+        hosted(free={"members": 1}, paid={"members": 2})
+        host = await signed_in(client)
+        await set_tier("paid")
+        code = (await client.post("/auth/invites", json={})).json()["code"]
+        await set_tier("free")
+
+        joiner = await register(client, email="joiner@example.com", name="Joiner")
+        response = await client.post("/auth/invites/redeem", json={"code": code}, headers=headers(joiner))
+        assert response.status_code == 402
+        assert response.json()["resource"] == "members"
+        # Nobody moved, and the invite is still unredeemed.
+        assert (await client.get("/auth/household", headers=headers(host))).json()["members"] != []
+
+    async def test_a_household_with_headroom_still_admits_people(self, client, hosted, set_tier):
+        hosted(paid={"members": 2})
+        await signed_in(client)
+        await set_tier("paid")
+        code = (await client.post("/auth/invites", json={})).json()["code"]
+        response = await client.post(
+            "/auth/register",
+            json={
+                "email": "second@example.com",
+                "password": PASSWORD,
+                "display_name": "Second",
+                "invite_code": code,
+            },
+        )
+        assert response.status_code == 201
+
+    async def test_registering_a_household_of_your_own_is_never_a_membership_question(self, client, hosted):
+        """The members cap is per household. A stranger starting their own is
+        an instance question (#96), not this one."""
+        hosted()
+        await signed_in(client)
+        response = await client.post(
+            "/auth/register",
+            json={"email": "stranger@example.com", "password": PASSWORD, "display_name": "Stranger"},
+        )
+        assert response.status_code == 201
+
+
+class TestTheIngestQuota:
+    @pytest.fixture
+    def fetch_stub(self, monkeypatch):
+        from app.services import recipe_parser
+        from tests.conftest import fixture_html
+
+        calls: list[str] = []
+
+        def install(name: str = "jsonld_simple.html"):
+            html = fixture_html(name)
+
+            async def fake_fetch(url: str) -> str:
+                calls.append(url)
+                return html
+
+            monkeypatch.setattr(recipe_parser, "fetch_page", fake_fetch)
+            return calls
+
+        return install
+
+    async def test_the_month_runs_out(self, client, hosted, fetch_stub):
+        hosted(free={"ingests_per_month": 1, "recipes": None, "ingredients": None})
+        await signed_in(client)
+        calls = fetch_stub()
+
+        assert (await client.post("/recipes/ingest", json={"url": "https://example.com/a"})).status_code == 200
+        response = await client.post("/recipes/ingest", json={"url": "https://example.com/b"})
+        assert response.status_code == 402
+        detail = response.json()["detail"]
+        assert "1 recipe URL ingest a month" in detail
+        assert "The count resets on" in detail
+        assert "parse_source='ai'" in detail  # the way round it, which costs us nothing
+        assert len(calls) == 1  # refused before the page was fetched
+
+    async def test_a_cached_url_costs_nothing(self, client, hosted, fetch_stub):
+        hosted(free={"ingests_per_month": 1, "recipes": None, "ingredients": None})
+        await signed_in(client)
+        fetch_stub()
+        await client.post("/recipes/ingest", json={"url": "https://example.com/a"})
+        again = await client.post("/recipes/ingest", json={"url": "https://example.com/a"})
+        assert again.status_code == 200
+        assert again.json()["cached"] is True
+
+    async def test_a_failed_fetch_still_costs_the_bandwidth_it_used(self, client, hosted, monkeypatch):
+        """Charged up front, like deps.auth_rate_limit charges an attempt: a
+        refund on failure would make the limit free to evade."""
+        from app.services import recipe_parser
+
+        hosted(free={"ingests_per_month": 1, "recipes": None, "ingredients": None})
+        await signed_in(client)
+
+        async def failing_fetch(url: str) -> str:
+            raise recipe_parser.RecipeFetchError("fetching failed with HTTP 403; POST /recipes instead")
+
+        monkeypatch.setattr(recipe_parser, "fetch_page", failing_fetch)
+        assert (await client.post("/recipes/ingest", json={"url": "https://example.com/a"})).status_code == 422
+        second = await client.post("/recipes/ingest", json={"url": "https://example.com/b"})
+        assert second.status_code == 402
+
+    async def test_deleting_the_recipe_does_not_refund_the_ingest(self, client, hosted, fetch_stub):
+        """The hole a COUNT would leave: ingest, delete, repeat."""
+        hosted(free={"ingests_per_month": 1, "recipes": None, "ingredients": None})
+        await signed_in(client)
+        fetch_stub()
+        ingested = await client.post("/recipes/ingest", json={"url": "https://example.com/a"})
+        await client.delete(f"/recipes/{ingested.json()['recipe']['id']}")
+
+        assert (await client.post("/recipes/ingest", json={"url": "https://example.com/b"})).status_code == 402
+
+    async def test_a_reparse_costs_the_same_fetch(self, client, hosted, fetch_stub):
+        """Otherwise the limit is one POST away from being bypassed: store any
+        URL as a recipe, then re-parse it as often as you like."""
+        hosted(free={"ingests_per_month": 2, "recipes": None, "ingredients": None})
+        await signed_in(client)
+        calls = fetch_stub()
+        recipe = (await client.post("/recipes/ingest", json={"url": "https://example.com/a"})).json()["recipe"]
+
+        assert (await client.post(f"/recipes/{recipe['id']}/reparse", json={})).status_code == 200
+        refused = await client.post(f"/recipes/{recipe['id']}/reparse", json={})
+        assert refused.status_code == 402
+        assert refused.json()["resource"] == "ingests_per_month"
+        assert "PATCH /recipes/{recipe_id}" in refused.json()["detail"]
+        assert len(calls) == 2  # refused before the third fetch
+
+    async def test_a_refused_reparse_leaves_the_recipe_alone(self, client, hosted, fetch_stub):
+        hosted(free={"ingests_per_month": 1, "recipes": None, "ingredients": None})
+        await signed_in(client)
+        fetch_stub()
+        recipe = (await client.post("/recipes/ingest", json={"url": "https://example.com/a"})).json()["recipe"]
+
+        assert (await client.post(f"/recipes/{recipe['id']}/reparse", json={})).status_code == 402
+        assert (await client.get(f"/recipes/{recipe['id']}")).json()["title"] == recipe["title"]
+
+    async def test_posting_a_recipe_directly_is_not_an_ingest(self, client, hosted):
+        hosted(free={"ingests_per_month": 0, "recipes": None, "ingredients": None})
+        await signed_in(client)
+        recipe = await create_recipe(client, title="Read it myself", source_url="https://example.com/a")
+        assert recipe["id"]
+
+    async def test_the_counter_is_the_households_own(self, engine, client, hosted, fetch_stub):
+        hosted(free={"ingests_per_month": 2, "recipes": None, "ingredients": None})
+        await signed_in(client)
+        fetch_stub()
+        await client.post("/recipes/ingest", json={"url": "https://example.com/a"})
+
+        maker = async_sessionmaker(engine, expire_on_commit=False)
+        async with maker() as session:
+            user = (await session.execute(select(User))).scalars().one()
+            household = await session.get(Household, user.household_id)
+            assert household.ingests_used == 1
+            assert household.ingest_period_started_at is not None

--- a/backend/tests/integration/test_limits.py
+++ b/backend/tests/integration/test_limits.py
@@ -191,6 +191,29 @@ class TestACeilingIsADifferentAnswer:
         assert (record.outcome, record.tier, record.resource) == ("ceiling", "paid", "recipes")
         assert (record.limit, record.used) == (1, 1)
 
+    async def test_a_server_that_sells_nothing_never_answers_402(self, client, settings_override):
+        """A self-hoster who caps their own box has nothing to sell anybody, so
+        Payment Required would be a lie — and naming the "unlimited tier" in the
+        sentence would be another one."""
+        settings_override(LIMITS_OVERRIDES=json.dumps({"unlimited": {"recipes": 1}}))
+        await signed_in(client)
+        await create_recipe(client, title="One")
+
+        response = await client.post("/recipes", json={"title": "Two", "ingredients": []})
+        assert response.status_code == 403
+        detail = response.json()["detail"]
+        assert detail.startswith("This server allows at most 1 recipe per household")
+        assert "tier" not in detail.split("No tier")[0]
+
+    async def test_a_cap_with_nothing_bigger_above_it_is_403(self, client, hosted):
+        """Free and paid set to the same number: moving between them would
+        change nothing, so there is nothing to be sold."""
+        hosted(free={"recipes": 1}, paid={"recipes": 1})
+        await signed_in(client)
+        await create_recipe(client, title="One")
+        response = await client.post("/recipes", json={"title": "Two", "ingredients": []})
+        assert response.status_code == 403
+
     async def test_a_comped_household_keeps_the_ceiling(self, client, hosted, set_tier):
         hosted(ceiling={"recipes": 1})
         await signed_in(client)
@@ -301,6 +324,23 @@ class TestEveryResourceHasABoundary:
         assert response.status_code == 402
         assert response.json()["resource"] == "plans"
 
+    async def test_finishing_a_week_frees_the_place_for_the_next_one(self, client, hosted):
+        """Plans cannot be deleted — a plan's cooked history is why — so a cap
+        that counted archived ones could never be got back under, and the weekly
+        loop would simply end. Archiving is the key."""
+        hosted(free={"plans": 1})
+        await signed_in(client)
+        plan = await create_plan(client, label="This week")
+        refused = await client.post("/plans", json={"label": "Next week"})
+        assert refused.status_code == 402
+        assert "POST /plans/{plan_id}/archive" in refused.json()["detail"]
+
+        assert (await client.post(f"/plans/{plan['id']}/archive")).status_code == 200
+        assert (await client.post("/plans", json={"label": "Next week"})).status_code == 201
+        # And the finished week is still there to read.
+        labels = sorted(p["label"] for p in (await client.get("/plans")).json())
+        assert labels == ["Next week", "This week"]
+
     async def test_meals_in_one_plan(self, client, hosted):
         hosted(free={"plan_meals": 1}, paid={"plan_meals": 1}, ceiling={"plan_meals": 1})
         await signed_in(client)
@@ -311,6 +351,25 @@ class TestEveryResourceHasABoundary:
         response = await client.post(f"/plans/{plan['id']}/meals", json={"meal_id": second["id"]})
         assert response.status_code == 403
         assert "at most 1 meal in one plan" in response.json()["detail"]
+
+    async def test_a_full_plan_still_says_it_is_already_there(self, client, hosted):
+        """A write that adds no row cannot cross a limit, so it must not be
+        refused as one — and the plan_meals hint says to archive the plan, which
+        is a destructive thing to tell a retrying assistant to do."""
+        hosted(free={"plan_meals": 1}, paid={"plan_meals": 1}, ceiling={"plan_meals": 1})
+        await signed_in(client)
+        plan = await create_plan(client)
+        meal = await create_meal(client, name="Spag bol")
+        assert (await client.post(f"/plans/{plan['id']}/meals", json={"meal_id": meal["id"]})).status_code == 201
+
+        again = await client.post(f"/plans/{plan['id']}/meals", json={"meal_id": meal["id"]})
+        assert again.status_code == 409
+        assert "already in plan" in again.json()["detail"]
+
+        missing = await client.post(
+            f"/plans/{plan['id']}/meals", json={"meal_id": "11111111-1111-1111-1111-111111111111"}
+        )
+        assert missing.status_code == 422
 
     async def test_copying_a_plan_stops_at_the_same_line(self, client, hosted):
         """`copy_from_plan_id` reaches the same helper in a loop, so it has to
@@ -367,7 +426,7 @@ class TestMembersAreTheGate:
         body = response.json()
         assert body["resource"] == "members"
         assert "1 member per household" in body["detail"]
-        assert "keeps full access" in body["detail"]
+        assert "still works, so this only stops it growing" in body["detail"]
 
     async def test_an_invite_issued_before_the_headroom_went_is_refused_on_use(self, client, hosted, set_tier):
         """The check at redemption is the authoritative one: an invite can
@@ -527,6 +586,23 @@ class TestTheIngestQuota:
 
         assert (await client.post(f"/recipes/{recipe['id']}/reparse", json={})).status_code == 402
         assert (await client.get(f"/recipes/{recipe['id']}")).json()["title"] == recipe["title"]
+
+    async def test_a_full_library_is_refused_before_the_page_is_fetched(self, client, hosted, fetch_stub):
+        """Otherwise a household at its recipe cap spends a month's ingests, and
+        this server's bandwidth, on pages it is about to refuse to store."""
+        hosted(free={"recipes": 1, "ingests_per_month": 5, "ingredients": None})
+        await signed_in(client)
+        calls = fetch_stub()
+        await create_recipe(client, title="The one we have")
+
+        response = await client.post("/recipes/ingest", json={"url": "https://example.com/a"})
+        assert response.status_code == 402
+        assert response.json()["resource"] == "recipes"
+        assert calls == []  # nothing was fetched
+
+        # And the ingest allowance is untouched, so it is still there once room is made.
+        assert (await client.delete(f"/recipes/{(await client.get('/recipes')).json()[0]['id']}")).status_code == 204
+        assert (await client.post("/recipes/ingest", json={"url": "https://example.com/a"})).status_code == 200
 
     async def test_posting_a_recipe_directly_is_not_an_ingest(self, client, hosted):
         hosted(free={"ingests_per_month": 0, "recipes": None, "ingredients": None})

--- a/backend/tests/unit/test_limits.py
+++ b/backend/tests/unit/test_limits.py
@@ -1,0 +1,204 @@
+"""The limits table itself: what it resolves to, what it refuses to be
+configured as, and what its refusals are allowed to say.
+
+The behavioural half lives in tests/integration/test_limits.py. What is here is
+the part that has to hold before any request arrives — above all that an
+unconfigured server has no limits at all, which is the promise the whole feature
+is built on (planning/08-freemium.md §1).
+"""
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from app import limits
+
+
+def _hosted(settings_override, **overrides):
+    settings_override(
+        LIMITS_PROFILE="hosted",
+        LIMITS_OVERRIDES=json.dumps(overrides),
+        DEFAULT_HOUSEHOLD_TIER="free",
+    )
+
+
+class TestUnconfiguredIsUnlimited:
+    def test_nothing_is_configured_by_default(self):
+        assert limits.anything_configured() is False
+
+    def test_every_tier_resolves_to_unlimited(self):
+        for tier in limits.TIERS:
+            assert limits.limits_for(tier) == limits.UNLIMITED_LIMITS
+        assert limits.ceilings() == limits.UNLIMITED_LIMITS
+
+    def test_a_new_household_starts_unlimited(self):
+        assert limits.default_tier() == limits.UNLIMITED
+
+    def test_every_limits_field_defaults_to_none(self):
+        """None means unlimited. A field that defaulted to 0 would mean a
+        self-hoster's first recipe was refused."""
+        for name in limits.RESOURCE_NAMES:
+            assert getattr(limits.UNLIMITED_LIMITS, name) is None
+
+
+class TestProfileResolution:
+    def test_the_hosted_profile_is_the_documented_table(self, settings_override):
+        _hosted(settings_override)
+        assert limits.anything_configured() is True
+        free = limits.limits_for("free")
+        assert (free.members, free.recipes, free.ingredients, free.meals) == (1, 50, 500, 100)
+        assert (free.plans, free.supermarkets, free.api_tokens, free.ingests_per_month) == (20, 2, 3, 20)
+        paid = limits.limits_for("paid")
+        assert (paid.members, paid.recipes, paid.plans, paid.ingests_per_month) == (8, 2_000, 1_000, 500)
+        ceiling = limits.ceilings()
+        assert (ceiling.members, ceiling.recipes, ceiling.ingredients) == (12, 5_000, 10_000)
+
+    def test_the_unlimited_tier_is_a_comp_and_keeps_the_ceiling(self, settings_override):
+        """Comping somebody lifts their caps. It does not lift the ceilings,
+        which are there to protect the box rather than to sell anything."""
+        _hosted(settings_override)
+        assert limits.limits_for("unlimited").recipes is None
+        assert limits.ceilings().recipes == 5_000
+
+    def test_an_unknown_tier_resolves_to_unlimited(self, settings_override):
+        """A tier this build has never heard of must not lock a household out of
+        its own data — the additive-only contract, applied to a column."""
+        _hosted(settings_override)
+        assert limits.limits_for("enterprise-platinum") == limits.UNLIMITED_LIMITS
+
+    def test_overrides_land_on_top_of_the_profile(self, settings_override):
+        _hosted(settings_override, free={"recipes": 3})
+        assert limits.limits_for("free").recipes == 3
+        assert limits.limits_for("free").meals == 100  # everything else survives
+
+    def test_an_override_of_null_means_unlimited(self, settings_override):
+        _hosted(settings_override, ceiling={"recipes": None})
+        assert limits.ceilings().recipes is None
+
+    def test_overrides_alone_are_enough_to_configure_a_server(self, settings_override):
+        """A self-hoster who wants one cap and none of the hosted numbers should
+        not have to adopt a profile to get it."""
+        settings_override(LIMITS_OVERRIDES=json.dumps({"unlimited": {"recipes": 10}}))
+        assert limits.anything_configured() is True
+        assert limits.limits_for("unlimited").recipes == 10
+        assert limits.limits_for("free").recipes is None
+
+
+class TestConfigurationIsChecked:
+    """A typo should stop the container at startup, not surface as a 500 on
+    somebody's fiftieth recipe — app/main.py calls check_settings() at import."""
+
+    def test_a_good_configuration_passes(self, settings_override):
+        _hosted(settings_override, free={"recipes": 3}, ceiling={"members": None})
+        limits.check_settings()
+
+    def test_an_unknown_profile_is_refused(self, settings_override):
+        settings_override(LIMITS_PROFILE="generous")
+        with pytest.raises(ValueError, match="not a profile"):
+            limits.check_settings()
+
+    def test_an_unknown_default_tier_is_refused(self, settings_override):
+        settings_override(DEFAULT_HOUSEHOLD_TIER="platinum")
+        with pytest.raises(ValueError, match="not a tier"):
+            limits.check_settings()
+
+    def test_an_unknown_override_section_is_refused(self, settings_override):
+        settings_override(LIMITS_OVERRIDES=json.dumps({"gold": {"recipes": 5}}))
+        with pytest.raises(ValueError, match="sections are"):
+            limits.check_settings()
+
+    def test_an_unknown_resource_is_refused(self, settings_override):
+        settings_override(LIMITS_OVERRIDES=json.dumps({"free": {"casseroles": 5}}))
+        with pytest.raises(ValueError, match="not a limit"):
+            limits.check_settings()
+
+    def test_a_negative_limit_is_refused(self, settings_override):
+        settings_override(LIMITS_OVERRIDES=json.dumps({"free": {"recipes": -1}}))
+        with pytest.raises(ValueError, match="non-negative whole number"):
+            limits.check_settings()
+
+    def test_a_limit_that_is_not_a_number_is_refused(self, settings_override):
+        """This one is pydantic's rather than ours, but it still has to stop the
+        container rather than pass through as something unusable."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            settings_override(LIMITS_OVERRIDES=json.dumps({"free": {"recipes": "lots"}}))
+            limits.check_settings()
+
+
+class TestRefusalsSayNothingAboutMoney:
+    """planning/08-freemium.md §6: all commerce lives on the web, and an error
+    string is a call to action if it points anywhere. iOS renders 4xx details
+    verbatim, so every sentence this module can produce has to be equally true
+    on a self-hosted instance — which is exactly what this asserts."""
+
+    FORBIDDEN = (
+        "upgrade",
+        "subscribe",
+        "subscription",
+        "premium",
+        "pricing",
+        "pay ",
+        "payment",
+        "purchase",
+        "billing",
+        "£",
+        "$",
+        "http://",
+        "https://",
+        "@",
+    )
+
+    def _every_refusal(self):
+        for name, spec in limits.RESOURCES.items():
+            for kind in ("cap", "ceiling"):
+                for upgradable in (True, False):
+                    yield name, limits._refusal(spec, tier="free", limit=50, used=50, kind=kind, upgradable=upgradable)
+
+    def test_no_refusal_mentions_money_or_points_anywhere(self):
+        for name, sentence in self._every_refusal():
+            lowered = sentence.lower()
+            for word in self.FORBIDDEN:
+                assert word not in lowered, f"{name} refusal says {word!r}: {sentence}"
+
+    def test_a_refusal_names_the_limit_the_tier_and_the_number_in_use(self):
+        sentence = limits._refusal(
+            limits.RESOURCES["recipes"], tier="free", limit=50, used=50, kind="cap", upgradable=True
+        )
+        assert "free tier" in sentence
+        assert "50 recipes" in sentence
+        assert "this household has 50" in sentence
+        assert "still works" in sentence  # nothing was deleted
+
+    def test_a_ceiling_says_no_tier_fixes_it(self):
+        sentence = limits._refusal(
+            limits.RESOURCES["recipes"], tier="paid", limit=5_000, used=5_000, kind="ceiling", upgradable=False
+        )
+        assert "at most 5,000 recipes" in sentence
+        assert "No tier on this server goes beyond that" in sentence
+
+    def test_a_refusal_ends_with_something_to_do_instead(self):
+        for name, spec in limits.RESOURCES.items():
+            assert spec.hint, f"{name} refuses without saying what to do instead"
+
+    def test_one_of_something_reads_as_singular(self):
+        sentence = limits._refusal(
+            limits.RESOURCES["members"], tier="free", limit=1, used=1, kind="cap", upgradable=True
+        )
+        assert "1 member per household" in sentence
+
+
+class TestTheIngestMonth:
+    def test_the_next_month_is_found_whatever_the_month_length(self):
+        for start, expected in (
+            (datetime(2026, 1, 1, tzinfo=UTC), datetime(2026, 2, 1, tzinfo=UTC)),
+            (datetime(2026, 2, 1, tzinfo=UTC), datetime(2026, 3, 1, tzinfo=UTC)),
+            (datetime(2024, 2, 1, tzinfo=UTC), datetime(2024, 3, 1, tzinfo=UTC)),  # leap year
+            (datetime(2026, 12, 1, tzinfo=UTC), datetime(2027, 1, 1, tzinfo=UTC)),
+        ):
+            assert limits._next_month(start) == expected
+
+    def test_a_month_starts_at_its_first_instant(self):
+        assert limits._month_start(datetime(2026, 8, 21, 17, 4, 3, 9, tzinfo=UTC)) == datetime(2026, 8, 1, tzinfo=UTC)


### PR DESCRIPTION
Closes #94. Item 1 of `planning/08-freemium.md` §8.

`app/limits.py` holds one `Limits` set of numbers per tier and one `enforce()`
the write paths call immediately before a row is inserted. **With nothing
configured it returns before it runs a single query**, so a server that sets
nothing has no caps, no paywall, and nothing anywhere that says a hosted tier
exists — the 625 tests that existed before this branch pass unchanged, which is
the assertion that matters most.

`LIMITS_PROFILE=hosted` runs §3's table, `LIMITS_OVERRIDES` tunes any single
number as JSON, and `DEFAULT_HOUSEHOLD_TIER` says what a new registration starts
on. Existing households backfill to `unlimited`, so the family instance notices
nothing.

## Two refusals, because a caller has to act differently

A tier cap something above it would lift answers **402**, and says so *only in
the status code*: the sentence stays factual and points nowhere, so it reads the
same on a self-hosted box and the iPhone app can render it verbatim without
becoming a shop (§6). A fair-use ceiling — or a cap nothing can be bought to
lift — answers **403**. Both name the limit, the tier and the number in use, and
end with something to do instead. Every block logs `limit.reached`;
`outcome="ceiling"` with `tier="paid"` is the one worth alerting on.

`UPGRADE_PATH` is the whole of the 402-vs-403 judgement, and it is deliberately a
path rather than "is some other tier bigger" — otherwise a self-hoster who capped
only their own default tier would have their own server answer them
402 Payment Required.

## Three scope calls, flagged rather than buried

1. **`enforce()` is called from four routers, not only from services.** Recipes,
   ingredients and the ingest quota live in `services/`; meals, plans,
   supermarkets and the auth resources have no service module, so the call is in
   the router. No router holds a number or picks a status code — the module
   decides everything — but inventing four service modules to satisfy the letter
   of the issue would have been a far larger diff than #94.
2. **Four rows of §3's table are deliberately unenforced**, each for a stated
   reason in the module docstring: items-per-list and archived-shops (both under
   `/shopping-list*`, which §5 exempts — `ShoppingListStore.swift:256` *drops*
   any op the server refuses, so a cap there deletes what someone typed in a
   supermarket); archived-shops-readable (§3 says a free household sees its last
   three, §5 says everything already there stays readable — §5 wins); and
   per-token request limits, which are a rate limiter answering 429, not a count.
3. **The ingest quota covers `POST /recipes/{id}/reparse` too.** Same outbound
   fetch, same cost; metering only `/recipes/ingest` leaves the limit one POST
   away from bypass — store any URL as a recipe, then re-parse it in a loop.

## One product decision inside this

**Archived plans are not counted.** There is no `DELETE /plans/{id}` — a plan's
`cooked_events` are why — so counting them made the cap a wall with no key: a
free household would plan its twentieth week and never plan another, with iOS's
"add to plan" dead behind it (`PlanStore.planForWriting` creates the plan
implicitly). Finishing a week now frees the place for the next one, which is the
loop the product already has. The alternative was a new `DELETE /plans/{id}`
endpoint; happy to swap if you'd rather.

## Migration

`b1d73e5c9a24`, six additive columns on `households`, safe under a start-first
rollout. `tier`, the price snapshot the founding-price-for-life promise needs,
and the URL-ingest counter — which has to be stored rather than counted, because
counting rows would refund the quota every time a recipe was deleted, and
delete-and-retry is the loop it exists to stop.

## Checks

- 692 tests pass (67 new), `make lint` clean.
- Migration verified on SQLite up → down → up; `alembic check` reports no drift
  on `households`.
- Startup refuses a bad `LIMITS_*` value rather than 500ing on someone's
  fiftieth recipe.
- Smoke-tested against the real `hosted` numbers: 50 recipes then 402, invite
  then 402, and a shopping-list add still 201 while over the recipe cap.
- Reviewed by five adversarial passes; five confirmed findings fixed in c9ab2b7,
  plus one the verifiers wrongly refuted.

`planning/08-freemium.md` itself is still on the branch behind #101, so the doc
references here resolve once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
