### PR TITLE
Deployed: hosted tier limits are live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,16 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 
 ## Unreleased
 
-**One migration**, `b1d73e5c9a24`: six new columns on `households`, all
-additive, all safe under a start-first rollout. Every existing household
-backfills to `tier = 'unlimited'`, which means no limits at all — so applying
-this changes nothing about how the deployment behaves.
+Nothing merged since the last deploy.
+
+## 2026-08-22 — hosted tier limits
+
+Deployed to `meals.marcuslab.uk` as **1.1.0**. **One migration**,
+`b1d73e5c9a24`, applied on rollout: six additive columns on `households`, and
+both existing households backfilled to `tier = 'unlimited'`. No `LIMITS_*` is
+set on this deployment, so nothing about it is capped and nothing behaves
+differently — which is the promise the feature is built on, checked rather than
+assumed.
 
 ### Added
 


### PR DESCRIPTION
Changelog bookkeeping after the deploy. `## Unreleased` becomes
`## 2026-08-22 — hosted tier limits`, the same way #52's release did it — the
file's own rule is that "released" means live on the deployment, not merged to
main, so the rename waits for the deploy rather than riding the tag.

1.1.0 went out by digest and verified itself:

- live `api_version` is `1.1.0`, checked *after* the rollout converged, so it
  cannot be the outgoing container answering;
- every service running the digest the deploy asked for;
- `/healthz`, `/client-config`, `/skill`, `/prompt-pack`, `/privacy`,
  `/support`, the web app and an MCP initialize handshake, all through Traefik.

Migration `b1d73e5c9a24` applied on the way in. Checked against the running
database rather than assumed from the defaults: `alembic_version` is
`b1d73e5c9a24`, all six columns are on `households`, both households read
`tier = 'unlimited'`, and no `LIMITS_*` is set either in the stack env or in the
running container. Nothing is capped and nothing behaves differently, which is
the claim the whole feature rests on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
