### PR TITLE
Stop loo roll landing in the bakery, and shelve water

### DIFF
--- a/backend/app/services/aisles.py
+++ b/backend/app/services/aisles.py
@@ -198,6 +198,7 @@ _KEYWORDS: dict[str, str] = {
     "cannellini beans": "🥫",
     "chickpeas": "🥫",
     "coconut milk": "🥫",
+    "water chestnut": "🥫",  # guard: the "water" keyword would put these in Drinks
     "tuna": "🥫",
     "sweetcorn tin": "🥫",
     "olives": "🥫",
@@ -257,6 +258,7 @@ _KEYWORDS: dict[str, str] = {
     "bicarbonate of soda": "🍝",
     "yeast": "🍝",
     "vanilla extract": "🍝",
+    "rose water": "🍝",  # guard: a flavouring, not a drink
     "olive oil": "🍝",
     "vegetable oil": "🍝",
     "sunflower oil": "🍝",
@@ -302,6 +304,7 @@ _KEYWORDS: dict[str, str] = {
     "juice": "🥤",
     "squash": "🥤",
     "sparkling water": "🥤",
+    "water": "🥤",
     "cola": "🥤",
     "lemonade": "🥤",
     "beer": "🥤",
@@ -336,6 +339,8 @@ _KEYWORDS: dict[str, str] = {
     "bin bags": "🧴",
     "kitchen roll": "🧴",
     "toilet roll": "🧴",
+    "loo roll": "🧴",
+    "toilet paper": "🧴",
     "washing up liquid": "🧴",
     "dishwasher tablets": "🧴",
     "laundry detergent": "🧴",

--- a/backend/tests/unit/test_aisles.py
+++ b/backend/tests/unit/test_aisles.py
@@ -21,6 +21,16 @@ class TestGuessAisle:
             ("shampoo", "🧼"),
             ("sun cream", "🧼"),  # longest keyword wins over 'cream'
             ("toilet roll", "🧴"),  # paper goods stay household
+            ("loo roll", "🧴"),  # longest keyword wins over 'roll' -> bakery
+            ("loo rolls", "🧴"),
+            ("toilet paper", "🧴"),
+            ("bread rolls", "🍞"),  # 'roll' still means bakery when it is bread
+            ("sausage roll", "❄️"),
+            ("water", "🥤"),
+            ("bottled water", "🥤"),
+            ("watercress", "🥬"),  # whole-word matching: 'water' must not match inside it
+            ("water chestnuts", "🥫"),  # longest keyword wins over 'water'
+            ("rose water", "🍝"),  # a flavouring, shelved with vanilla extract
             ("smoked paprika", "🌶️"),
             ("self-raising flour", "🍝"),
             ("sourdough", "🍞"),


### PR DESCRIPTION
Two aisle-table gaps that #103 surfaced. They matter more now than they did, because a voice add goes through `guess_aisle` with no chance for a human to correct it on the way in.

### `loo roll` → Bakery

It had no keyword of its own, so it fell through to the single-word `roll`. `toilet roll` and `kitchen roll` were already in the table; this finishes the set and adds `toilet paper` alongside. Longest-keyword-wins handles the rest, and `bread rolls` and `sausage roll` are unaffected.

### `water` → ❓

Not in the table at all, so bottled water arrived unknown. Adding it needs two guards, because a single-word keyword matches any whole word in the name:

- `water chestnut` → 🥫, or it becomes a drink rather than a tin.
- `rose water` → 🍝, a flavouring, shelved next to `vanilla extract` the way the table already handles those.

`watercress` was never at risk, since single-word keywords match whole words only, but there's now a test saying so — that's exactly the sort of invariant a later refactor breaks silently.

### Notes

- **No vocabulary change**, so the skill stays in step; this is keywords only.
- **Only affects ingredients created from here on.** An existing row keeps the aisle it was stored with and still needs `PATCH /ingredients` to move. Worth a look at any `loo roll` already in a household catalogue.

Five keyword lines, ten test cases. `make lint` clean, 635 backend + 62 mcp tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)