### PR TITLE
Put the coffee button on the site's Supporter tier

### DIFF
--- a/SUPPORTERS.md
+++ b/SUPPORTERS.md
@@ -1,7 +1,7 @@
 # Supporters
 
-People who chip in to keep the free thing free, via GitHub Sponsors.
-Listed here if they want to be, with a link if they like.
+People who chip in to keep the free thing free, via GitHub Sponsors or Buy
+Me a Coffee. Listed here if they want to be, with a link if they like.
 Supporters also get first crack at TestFlight builds.
 
 Nobody yet. Be the first, and enjoy disproportionate prominence.

--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -694,6 +694,7 @@ mark {
   color: var(--leek);
 }
 .tier .btn { display: block; }
+.tier .btn + .btn { margin-top: .55rem; }
 .tier .small {
   font-size: .78rem;
   color: var(--ink-mute);

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,7 +11,7 @@
 <meta property="og:type" content="website">
 <!-- bump ?v= whenever site.css changes: the HTML is always revalidated,
      so a new query string forces every browser past its cached stylesheet -->
-<link rel="stylesheet" href="assets/site.css?v=2">
+<link rel="stylesheet" href="assets/site.css?v=3">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🍳</text></svg>">
 </head>
 <body>
@@ -319,6 +319,8 @@
         <li>Warm glow, genuine gratitude</li>
       </ul>
       <a class="btn" href="https://github.com/sponsors/marco308">Sponsor on GitHub</a>
+      <a class="btn ghost" href="https://buymeacoffee.com/marcuslab">Buy me a coffee</a>
+      <p class="small">GitHub takes no cut of the first one, so it is the one that helps most.</p>
     </article>
   </div>
 


### PR DESCRIPTION
Follow-up to #105, which was merged while this was being written. That PR added Buy Me a Coffee to `.github/FUNDING.yml`; the marketing site's Supporter tier still offered only one way to pay.

The coffee link goes under the solid "Sponsor on GitHub" button in ghost style, with a line explaining the order: GitHub takes no cut and Buy Me a Coffee costs 8 to 9% all in, so a visitor choosing at random costs money that a visitor who is told does not.

Plain `<a>`, no vendor badge, because the site makes no external requests. It is the first `.tier .btn` on the page to have a sibling, hence the one new CSS rule; `site.css` is cache-busted to `v=3`.

Checked in the browser at desktop width: all three tier cards stay 516px, both buttons render full width, ghost styling resolves as intended, no horizontal overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)