### PR TITLE
Publish the limits rather than only enforcing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,32 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 
 ## Unreleased
 
-Nothing merged since the last deploy.
+### Added
+
+- **`GET /limits` publishes what a household is allowed** and how much of it is
+  left — every resource with its limit, usage and remainder, plus the tier the
+  numbers came from ([#95](https://github.com/marco308/meals/issues/95),
+  `planning/08-freemium.md` §4). An assistant about to import two hundred
+  recipes can now ask before it starts rather than stopping on the fifty-first,
+  which is worth more than any refusal sentence. The endpoint holds no numbers
+  of its own: everything comes from the module that would refuse the write, so
+  what is published and what is enforced cannot drift apart. `limit` is the
+  number the household will actually meet, whichever of its tier's cap and the
+  server's fair-use ceiling is lower, and `upgradable` carries the same
+  judgement that picks 402 from 403.
+- **It answers on a server that limits nothing**, reporting every resource as
+  unlimited rather than 404ing, so no client has to special-case its absence —
+  and it counts nothing there, because an unlimited allowance has nothing to be
+  short of. The module's "no queries when nothing is configured" promise holds
+  on the endpoint as well as on the write path.
+- **`check_limits` MCP tool** and a golden rule in the skill and prompt pack
+  telling an assistant to check before a bulk import, which is the only time
+  ordinary use comes near a limit.
+- **`free_tier_limits` on `GET /client-config`**, unauthenticated, so a signup
+  page can show what an account costs nothing before anybody has one to log in
+  with. Every value is null on a server that caps nothing, which says
+  "unlimited" and names no hosted tier that does not exist. Additive, so older
+  clients ignore it.
 
 ## 2026-08-22 — backups that recover on their own
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,14 @@ instrumentation a new feature usually needs.
   to be one a household can get back under: **archived plans are not counted**,
   because there is no `DELETE /plans/{id}` (a plan's cooked history is why), so
   counting them would end the weekly loop at plan 21 with no way back.
+  Whatever is configured is **published** by `GET /limits` (`routers/limits.py`
+  over `limits.snapshot`) and, for the free tier alone, unauthenticated on
+  `GET /client-config` — a signup page has nobody to log in as yet. The endpoint
+  holds no numbers of its own, which is the point: a limit published from a
+  second source is one that will eventually disagree with the one being
+  enforced. It answers unlimited rather than 404 on an unconfigured server, and
+  counts only what is actually limited, so the "no queries when nothing is set"
+  promise holds there too.
 
 ### The web client (`web/`)
 
@@ -257,7 +265,7 @@ verbatim — never add a server-side token fallback in http mode. That header
 reaches the tools through the `_capture_caller_headers` middleware, which
 publishes them in a contextvar for the life of the request: SDK 2.0 only hands
 the request context to a handler that declares a `Context` parameter, and the
-alternative is threading one through all 29 tools and their helpers. Keep the
+alternative is threading one through all 30 tools and their helpers. Keep the
 middleware registered — without it every remote call silently drops to the
 stdio env-token path.
 

--- a/README.md
+++ b/README.md
@@ -360,7 +360,11 @@ published table of numbers, `LIMITS_OVERRIDES` tunes any single one as JSON, and
 `DEFAULT_HOUSEHOLD_TIER` says what a new registration starts on. Being over a
 limit blocks only the writes that grow a household; nothing is deleted, nothing
 becomes unreadable, and the shopping list is exempt in every case because the
-iPhone app drains its offline queue through it.
+iPhone app drains its offline queue through it. Whatever you set, `GET /limits`
+publishes it: every resource with its cap, what is used and what is left, so an
+assistant about to import two hundred recipes can ask first. On a server that
+caps nothing it answers "unlimited" rather than 404, so no client ever has to
+special-case its absence.
 
 `make deploy` runs `deploy/deploy.sh`, which is **not in this repo** — a swarm
 stack file is a description of somebody's specific hardware (node names, ingress

--- a/backend/app/limits.py
+++ b/backend/app/limits.py
@@ -266,6 +266,12 @@ class _Spec:
     #: What to do instead. Appended to the refusal, so it is the last thing an
     #: assistant reads and the first thing it can act on.
     hint: str = ""
+    #: Whether `count` answers for the household as a whole. `False` for an
+    #: allowance scoped to one parent — a meal's lines, a plan's meals — where
+    #: "how many are used" has no answer until the caller names which meal or
+    #: which plan. `GET /limits` publishes the allowance for those and leaves
+    #: the usage null rather than inventing a household-wide number for them.
+    household_wide: bool = True
 
 
 RESOURCES: dict[str, _Spec] = {
@@ -318,6 +324,7 @@ RESOURCES: dict[str, _Spec] = {
             "A line is one recipe or one loose ingredient. Split this into two meals and put both on the "
             "plan — a plan is a pool of options, so two entries cost nothing."
         ),
+        household_wide=False,
     ),
     "plans": _Spec(
         singular="plan",
@@ -340,6 +347,7 @@ RESOURCES: dict[str, _Spec] = {
             "A plan is a week's pool of options rather than a calendar, so this many is already more than "
             "a week of choices — archive it (POST /plans/{plan_id}/archive) and start the next one."
         ),
+        household_wide=False,
     ),
     "supermarkets": _Spec(
         singular="supermarket",
@@ -563,11 +571,22 @@ def _upgradable(tier: str, resource: str, cap: int) -> bool:
     return False
 
 
+def effective_tier(household: Household) -> str:
+    """The tier this household is actually treated as being on.
+
+    A column holding a value this build has not heard of resolves to
+    `unlimited` rather than raising, for the same reason `limits_for` does: a
+    household must never be locked out of its own data by a tier name from a
+    newer deployment.
+    """
+    return household.tier if household.tier in TIERS else UNLIMITED
+
+
 def _verdict(household: Household, spec: _Spec, resource: str, *, used: int, adding: int) -> LimitExceeded | None:
     """Whether this household may add `adding` more of `resource`, and if not,
     the refusal to raise. The single place caps, ceilings and status codes meet.
     """
-    tier = household.tier if household.tier in TIERS else UNLIMITED
+    tier = effective_tier(household)
     cap = getattr(limits_for(tier), resource)
     ceiling = getattr(ceilings(), resource)
     after = used + adding
@@ -586,7 +605,7 @@ def _verdict(household: Household, spec: _Spec, resource: str, *, used: int, add
 def _has_limit(household: Household, resource: str) -> bool:
     """Whether either a cap or a ceiling applies here — the check that keeps an
     unconfigured server from ever running a COUNT."""
-    tier = household.tier if household.tier in TIERS else UNLIMITED
+    tier = effective_tier(household)
     return getattr(limits_for(tier), resource) is not None or getattr(ceilings(), resource) is not None
 
 
@@ -670,6 +689,100 @@ async def enforce(
     refusal = _verdict(row, spec, resource, used=used, adding=adding)
     if refusal is not None:
         raise refusal
+
+
+# ----------------------------------------------------------------- publication
+
+# §4: "Better than a good error is not hitting the wall at all, so limits are
+# published." An assistant about to import two hundred recipes can ask what it
+# is allowed before it starts, rather than finding out on the fifty-first — and
+# on a server that has configured nothing, the honest answer is "no limits",
+# which is why `GET /limits` answers rather than 404s.
+
+
+@dataclass(frozen=True)
+class ResourceAllowance:
+    """One row of `GET /limits`: what this household is allowed, and how much of
+    it is spent."""
+
+    resource: str
+    #: The number this household will actually meet, whichever of the tier cap
+    #: and the fair-use ceiling is lower. `None` means unlimited.
+    limit: int | None
+    #: How many exist now, or `None` when the number has no meaning here:
+    #: unlimited (so nothing was counted), or an allowance scoped to one meal
+    #: or one plan, which has no household-wide answer.
+    used: int | None
+    remaining: int | None
+    #: Where the allowance applies: "per household", "in one meal", "a month".
+    scope: str
+    #: Whether a larger tier on this server would raise this number. `False` is
+    #: the ceiling, the top tier and the self-hosted default alike, and it is
+    #: the same judgement that decides 402 from 403 on a refusal.
+    upgradable: bool
+
+
+@dataclass(frozen=True)
+class LimitsSnapshot:
+    tier: str
+    #: Whether this deployment limits anything at all. `False` on a self-hosted
+    #: server that has set nothing, where every allowance below is unlimited.
+    limited: bool
+    resources: tuple[ResourceAllowance, ...]
+
+
+def _effective(tier: str, resource: str) -> tuple[int | None, bool]:
+    """The binding number for this tier and resource, and whether money lifts it.
+
+    Ties go to the ceiling, because `_verdict` checks the ceiling first: when a
+    tier's cap has caught up with it, "no tier fixes this" is the true answer.
+    """
+    cap = getattr(limits_for(tier), resource)
+    ceiling = getattr(ceilings(), resource)
+    if ceiling is not None and (cap is None or cap >= ceiling):
+        return ceiling, False
+    if cap is None:
+        return None, False
+    return cap, _upgradable(tier, resource, cap)
+
+
+async def snapshot(db: AsyncSession, household: Household) -> LimitsSnapshot:
+    """Every allowance this household has, with usage where usage means anything.
+
+    Counts only what is actually limited, which keeps the module's first promise
+    on the endpoint too: a self-hosted server answers this without running a
+    single query, because there is nothing to be short of.
+    """
+    tier = effective_tier(household)
+    allowances = []
+    for resource, spec in RESOURCES.items():
+        limit, upgradable = _effective(tier, resource)
+        used = None
+        if limit is not None and spec.count is not None and spec.household_wide:
+            used = await spec.count(db, household.id, None)
+        allowances.append(
+            ResourceAllowance(
+                resource=resource,
+                limit=limit,
+                used=used,
+                remaining=None if limit is None or used is None else max(0, limit - used),
+                scope=spec.scope,
+                upgradable=upgradable,
+            )
+        )
+    return LimitsSnapshot(tier=tier, limited=anything_configured(), resources=tuple(allowances))
+
+
+def free_tier_allowances() -> dict[str, int | None]:
+    """The free tier's own numbers, for the unauthenticated pricing table (§4).
+
+    The tier caps rather than the effective numbers: a pricing table is about
+    what the tiers differ by, and a ceiling is the same in all of them. On a
+    server that has configured nothing every value is `None`, which says
+    "unlimited" and reveals no hosted tier that does not exist.
+    """
+    free = limits_for(FREE)
+    return {name: getattr(free, name) for name in RESOURCE_NAMES}
 
 
 # ------------------------------------------------------------------ ingest quota

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from app import client_gate, limits, mcp_mount, metrics, observability
 from app.config import get_settings
 from app.observability import log_event
 from app.routers import auth, ingredients, meals, pages, plans, recipes, shopping, skill, supermarkets
+from app.routers import limits as limits_router
 from app.routers.skill import base_url, playbook_version
 
 settings = get_settings()
@@ -133,6 +134,7 @@ app.include_router(shopping.router)
 app.include_router(supermarkets.router)
 app.include_router(skill.router)
 app.include_router(pages.router)
+app.include_router(limits_router.router)
 
 # The web client is served by the API itself so it is always same-origin with
 # the endpoints it calls — no CORS, no second host to deploy or certify. Plain
@@ -237,7 +239,12 @@ async def client_config() -> dict:
 
     `password_reset_enabled` says whether this server can send email at all. A
     client that shows "Forgot password?" regardless leads people to a 503 they
-    can do nothing about, so it can ask here first and hide the door instead."""
+    can do nothing about, so it can ask here first and hide the door instead.
+
+    `free_tier_limits` is what an account costs nothing here, so a signup page
+    can show it before anyone has an account to authenticate with. Every value
+    is null on a server that limits nothing, which is the same thing an
+    authenticated `GET /limits` says in more detail."""
     config = get_settings()
     return {
         "api_version": app.version,
@@ -245,6 +252,7 @@ async def client_config() -> dict:
         "current_ios_build": config.current_ios_build,
         "upgrade_url": config.ios_upgrade_url,
         "password_reset_enabled": config.email_configured,
+        "free_tier_limits": limits.free_tier_allowances(),
     }
 
 

--- a/backend/app/routers/limits.py
+++ b/backend/app/routers/limits.py
@@ -1,0 +1,51 @@
+"""What this server allows the calling household — published, not discovered.
+
+planning/08-freemium.md §4: "Better than a good error is not hitting the wall
+at all." An assistant that is about to import two hundred recipes can ask first
+and act on the answer, instead of finding out on the fifty-first.
+
+Two rules shape the endpoint:
+
+- **It always answers.** A self-hosted server that has configured nothing
+  reports every resource as unlimited rather than 404ing, so no client ever has
+  to special-case the absence of limits (and no client learns that some *other*
+  deployment sells something).
+- **It holds no numbers of its own.** Everything here comes from
+  `app/limits.py`, which is the module that would refuse the write — a limit
+  published from a second source is a limit that will eventually disagree with
+  the one being enforced.
+"""
+
+from fastapi import APIRouter
+
+from app import limits
+from app.deps import CurrentUser, DbSession
+from app.schemas.limits import LimitsOut, ResourceAllowanceOut
+
+router = APIRouter(tags=["meta"])
+
+
+@router.get("/limits", response_model=LimitsOut)
+async def get_limits(user: CurrentUser, db: DbSession) -> LimitsOut:
+    """Every limit that applies to your household, with how much is used and how
+    much is left.
+
+    **Check this before a bulk import.** `remaining` is how many more of a thing
+    you can create; a `limit` of `null` means unlimited, and on a server that
+    limits nothing every one of them is null and `limited` is `false`.
+
+    `used` is null wherever the count has no household-wide meaning: an
+    unlimited allowance (nothing is counted, so nothing is spent) and the
+    per-meal and per-plan ones, whose usage depends on which meal or plan you
+    mean — for those, `limit` is still the number to keep that one under.
+
+    Growing past a limit is refused with 402 when `upgradable` is true and 403
+    when it is false; nothing is ever deleted, everything already here stays
+    readable, and the shopping list is exempt from both.
+    """
+    snapshot = await limits.snapshot(db, user.household)
+    return LimitsOut(
+        tier=snapshot.tier,
+        limited=snapshot.limited,
+        resources=[ResourceAllowanceOut(**vars(allowance)) for allowance in snapshot.resources],
+    )

--- a/backend/app/schemas/limits.py
+++ b/backend/app/schemas/limits.py
@@ -1,0 +1,40 @@
+from pydantic import BaseModel, Field
+
+
+class ResourceAllowanceOut(BaseModel):
+    """What this household is allowed of one resource, and how much is spent."""
+
+    resource: str = Field(description="The resource this allowance governs, e.g. 'recipes'.")
+    limit: int | None = Field(
+        description=(
+            "How many are allowed, or null for unlimited. This is the number the household will "
+            "actually meet: whichever of its tier's cap and this server's fair-use ceiling is lower."
+        )
+    )
+    used: int | None = Field(
+        description=(
+            "How many exist now, or null where the number has no meaning: an unlimited allowance "
+            "(nothing was counted), or one scoped to a single meal or plan rather than the household."
+        )
+    )
+    remaining: int | None = Field(description="limit - used, floored at zero; null whenever either is null.")
+    scope: str = Field(description="Where the allowance applies: 'per household', 'in one meal', 'a month'.")
+    upgradable: bool = Field(
+        description=(
+            "Whether a larger tier on this server would raise this limit. False for a fair-use "
+            "ceiling, for the largest tier, and for a server that sells nothing."
+        )
+    )
+
+
+class LimitsOut(BaseModel):
+    """Everything this server allows the calling household."""
+
+    tier: str = Field(description="The tier that produced these numbers.")
+    limited: bool = Field(
+        description=(
+            "Whether this deployment limits anything at all. False on a self-hosted server that has "
+            "configured nothing, where every allowance below is unlimited."
+        )
+    )
+    resources: list[ResourceAllowanceOut]

--- a/backend/tests/integration/test_limits.py
+++ b/backend/tests/integration/test_limits.py
@@ -21,6 +21,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
+from app import limits
 from app.models import Household, User
 from tests.conftest import create_meal, create_plan, create_recipe, register
 
@@ -492,6 +493,190 @@ class TestMembersAreTheGate:
             json={"email": "stranger@example.com", "password": PASSWORD, "display_name": "Stranger"},
         )
         assert response.status_code == 201
+
+
+async def allowances(client, **kwargs) -> dict:
+    """`GET /limits`, keyed by resource."""
+    response = await client.get("/limits", **kwargs)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    return {row["resource"]: row for row in body["resources"]} | {"_": body}
+
+
+class TestPublishedLimits:
+    """§4: "Better than a good error is not hitting the wall at all." An
+    assistant about to import two hundred recipes asks first, so what it is told
+    has to be the same number that would refuse it."""
+
+    async def test_an_unconfigured_server_answers_unlimited_rather_than_404(self, auth_client):
+        """No client should ever have to special-case the absence of limits, and
+        a self-hosted box must not learn that some other deployment sells
+        something."""
+        rows = await allowances(auth_client)
+        assert rows["_"]["tier"] == "unlimited"
+        assert rows["_"]["limited"] is False
+        assert {row["resource"] for row in rows["_"]["resources"]} == set(limits.RESOURCE_NAMES)
+        for name in limits.RESOURCE_NAMES:
+            row = rows[name]
+            assert (row["limit"], row["used"], row["remaining"]) == (None, None, None), name
+            assert row["upgradable"] is False, name
+
+    async def test_nothing_is_counted_when_nothing_is_limited(self, auth_client):
+        """The module's first promise holds on the endpoint too: an unlimited
+        allowance runs no COUNT, because there is nothing to be short of."""
+        await create_recipe(auth_client, title="One")
+        assert (await allowances(auth_client))["recipes"]["used"] is None
+
+    async def test_it_needs_a_household_to_answer_for(self, client):
+        assert (await client.get("/limits")).status_code == 401
+
+    async def test_a_configured_server_publishes_the_numbers_and_the_usage(self, client, hosted):
+        hosted(free={"recipes": 3})
+        await signed_in(client)
+        await create_recipe(client, title="One")
+
+        rows = await allowances(client)
+        assert rows["_"]["tier"] == "free"
+        assert rows["_"]["limited"] is True
+        assert rows["recipes"] == {
+            "resource": "recipes",
+            "limit": 3,
+            "used": 1,
+            "remaining": 2,
+            "scope": "per household",
+            "upgradable": True,
+        }
+        # The profile's own numbers apply to everything the overrides left alone.
+        assert rows["meals"]["limit"] == 100
+        assert rows["members"]["limit"] == 1
+
+    async def test_remaining_reaches_zero_exactly_where_the_refusal_is(self, client, hosted):
+        """The whole point of publishing: the number an assistant plans against
+        and the number that refuses it are the same number."""
+        hosted(free={"recipes": 2})
+        await signed_in(client)
+        await create_recipe(client, title="One")
+        assert (await allowances(client))["recipes"]["remaining"] == 1
+        await create_recipe(client, title="Two")
+
+        spent = (await allowances(client))["recipes"]
+        assert (spent["used"], spent["remaining"]) == (2, 0)
+        refusal = await client.post("/recipes", json={"title": "Three", "ingredients": []})
+        assert refusal.status_code == 402
+        assert (refusal.json()["limit"], refusal.json()["used"]) == (spent["limit"], spent["used"])
+
+    async def test_remaining_never_goes_negative(self, client, hosted):
+        """A household can end up over a cap without ever being refused — a
+        downgrade, or an operator lowering the number — and "-3 left" is not
+        something to publish at it."""
+        hosted(free={"recipes": None})
+        await signed_in(client)
+        await create_recipe(client, title="One")
+        await create_recipe(client, title="Two")
+        hosted(free={"recipes": 1})
+
+        assert (await allowances(client))["recipes"] == {
+            "resource": "recipes",
+            "limit": 1,
+            "used": 2,
+            "remaining": 0,
+            "scope": "per household",
+            "upgradable": True,
+        }
+
+    async def test_a_ceiling_is_published_as_the_limit_and_as_unupgradable(self, client, hosted):
+        """`upgradable` is the same judgement that picks 402 from 403, so a
+        caller can tell "this needs a bigger tier" from "this needs a
+        conversation" before it hits either."""
+        hosted(free={"recipes": 500}, ceiling={"recipes": 2})
+        await signed_in(client)
+        rows = await allowances(client)
+        assert (rows["recipes"]["limit"], rows["recipes"]["upgradable"]) == (2, False)
+
+    async def test_the_top_tier_has_nothing_above_it_to_be_sold(self, client, hosted, set_tier):
+        hosted(free={"recipes": 1}, paid={"recipes": 2})
+        await signed_in(client)
+        await set_tier("paid")
+        rows = await allowances(client)
+        assert rows["_"]["tier"] == "paid"
+        assert (rows["recipes"]["limit"], rows["recipes"]["upgradable"]) == (2, False)
+
+    async def test_a_comped_household_reads_as_unlimited_but_keeps_the_ceiling(self, client, hosted, set_tier):
+        hosted(ceiling={"recipes": 5})
+        await signed_in(client)
+        await set_tier("unlimited")
+        rows = await allowances(client)
+        assert rows["_"]["tier"] == "unlimited"
+        assert (rows["recipes"]["limit"], rows["recipes"]["upgradable"]) == (5, False)
+        # Nothing is upgradable from a comp, and the profile's own ceilings are
+        # still what binds everything the override left alone.
+        assert (rows["meals"]["limit"], rows["meals"]["upgradable"]) == (5_000, False)
+
+    async def test_an_allowance_scoped_to_one_meal_or_plan_publishes_no_usage(self, client, hosted):
+        """ "How many are used" has no household-wide answer for these, and
+        inventing one would be worse than leaving it null — the number that
+        matters is the allowance itself."""
+        # The same in both tiers, exactly as §3's table has them.
+        same = {"meal_lines": 2, "plan_meals": 3}
+        hosted(free=same, paid=same, ceiling=same)
+        await signed_in(client)
+        await create_meal(client, name="Sunday dinner", loose_ingredients=[{"name": "peas"}])
+
+        rows = await allowances(client)
+        assert rows["meal_lines"] == {
+            "resource": "meal_lines",
+            "limit": 2,
+            "used": None,
+            "remaining": None,
+            "scope": "in one meal",
+            "upgradable": False,
+        }
+        assert (rows["plan_meals"]["limit"], rows["plan_meals"]["used"]) == (3, None)
+
+    async def test_the_ingest_quota_is_the_months_counter_not_a_row_count(self, client, hosted):
+        hosted(free={"ingests_per_month": 5})
+        await signed_in(client)
+        rows = await allowances(client)
+        assert rows["ingests_per_month"]["scope"] == "a month"
+        assert (rows["ingests_per_month"]["used"], rows["ingests_per_month"]["remaining"]) == (0, 5)
+
+    async def test_usage_is_this_households_own(self, client, hosted):
+        """The endpoint reads a household's own counts, which is the one thing
+        it must not get wrong."""
+        hosted(free={"recipes": 10})
+        first = await register(client, email="first@example.com", name="First")
+        second = await register(client, email="second@example.com", name="Second")
+        made = await client.post("/recipes", json={"title": "Theirs", "ingredients": []}, headers=headers(first))
+        assert made.status_code == 201
+
+        assert (await allowances(client, headers=headers(first)))["recipes"]["used"] == 1
+        assert (await allowances(client, headers=headers(second)))["recipes"]["used"] == 0
+
+
+class TestTheFreeTierRidesOnClientConfig:
+    """A signup page has nobody to authenticate as yet, so the numbers that
+    decide whether to sign up at all cannot need a login."""
+
+    async def test_it_is_there_and_needs_no_token(self, client):
+        response = await client.get("/client-config")
+        assert response.status_code == 200
+        assert set(response.json()["free_tier_limits"]) == set(limits.RESOURCE_NAMES)
+
+    async def test_a_server_that_limits_nothing_publishes_no_numbers(self, client):
+        published = (await client.get("/client-config")).json()["free_tier_limits"]
+        assert set(published.values()) == {None}
+
+    async def test_a_configured_server_publishes_its_free_tier(self, client, hosted):
+        hosted(free={"recipes": 50})
+        published = (await client.get("/client-config")).json()["free_tier_limits"]
+        assert published["recipes"] == 50
+        assert published["members"] == 1  # straight from §3's table
+
+    async def test_it_is_the_tiers_own_numbers_not_the_ceiling(self, client, hosted):
+        """A pricing table is about what the tiers differ by; the ceiling is the
+        same in all of them and belongs to the box, not to the price."""
+        hosted(free={"recipes": None}, ceiling={"recipes": 5})
+        assert (await client.get("/client-config")).json()["free_tier_limits"]["recipes"] is None
 
 
 class TestTheIngestQuota:

--- a/backend/tests/integration/test_misc.py
+++ b/backend/tests/integration/test_misc.py
@@ -161,8 +161,8 @@ class TestPublicPages:
 # Without this, guidance can ship under an unchanged number — which is exactly
 # what happened when the premium/budget tools landed on v1: a stale v1 copy
 # compared v1 to v1, found no drift, and never learned the tools existed.
-PINNED_PLAYBOOK_VERSION = 15
-PINNED_PLAYBOOK_DIGEST = "67097edeb115e6f0610484f7ae7b687c1f0594fceddac0c4450f29b16ec31c95"
+PINNED_PLAYBOOK_VERSION = 16
+PINNED_PLAYBOOK_DIGEST = "e0bc6409b012242d2781dfee0d93f676134fd393965a5527a3298a2096320333"
 
 _VERSION_STAMP = re.compile(r"<!--\s*playbook-version:\s*\d+\s*-->\n?")
 _VERSION_PROSE = re.compile(r"playbook v\d+", re.IGNORECASE)

--- a/backend/tests/unit/test_limits.py
+++ b/backend/tests/unit/test_limits.py
@@ -85,6 +85,63 @@ class TestProfileResolution:
         assert limits.limits_for("free").recipes is None
 
 
+class TestTheBindingNumber:
+    """What `GET /limits` publishes as the limit: whichever of the tier cap and
+    the ceiling a household actually meets, and whether money moves it. The same
+    judgement `_verdict` makes on a refusal, so the two must not disagree."""
+
+    def test_nothing_configured_is_unlimited_and_unupgradable(self):
+        assert limits._effective("free", "recipes") == (None, False)
+
+    def test_a_cap_below_the_ceiling_binds_and_a_bigger_tier_lifts_it(self, settings_override):
+        _hosted(settings_override)
+        assert limits._effective("free", "recipes") == (50, True)
+
+    def test_the_ceiling_binds_when_it_is_the_lower_of_the_two(self, settings_override):
+        _hosted(settings_override, free={"recipes": 9_999})
+        assert limits._effective("free", "recipes") == (5_000, False)
+
+    def test_a_tie_goes_to_the_ceiling(self, settings_override):
+        """`_verdict` checks the ceiling first, so when a cap has caught up with
+        it the true answer is "no tier fixes this" rather than "buy a bigger
+        one"."""
+        _hosted(settings_override, free={"recipes": 5_000})
+        assert limits._effective("free", "recipes") == (5_000, False)
+
+    def test_the_top_tier_has_nothing_above_it(self, settings_override):
+        _hosted(settings_override)
+        assert limits._effective("paid", "recipes") == (2_000, False)
+
+    def test_a_comp_keeps_the_ceiling_and_sells_nothing(self, settings_override):
+        _hosted(settings_override)
+        assert limits._effective("unlimited", "recipes") == (5_000, False)
+
+    def test_a_cap_with_no_ceiling_above_it_still_binds(self, settings_override):
+        _hosted(settings_override, free={"recipes": 3}, ceiling={"recipes": None})
+        assert limits._effective("free", "recipes") == (3, True)
+
+
+class TestEveryResourceCanBePublished:
+    def test_a_resource_with_no_household_wide_count_says_so(self):
+        """Publishing a household-wide "used" for a per-meal or per-plan
+        allowance would be inventing a number, so the spec has to say which is
+        which."""
+        scoped = {name for name, spec in limits.RESOURCES.items() if not spec.household_wide}
+        assert scoped == {"meal_lines", "plan_meals"}
+
+    def test_anything_counted_household_wide_has_a_counter_to_do_it_with(self):
+        for name, spec in limits.RESOURCES.items():
+            assert (spec.count is not None) or not spec.household_wide, name
+
+    def test_the_free_tier_is_published_whole(self, settings_override):
+        """The unauthenticated pricing table names every resource, so a client
+        reading it never has to guess whether a missing key means unlimited."""
+        assert set(limits.free_tier_allowances()) == set(limits.RESOURCE_NAMES)
+        assert set(limits.free_tier_allowances().values()) == {None}
+        _hosted(settings_override)
+        assert limits.free_tier_allowances()["recipes"] == 50
+
+
 class TestConfigurationIsChecked:
     """A typo should stop the container at startup, not surface as a 500 on
     somebody's fiftieth recipe — app/main.py calls check_settings() at import."""

--- a/mcp/meals_mcp/server.py
+++ b/mcp/meals_mcp/server.py
@@ -34,7 +34,7 @@ from starlette.responses import PlainTextResponse, Response
 # they drift, and the backend suite fails if the guidance changes without a bump).
 # Instructions ship fresh on every connection, so this is the one channel that can
 # tell an assistant its installed skill snapshot has gone stale.
-PLAYBOOK_VERSION = 15
+PLAYBOOK_VERSION = 16
 
 # The caller's HTTP headers for the request being served, or None over stdio
 # (and in direct tool-function calls), where env-token auth applies.
@@ -920,6 +920,48 @@ async def delete_ingredient(name: str) -> str:
     except ApiError as exc:
         return str(exc)
     return f"Deleted '{ingredient['name']}' from the catalogue."
+
+
+# --------------------------------------------------------------------- limits
+
+
+def _fmt_allowance(row: dict) -> str:
+    name = row["resource"].replace("_", " ")
+    if row["used"] is None:
+        # Scoped to one meal or one plan, so there is no household-wide "used".
+        return f"{name}: at most {row['limit']:,} {row['scope']}"
+    return f"{name}: {row['used']:,} of {row['limit']:,} used, {row['remaining']:,} left"
+
+
+@mcp.tool()
+async def check_limits() -> str:
+    """What this server allows the household, and how much is left.
+
+    **Check this before a bulk import** — dozens of recipe links, a library
+    migration, a script that creates meals in a loop. Most servers cap nothing
+    and say so in one line; where a server does cap something, this is how many
+    more you can create before the writes start being refused. Reading it first
+    is the difference between importing what fits and stopping half way through
+    with a hundred left over.
+    """
+    try:
+        data = await _call("GET", "/limits")
+    except ApiError as exc:
+        return str(exc)
+    # `limited` is about the server; the rows are about this household, and a
+    # deployment can have configured a tier this one is not on.
+    rows = [row for row in data["resources"] if row["limit"] is not None]
+    if not data["limited"] or not rows:
+        return "Nothing is capped here — import as much as you like."
+    lines = [f"This household is on the {data['tier']} tier."]
+    lines += [_fmt_allowance(row) for row in rows]
+    spent = [row["resource"].replace("_", " ") for row in rows if row["remaining"] == 0]
+    if spent:
+        lines.append(
+            f"Already at the limit for {', '.join(spent)} — creating more will be refused, so say so "
+            "rather than retrying."
+        )
+    return "\n".join(lines)
 
 
 @mcp.custom_route("/healthz", methods=["GET"])

--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -168,6 +168,100 @@ class TestShoppingList:
         assert result.rstrip().endswith("onion — ×2"), "untagged items stay unadorned"
 
 
+def _allowance(resource, limit, used, scope="per household", upgradable=True):
+    return {
+        "resource": resource,
+        "limit": limit,
+        "used": used,
+        "remaining": None if limit is None or used is None else max(0, limit - used),
+        "scope": scope,
+        "upgradable": upgradable,
+    }
+
+
+class TestCheckLimits:
+    """The tool exists so a bulk import asks before it starts rather than
+    stopping half way through."""
+
+    @respx.mock
+    async def test_a_server_that_limits_nothing_says_so_in_one_line(self):
+        respx.get(f"{API}/limits").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "tier": "unlimited",
+                    "limited": False,
+                    "resources": [_allowance("recipes", None, None, upgradable=False)],
+                },
+            )
+        )
+        assert await server.check_limits() == "Nothing is capped here — import as much as you like."
+
+    @respx.mock
+    async def test_a_configured_server_that_caps_nothing_for_this_household_reads_the_same(self):
+        """A deployment can have numbers set for a tier this household is not
+        on, and "the free tier allows 50 recipes" is not an answer to "what am
+        I allowed"."""
+        respx.get(f"{API}/limits").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "tier": "unlimited",
+                    "limited": True,
+                    "resources": [_allowance("recipes", None, None, upgradable=False)],
+                },
+            )
+        )
+        assert await server.check_limits() == "Nothing is capped here — import as much as you like."
+
+    @respx.mock
+    async def test_it_reads_back_the_numbers_and_what_is_left(self):
+        respx.get(f"{API}/limits").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "tier": "free",
+                    "limited": True,
+                    "resources": [
+                        _allowance("recipes", 50, 12),
+                        _allowance("ingests_per_month", 20, 3, scope="a month"),
+                        _allowance("meal_lines", 50, None, scope="in one meal", upgradable=False),
+                        _allowance("plans", None, None, upgradable=False),
+                    ],
+                },
+            )
+        )
+        result = await server.check_limits()
+        assert "This household is on the free tier." in result
+        assert "recipes: 12 of 50 used, 38 left" in result
+        assert "ingests per month: 3 of 20 used, 17 left" in result
+        # No household-wide usage for a per-meal allowance, so it reads as the
+        # bound it is.
+        assert "meal lines: at most 50 in one meal" in result
+        assert "plans" not in result  # unlimited, so nothing to report
+
+    @respx.mock
+    async def test_a_spent_allowance_is_called_out_rather_than_left_to_arithmetic(self):
+        respx.get(f"{API}/limits").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "tier": "free",
+                    "limited": True,
+                    "resources": [_allowance("recipes", 50, 50), _allowance("members", 1, 1)],
+                },
+            )
+        )
+        result = await server.check_limits()
+        assert "recipes: 50 of 50 used, 0 left" in result
+        assert "Already at the limit for recipes, members" in result
+
+    @respx.mock
+    async def test_an_api_error_comes_back_as_the_servers_own_sentence(self):
+        respx.get(f"{API}/limits").mock(return_value=httpx.Response(401, json={"detail": "nope"}))
+        assert "authentication failed" in await server.check_limits()
+
+
 class TestValueTier:
     def _ingredient(self, **extra):
         return {

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -3,7 +3,7 @@ name: meal-planner
 description: Plan meals and manage the shopping list through the Meals API/MCP. Use when the user shares recipe links, asks what to cook, wants to plan the week's meals, needs the shopping list, or says they're out of something. Covers recipe ingestion (including parsing pages the backend can't), building meal options, and shopping-mode check-offs.
 ---
 
-<!-- playbook-version: 15 -->
+<!-- playbook-version: 16 -->
 
 # Being a great meal-planning assistant
 
@@ -12,7 +12,7 @@ calendar), a recipe library, and an aisle-sorted shopping list that knows why
 every item is on it. Prefer the MCP tools when connected; otherwise use the
 REST API (OpenAPI at `/openapi.json`, auth via `Authorization: Bearer <PAT>`).
 
-**This is playbook v15, and this file is a snapshot** — once installed it never
+**This is playbook v16, and this file is a snapshot** — once installed it never
 updates itself. If a connected Meals MCP server names a higher playbook version
 in its instructions, or `GET {{API_URL}}/skill/version` reports one, this copy
 is stale: fetch `{{API_URL}}/skill`, follow the fresh copy for the rest of the
@@ -32,6 +32,13 @@ conversation, and tell the user to replace their installed copy.
    library may already have it, and most sites parse for free from JSON-LD.
 4. **The list explains itself.** When reading the shopping list back, keep the
    aisle grouping and mention which meal needs an item when it's useful.
+5. **Check the limits before a bulk import.** A folder of links, a library
+   migration, anything more than a handful at once: `check_limits()`
+   (`GET /limits`) says what this server allows the household and how much is
+   left. Most servers cap nothing and answer in a line; where one does, knowing
+   first is the difference between importing what fits and stopping half way
+   through with a hundred left over. Ordinary work never goes near a limit, so
+   don't check before every recipe.
 
 ## Workflow: user shares recipe link(s)
 

--- a/skill/prompt-pack.md
+++ b/skill/prompt-pack.md
@@ -1,6 +1,6 @@
 # Meals prompt pack (portable)
 
-<!-- playbook-version: 15 -->
+<!-- playbook-version: 16 -->
 
 Paste this into any AI assistant's custom instructions to make it a good
 meal-planning assistant for your Meals server. (Claude-family tools can use
@@ -13,7 +13,7 @@ You help me plan meals and manage shopping through my Meals API at
 `Authorization: Bearer {{YOUR_API_TOKEN}}`. The full OpenAPI spec is at
 `{{API_URL}}/openapi.json` — fetch it if unsure about an endpoint.
 
-These instructions are playbook v15 and don't update themselves. If
+These instructions are playbook v16 and don't update themselves. If
 `{{API_URL}}/skill/version` reports a higher version, tell me — re-fetching
 `{{API_URL}}/prompt-pack` gets the current guidance.
 
@@ -40,6 +40,7 @@ Key endpoints:
 - Per-store walking orders: `GET /supermarkets` lists the household's saved stores; the `is_active` one is the order the list (and `GET /aisles`) comes sorted in. "I'm at Aldi" and Aldi is saved → `PATCH /supermarkets/{id} {"is_active": true}`; `{"is_active": false}` returns to the default order. Save a store they describe with `POST /supermarkets {"name", "aisle_order": ["🧊", "🥤", …], "is_active": true}` — aisle emojis first-to-last as they walk it; aisles left out keep their usual place at the end. Never invent an order they didn't describe.
 - `POST /shopping-list/items {name, quantity, unit, id}` — ad-hoc adds ("out of milk"); send a fresh UUID as `id` so retries are safe
 - `PATCH /shopping-list/items/{id}` with `{"checked": true}` (shopping), `{"excluded": true}` ("already have it" — never delete provenance), or `{"staple_needed": true}` (staples check: "I'm low" — surfaces that staple; `false` hides it again)
+- `GET /limits` — what this server allows your household and how much is left: `resources[]` with `limit`, `used` and `remaining` per resource, plus the tier they came from. `limited: false` means this server caps nothing. **Check it before a bulk import** — a folder of links, a library migration — and import what fits rather than stopping half way through. Growth past a limit is refused with 402 where a larger tier would allow it and 403 where none would; nothing already there is ever removed, and the shopping list is never blocked.
 - `POST /shopping-list/archive` after the shop · `PATCH /ingredients/{id}` to fix ❓ aisles, flag staples, or record premium-vs-budget advice
 - Ingredient names are folded to one identity on the way in: "mint leaves", "fresh mint" and "mint" are one ingredient and one line, as are "garlic cloves"/"garlic" and "onions"/"onion". Write the bare food and don't try to match existing spellings — but don't flatten distinctions that change the product either (ground coriander ≠ coriander, dried oregano ≠ oregano, minced beef ≠ beef). `GET /ingredients?name=mint%20leaves` resolves a name the user said to the row it's filed under. If the list still looks repetitive, `GET /ingredients/duplicates` reports same-food-two-names rows and `POST /ingredients/{keeper_id}/merge {"duplicate_ids": [...]}` folds them into one — irreversible, so confirm anything you aren't sure is the same thing to buy. `DELETE /ingredients/{id}` removes a junk row outright (a bad parse, a typo'd add) once nothing references it — 409 while a recipe, meal or list line still does, and for a misparse of a real food merging is usually the better fix.
 - Premium vs budget: every ingredient carries `value_tier` — `"premium"` (⭐ worth paying up for), `"budget"` (💷 own-brand is fine) or `"any"` (no opinion, the default) — plus a one-line `value_note` reason. Set both with `PATCH /ingredients/{id} {"value_tier": "premium", "value_note": "the cheap stuff goes bitter"}`; read the tagged set back with `GET /ingredients?value_tier=premium`. Shopping-list items and recipe lines carry the tier and note, so mention them when reading the list back — that's the moment the decision gets made. Only save a tier the household has actually agreed to; suggest, don't assume.


### PR DESCRIPTION
## What and why

Closes [#95](https://github.com/marco308/meals/issues/95) — `planning/08-freemium.md` §4. A limit is worth less than knowing about it in advance, so `GET /limits` publishes every resource with its limit, usage and remainder for the calling household, and an assistant about to import two hundred recipes can ask before it starts rather than stopping on the fifty-first.

The endpoint holds no numbers of its own: everything comes from `limits.snapshot()`, the same module that would refuse the write, so published and enforced can't drift apart. `limit` is the number the household actually meets — whichever of its tier's cap and the server's fair-use ceiling is lower, ties going to the ceiling because `_verdict` checks it first — and `upgradable` carries the same judgement that picks 402 from 403.

It answers unlimited rather than 404 on a server that caps nothing, so no client special-cases the absence of limits, and it counts nothing there: the module's "no queries when nothing is configured" promise now holds on the read path too. `used` is likewise null for `meal_lines` and `plan_meals`, whose usage has no answer until the caller names which meal or plan.

Also here: a `check_limits` MCP tool, `free_tier_limits` on the unauthenticated `GET /client-config` (so a signup page can show the table before anyone has an account to log in with), and playbook **v16** carrying a golden rule that points at both.

## Checklist

- [x] **API contract stayed additive** — a new endpoint and one new `/client-config` key. Nothing removed, renamed, tightened or re-meant; iOS ignores the new key.
- [x] **Model change has a migration** — n/a, no model change.
- [x] **Shopping-list quantities still derive from `ListItemSource`** — n/a, nothing touches the list.
- [x] **Every new query filters on `household_id`** — the counters are the existing ones in `app/limits.py`, called with the caller's own household.
- [x] **Skill/prompt pack updated** — new golden rule in `SKILL.md`, a `GET /limits` line in the prompt pack, and the playbook bumped to v16 in all four places.
- [x] **New 4xx strings say what to do instead** — no new 4xx; the endpoint's docstring and the MCP tool description are the AI-facing surface, and both say when to call it and what the numbers mean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
