### PR TITLE
Let the backup sidecar recover from a missed night, and bound the dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,32 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 
 ## Unreleased
 
-Nothing merged since the last deploy.
+Version **1.1.1**. No migration.
+
+### Fixed
+
+- **The backup sidecar can recover from a missed night again.** One failed run
+  used to stop backups indefinitely: `freshness.sh` (which is the HEALTHCHECK)
+  fails at 36h, swarm then kills the container roughly every 25 minutes, but
+  `BACKUP_ON_START=auto` only took a dump when *no* dump existed at all. A
+  stale-but-present dump therefore sent every restart straight back to sleeping
+  until the scheduled time, which it was always killed long before reaching.
+  One missed night on 2026-08-20 cost three days with no backup while the
+  service looked merely restarty. `BACKUP_ON_START=auto` now asks
+  `freshness.sh` instead of asking whether a file exists, so the check that
+  kills the container is the same one that decides to dump on start, and a kill
+  becomes the recovery rather than the trap.
+- **A wedged backup can no longer stop the nightly loop.** `pg_dump` ran with no
+  timeout of any kind, so a database that accepts a connection but never answers
+  left it blocked forever: no dump, no `.part` file, and no event line, which is
+  exactly what the 2026-08-20 miss looked like. `PGCONNECT_TIMEOUT` (15s) bounds
+  getting a connection and `DUMP_TIMEOUT_S` (1h) bounds the dump itself, both
+  failing loudly so `outcome=error` reaches the staleness alert. `RUN_TIMEOUT_S`
+  (2h) is a backstop around the whole run, so a hang nobody predicted still
+  leaves the loop running. Partial dumps are now cleaned up on failure instead
+  of accumulating. Where `timeout` is unavailable the scripts run unbounded
+  rather than not at all, since depending on a missing command would recreate
+  the very bug these guard against.
 
 ## 2026-08-22 — hosted tier limits
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -44,7 +44,7 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(
     lifespan=lifespan,
     title="Meals API",
-    version="1.1.0",
+    version="1.1.1",
     description=(
         "A meal *options* planner (not a rigid Mon–Sun grid) with a recipe library and an "
         "aisle-sorted shopping list. Designed to be driven by any AI assistant: every error "

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meals-backend"
-version = "1.1.0"
+version = "1.1.1"
 description = "Meal options planner backend — recipes, meals, plans, aisle-sorted shopping list, AI-friendly API"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "meals-backend"
-version = "1.0.2"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosmtplib" },
@@ -890,7 +890,7 @@ dev = [
 
 [[package]]
 name = "meals-mcp"
-version = "1.0.2"
+version = "1.1.1"
 source = { directory = "../mcp" }
 dependencies = [
     { name = "httpx" },

--- a/backup/README.md
+++ b/backup/README.md
@@ -43,12 +43,15 @@ docker compose logs backup                    # one line per run
 | `PGPASSWORD` / `PGPASSWORD_FILE` | — | Password, or a file holding it (docker secret) |
 | `BACKUP_DIR` | `/backups` | Holds `daily/` and `weekly/`. Mount a volume here |
 | `BACKUP_AT` | `03:15` | Daily run time, **UTC** |
-| `BACKUP_ON_START` | `auto` | `auto` dumps at startup only when there are none; `always`, `never` |
+| `BACKUP_ON_START` | `auto` | `auto` dumps at startup whenever there is no dump newer than `STALE_AFTER_HOURS` (so a container that has fallen behind catches up rather than waiting for the next scheduled run); `always`, `never` |
 | `KEEP_DAILY` `KEEP_WEEKLY` | `7` `4` | Retention, local and offsite |
 | `RCLONE_REMOTE` | — | e.g. `gdrive:meals-backups`. Empty means local-only |
 | `RCLONE_CONFIG_FILE` | — | Read-only rclone config (a secret or a bind mount); copied to `RCLONE_CONFIG` (`/tmp/rclone.conf`), because rclone rewrites its config when it refreshes a token |
 | `BACKUP_PASSPHRASE_FILE` | — | File holding the gpg passphrase. **Required** whenever `RCLONE_REMOTE` is set |
-| `STALE_AFTER_HOURS` | `36` | How old the newest dump may be before the healthcheck fails |
+| `STALE_AFTER_HOURS` | `36` | How old the newest dump may be before the healthcheck fails, and before `BACKUP_ON_START=auto` dumps at startup |
+| `DUMP_TIMEOUT_S` | `3600` | How long `pg_dump` may run before it is killed and the run logged as an error |
+| `RUN_TIMEOUT_S` | `7200` | Backstop around a whole run, so a hang can never stop the nightly loop |
+| `PGCONNECT_TIMEOUT` | `15` | Seconds to get a database connection before giving up |
 | `LOG_FORMAT` | `json` | `text` for a human at a terminal |
 
 The image is built `FROM postgres:17-alpine` to match the database, and that

--- a/backup/backup.sh
+++ b/backup/backup.sh
@@ -23,6 +23,8 @@ RCLONE_REMOTE="${RCLONE_REMOTE:-}"
 # refuses rather than quietly sending a household's data somewhere in the clear.
 BACKUP_PASSPHRASE_FILE="${BACKUP_PASSPHRASE_FILE:-}"
 LOG_FORMAT="${LOG_FORMAT:-json}"
+# How long a dump may take before it is treated as wedged. See the dump section.
+DUMP_TIMEOUT_S="${DUMP_TIMEOUT_S:-3600}"
 
 DAILY_DIR="${BACKUP_DIR}/daily"
 WEEKLY_DIR="${BACKUP_DIR}/weekly"
@@ -90,6 +92,9 @@ if [ -n "${PGPASSWORD_FILE:-}" ]; then
     PGPASSWORD="$(cat "${PGPASSWORD_FILE}")"
     export PGPASSWORD
 fi
+# A dump that cannot get a connection must fail rather than wait for one; the
+# default here is no timeout at all.
+export PGCONNECT_TIMEOUT="${PGCONNECT_TIMEOUT:-15}"
 export PGHOST="${PGHOST:-db}"
 export PGPORT="${PGPORT:-5432}"
 export PGUSER="${PGUSER:-meals}"
@@ -132,7 +137,35 @@ final="${DAILY_DIR}/${name}"
 # pg_restore can list it, restore it selectively, and parallelise. The
 # database is a few megabytes of family recipes — PITR/WAL archiving would be
 # more machinery than the thing it protects.
-pg_dump --format=custom --compress=9 --file="${partial}" || fail dump "pg_dump failed"
+# A dump that hangs is worse than one that fails: `fail` never runs, so there is
+# no event line to alert on, and the loop in entrypoint.sh never comes back
+# round to try again tomorrow. That is the shape of the 2026-08-20 miss — no
+# dump, no `.part` file and no log line, which is what pg_dump blocked on an
+# unresponsive database looks like. PGCONNECT_TIMEOUT bounds getting a
+# connection; this bounds everything after it.
+# Empty if the base image has no `timeout`: bounding the dump matters, but not
+# so much that its absence should stop backups happening at all.
+dump_timeout=""
+if command -v timeout >/dev/null 2>&1; then
+    dump_timeout="timeout ${DUMP_TIMEOUT_S}"
+fi
+dump_status=0
+# Unquoted on purpose: ${dump_timeout} is a command prefix, not one argument.
+# shellcheck disable=SC2086
+${dump_timeout} pg_dump --format=custom --compress=9 --file="${partial}" || dump_status=$?
+# busybox timeout reports 128+SIGTERM, GNU coreutils reports 124. Accept both so
+# this keeps its meaning if the base image ever stops being Alpine.
+case "${dump_status}" in
+    0) ;;
+    124 | 143)
+        rm -f "${partial}"
+        fail dump "pg_dump did not finish within ${DUMP_TIMEOUT_S}s and was killed"
+        ;;
+    *)
+        rm -f "${partial}"
+        fail dump "pg_dump failed with status ${dump_status}"
+        ;;
+esac
 
 # The verification that makes this a backup rather than a file: read the table
 # of contents back out of what was just written.

--- a/backup/entrypoint.sh
+++ b/backup/entrypoint.sh
@@ -9,6 +9,19 @@ set -eu
 
 BACKUP_AT="${BACKUP_AT:-03:15}"
 BACKUP_DIR="${BACKUP_DIR:-/backups}"
+# Nothing below may block forever. backup.sh bounds the step most likely to
+# hang (see its dump section), but this loop is the thing that has to survive
+# a hang nobody predicted: one wedged run and no backup is ever taken again.
+RUN_TIMEOUT_S="${RUN_TIMEOUT_S:-7200}"
+
+# busybox and coreutils both ship `timeout`, so this is belt and braces: if some
+# future base image lacks it, run unbounded rather than not at all. Depending on
+# a missing command here would recreate the exact bug the timeout is for.
+if command -v timeout >/dev/null 2>&1; then
+    run_backup() { timeout "${RUN_TIMEOUT_S}" /usr/local/bin/backup.sh; }
+else
+    run_backup() { /usr/local/bin/backup.sh; }
+fi
 
 hours="${BACKUP_AT%%:*}"
 minutes="${BACKUP_AT#*:}"
@@ -16,25 +29,31 @@ minutes="${BACKUP_AT#*:}"
 # malformed octal.
 target=$(( ${hours#0} * 3600 + ${minutes#0} * 60 ))
 
-# A fresh deployment should not spend its first night unprotected, and the
-# healthcheck has nothing to look at until a dump exists — so take one now if
-# there is none. Set BACKUP_ON_START=always to dump on every restart, or
-# =never for a container that only ever runs on schedule.
+# A fresh deployment should not spend its first night unprotected, and neither
+# should one that has fallen behind — so take a dump now if there is no *recent*
+# one. Set BACKUP_ON_START=always to dump on every restart, or =never for a
+# container that only ever runs on schedule.
+#
+# The test is freshness.sh, which is also the HEALTHCHECK, and the agreement
+# between the two is the point. Swarm kills this container when the check
+# fails, so a start that does not fix what the check is complaining about is
+# just killed again ~25 minutes later, forever, and the scheduled run below is
+# never reached. Asking only "does a dump exist" was exactly that bug: one
+# missed night on 2026-08-20 left a stale-but-present dump, and the service
+# then took no backup at all for three days while looking merely restarty.
 case "${BACKUP_ON_START:-auto}" in
     always) first_run=1 ;;
     never) first_run=0 ;;
     *)
         first_run=0
-        if [ -z "$(ls -1 "${BACKUP_DIR}"/daily/meals-*.dump 2>/dev/null | head -1)" ]; then
-            first_run=1
-        fi
+        /usr/local/bin/freshness.sh >/dev/null 2>&1 || first_run=1
         ;;
 esac
 if [ "${first_run}" = "1" ]; then
     # `|| true`: a failed backup must not kill the loop, or one unreachable
     # database means no further attempts are ever made. backup.sh has already
     # logged why, and the healthcheck goes unhealthy if this keeps up.
-    /usr/local/bin/backup.sh || true
+    run_backup || true
 fi
 
 while :; do
@@ -44,5 +63,5 @@ while :; do
     next=$(( now - now % 86400 + target ))
     [ "${next}" -le "${now}" ] && next=$(( next + 86400 ))
     sleep $(( next - now ))
-    /usr/local/bin/backup.sh || true
+    run_backup || true
 done

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meals-mcp"
-version = "1.1.0"
+version = "1.1.1"
 description = "MCP server wrapping the Meals REST API with task-level tools for AI assistants"
 requires-python = ">=3.12"
 dependencies = [

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -365,7 +365,7 @@ wheels = [
 
 [[package]]
 name = "meals-mcp"
-version = "1.0.2"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Cuts **1.1.1**. No migration.

## The bug

One failed backup night used to stop backups indefinitely, and it did: the last good dump was **2026-08-19**, and nothing ran for three days while `meals_backup` looked merely restarty.

`freshness.sh` is the HEALTHCHECK and fails at 36h. Swarm then SIGKILLs the container (exit 137) roughly every 25 minutes. But `BACKUP_ON_START=auto` only took a dump when **no** dump existed at all, so a stale-but-present dump sent every restart straight back to sleeping until `BACKUP_AT`, which it was always killed long before reaching. Confirmed on the live container: `sleep 49720` against a ~26 minute lifetime.

`BACKUP_ON_START=auto` now asks `freshness.sh` instead of asking whether a file exists. The check that kills the container is the same one that decides to dump on start, so a kill becomes the recovery rather than the trap.

## The night that started it

No dump, no `.part` file, and no event line in Loki. Every failure path calls `fail()` and logs, so silence means the run never returned rather than never started, which is what `pg_dump` blocked on an unresponsive database looks like. `pg_dump` ran with no timeout of any kind.

- `PGCONNECT_TIMEOUT` (15s) bounds getting a connection
- `DUMP_TIMEOUT_S` (1h) bounds the dump, logging `outcome=error` so the staleness alert sees it
- `RUN_TIMEOUT_S` (2h) backstops the whole run, so a hang nobody predicted still leaves the nightly loop alive
- partial dumps are cleaned up on failure instead of accumulating

Where `timeout(1)` is unavailable the scripts run unbounded rather than not at all, since depending on a missing command would recreate the very bug these guard against.

## Verification

| Case | Result |
|---|---|
| no dump at all | dumps on start ✓ |
| fresh dump (<36h) | does not dump ✓ |
| **stale dump (72h)** | **dumps on start ✓** (was the bug) |
| `pg_dump` hangs | killed, logs `did not finish within Ns`, no `.part` left ✓ |
| `pg_dump` exits 1 | logs `failed with status 1`, no `.part` left ✓ |

The two failure paths were exercised inside the real Alpine container, which is how the busybox exit code turned up: **busybox `timeout` exits 143, not GNU's 124**. Both are handled.

Production was recovered by hand on 2026-08-22 (dump `meals-20260822T130512Z`, offsite copy confirmed), so backups are current; this ships the resilience.

`702 backend + 62 mcp tests pass`, ruff clean. The `uv.lock` files had drifted to 1.0.2 and now agree with 1.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)