### PR TITLE
Deployed: backups recover on their own now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,15 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 
 ## Unreleased
 
-Version **1.1.1**. No migration.
+Nothing merged since the last deploy.
+
+## 2026-08-22 — backups that recover on their own
+
+Deployed to `meals.marcuslab.uk` as **1.1.1**, by digest and verified: the live
+API reports 1.1.1, the rollout converged before that was checked, and each
+service runs the digest the deploy asked for. **No migration.** The running
+backup container was checked for the fix itself rather than just a new digest,
+and reports healthy.
 
 ### Fixed
 


### PR DESCRIPTION
Post-deploy changelog flip for **1.1.1**, following the repo's convention that a dated section means *live on the deployment*.

1.1.1 is on `meals.marcuslab.uk`, deployed by digest in registry mode. No migration.

Verified independently of the deploy script's own checks:

- live API reports **1.1.1**; all seven public endpoints 200 (`/app/`, `/healthz`, `/client-config`, `/skill`, `/prompt-pack`, `/privacy`, `/support`)
- all four services 1/1; rollout converged before the version was checked
- MCP initialize handshake answered through Traefik
- the running backup container carries the fix itself, not just a new digest: freshness-based start check in `entrypoint.sh`, `DUMP_TIMEOUT_S` + `PGCONNECT_TIMEOUT` in `backup.sh`, `RUN_TIMEOUT_S` in `entrypoint.sh`, container `healthy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)