### PR TITLE
Cut 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,11 +58,20 @@ this changes nothing about how the deployment behaves.
   up front and committed before the page is fetched — the bandwidth is spent
   whether or not the page turns out to be readable — and `POST
   /recipes/{id}/reparse` costs the same allowance as `POST /recipes/ingest`,
-  since it makes the same outbound request. A household whose library is
-  already full is refused before either, so a full library never costs a fetch. Archived plans are not counted
-  against the plans cap: there is no way to delete a plan — its cooked history
-  is the reason — so counting them would end the weekly loop at plan 21 with no
-  way back, and finishing a week is what frees the place for the next one.
+  since it makes the same outbound request. A household whose library is already
+  full is refused before either, so a full library never costs a fetch.
+- **Archived plans do not count against the plans cap.** There is no way to
+  delete a plan — its cooked history is the reason — so counting them would have
+  made that cap a wall nothing could bring a household back under: the twentieth
+  week planned and never another, with the iPhone app's "add to plan" dead
+  behind it. Finishing a week is what frees the place for the next one.
+- **Loo roll, toilet paper and water find their aisles**, and two guards keep
+  the new "water" keyword honest: water chestnuts stay in tins and rose water
+  stays with the baking. Keywords only — the aisle vocabulary the skill
+  publishes is unchanged, so no client needs to know.
+- **`integrations/node-red/`**: a worked example that drains an Alexa shopping
+  list into the household's via `POST /shopping-list/items`. It talks to the
+  public API and ships nothing into the image.
 
 ### Unchanged on purpose
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -44,7 +44,7 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(
     lifespan=lifespan,
     title="Meals API",
-    version="1.0.2",
+    version="1.1.0",
     description=(
         "A meal *options* planner (not a rigid Mon–Sun grid) with a recipe library and an "
         "aisle-sorted shopping list. Designed to be driven by any AI assistant: every error "

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meals-backend"
-version = "1.0.2"
+version = "1.1.0"
 description = "Meal options planner backend — recipes, meals, plans, aisle-sorted shopping list, AI-friendly API"
 requires-python = ">=3.12"
 dependencies = [

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meals-mcp"
-version = "1.0.2"
+version = "1.1.0"
 description = "MCP server wrapping the Meals REST API with task-level tools for AI assistants"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
The release commit for **v1.1.0**. Six PRs have merged since v1.0.2 and one of
them adds a feature, so this is a minor rather than a patch.

- `backend/pyproject.toml`, `mcp/pyproject.toml` and the FastAPI `version=` all
  move to 1.1.0 together, because the release job fails if any of them disagrees
  with the tag and the deploy compares the live `api_version` against the
  release it deployed. v1.0.1 shipped an API that reported 1.0.0; this is the
  check that stopped that happening twice.
- The release note gains entries for the two things that merged alongside the
  limits work and had none: the aisle keywords from #104 (keywords only — the
  vocabulary the skill publishes is unchanged) and the Node-RED integration from
  #103.
- One paragraph in the limits entry is split, so "archived plans do not count"
  is its own bullet rather than a tail on the ingest one.

`## Unreleased` stays as it is until the deploy actually happens — "released"
means live on `meals.marcuslab.uk`, and the `Deployed: …` commit is what renames
it, the same way #52's did.

Merging this, then `git push origin v1.1.0`, is the ritual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
