### PR TITLE
List Buy Me a Coffee alongside GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,8 +1,12 @@
 # Funding links shown on the repo's Sponsor button.
-# GitHub Sponsors is enrolled (0% platform fee for personal accounts) and the
-# profile is live at https://github.com/sponsors/marco308, so the github line
-# is active. Buy Me a Coffee stays commented until that account exists,
-# because uncommenting a line whose account is not set up shows visitors a
-# broken destination. See planning/06-marketing.md, Route 3.
-github: [marco308]
-# buy_me_a_coffee: marco308
+# GitHub Sponsors first (0% platform fee for personal accounts), profile live
+# at https://github.com/sponsors/marco308. Buy Me a Coffee second, for the
+# non-GitHub crowd, live at https://buymeacoffee.com/marcuslab. Both are the
+# two routes planning/06-marketing.md, Route 3 asks for, and both are the same
+# pair mdone lists.
+#
+# This file is necessary but not sufficient: the button also needs
+# Settings > General > Features > Sponsorships ticked on the repo, which is
+# why meals showed no button for three days with a valid file in place.
+github: marco308
+buy_me_a_coffee: marcuslab

--- a/planning/06-marketing.md
+++ b/planning/06-marketing.md
@@ -181,10 +181,14 @@ routes 1 and 3. A tip-jar IAP can come later without changing this.
 ### Route 3: donations and sponsorship (DO NOW, expect little)
 
 - **GitHub Sponsors** first: **0% platform fee** from personal accounts,
-  native Sponsor button, FUNDING.yml scaffold is in this branch (commented
-  until the account is enrolled).
+  native Sponsor button, enrolled and live at
+  https://github.com/sponsors/marco308.
 - **Buy Me a Coffee** second, for the non-GitHub crowd: ~5% platform fee,
-  realistically 8 to 9% after processing.
+  realistically 8 to 9% after processing. Live at
+  https://buymeacoffee.com/marcuslab.
+- Both are listed in `.github/FUNDING.yml`. The Sponsor button needs the
+  repo's **Settings > General > Features > Sponsorships** box ticked as well:
+  a valid FUNDING.yml on its own renders nothing.
 - Perks that cost nothing: a name in `SUPPORTERS.md` (file created in this
   branch), first crack at TestFlight builds.
 


### PR DESCRIPTION
`meals` shows no Sponsor button; `mdone` does. Two separate things were going on.

**The file.** `mdone` lists both `github: marco308` and `buy_me_a_coffee: marcuslab`. `meals` listed only GitHub Sponsors, with the Buy Me a Coffee line commented out behind a note saying the account did not exist. It does now: `buymeacoffee.com/marcuslab` and `github.com/sponsors/marco308` both answer 200. Both are in the file now, scalar form, same as `mdone`.

**Why the button is still missing, and this PR cannot fix it.** The old config was valid (GitHub documents `github: [user]` as well as `github: user`), so the YAML was never the problem. The Sponsor button also needs **Settings → General → Features → Sponsorships** ticked on the repo. `mdone` has it, `meals` does not, and there is no REST field for it (`PATCH /repos/...` accepts `has_sponsorships` and silently discards it). It is a one-click change in the web UI, and the button appears once it is ticked.

Both facts are now recorded in `.github/FUNDING.yml` and in `planning/06-marketing.md` Route 3, which still claimed the funding lines were commented out pending enrolment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)