### PR TITLE
Cap how many families the box holds, not just what each one costs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,13 @@ AUTH_RATE_LIMIT_PER_MINUTE=10
 #LIMITS_PROFILE=hosted
 #DEFAULT_HOUSEHOLD_TIER=free
 #LIMITS_OVERRIDES={"free": {"recipes": 100}, "ceiling": {"ingredients": null}}
+
+# Instance ceilings: how many households and accounts this box holds at all,
+# as opposed to what each one costs. Unset, there is no ceiling and the server
+# takes everyone who arrives. Set, POST /auth/register answers 503 with a
+# waitlist sentence instead of accepting somebody there is no room for; both
+# ceilings ride on /metrics beside the counts they bound, so "nearly full" is
+# visible first. REGISTRATION_ENABLED=false is a different refusal — closed
+# rather than full — and keeps its own message.
+#MAX_HOUSEHOLDS=25
+#MAX_USERS=60

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,34 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 
 ### Added
 
+- **`MAX_HOUSEHOLDS` and `MAX_USERS` bound the instance, not the household**
+  ([#96](https://github.com/marco308/meals/issues/96),
+  `planning/08-freemium.md` §3). The per-household caps say what one family
+  costs and nothing about how many families the box can hold; these are that
+  number, and the founding-cohort cap from `planning/06-marketing.md` §1b is now
+  a setting rather than a note in a document. Unset by default, so a self-hosted
+  server behaves exactly as it did.
+- **A full server answers 503 with a waitlist sentence** rather than accepting
+  somebody it has no room for. 503 and not 402/403 on purpose: no tier lifts
+  this, the caller has done nothing wrong, and a waitlist means "later, yes",
+  which is the one thing a status code can carry that 403 cannot. Being full
+  stops new registrations and nothing else — everyone already here keeps
+  writing, logging in and shopping.
+- **The refusal depends on who is knocking.** A stranger starting a household of
+  their own is offered the waitlist. Somebody registering against an invite is
+  expected — a household here issued them a code — so they are told their code
+  is unspent and still good once room appears, which it is: the check runs
+  before anything is written, so a refusal consumes no invite and leaves no
+  half-made household. `POST /auth/invites/redeem` is never refused by either
+  ceiling, because moving an existing user between existing households adds no
+  account and can only *lower* the household count.
+- **Both ceilings ride on `/metrics`** as `meals_households_limit` and
+  `meals_users_limit`, beside the counts they bound, so "nearly full" is a
+  dashboard line rather than something learned from the first person turned
+  away. Unset reports `+Inf` rather than 0, which would read as "this server
+  allows no households" and make the ratio a division by zero.
+- `REGISTRATION_ENABLED=false` is untouched and keeps its own 403: that server
+  is closed rather than full, so the answer there is still an invite code.
 - **`GET /limits` publishes what a household is allowed** and how much of it is
   left — every resource with its limit, usage and remainder, plus the tier the
   numbers came from ([#95](https://github.com/marco308/meals/issues/95),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,19 @@ instrumentation a new feature usually needs.
   enforced. It answers unlimited rather than 404 on an unconfigured server, and
   counts only what is actually limited, so the "no queries when nothing is set"
   promise holds there too.
+- **Instance ceilings are the other axis** (`MAX_HOUSEHOLDS`, `MAX_USERS`, at the
+  bottom of `app/limits.py`). They bound how many households the *box* holds
+  rather than what one costs, so no tier reaches them and none of the above
+  applies: they answer **503**, because the caller has done nothing wrong and
+  "full" means "later, yes" in a way 403 cannot. Only `POST /auth/register`
+  can cross one — `/auth/invites/redeem` moves an existing user and can only
+  lower the household count — and the sentence depends on who is knocking: a
+  stranger gets the waitlist, somebody holding an invite is told their code is
+  still good, because a household here is already expecting them. Keep the
+  check after the duplicate-email 409 and before anything is written, so a
+  refusal leaves no half-made household and no spent invite. Both ceilings are
+  published as `/metrics` gauges beside the counts they bound (`+Inf` when
+  unset, never 0 — a dashboard divides one by the other).
 
 ### The web client (`web/`)
 

--- a/README.md
+++ b/README.md
@@ -357,7 +357,12 @@ enforcement returns before it runs a query, so an install that sets nothing has
 no caps and no idea any exist. If you *want* them — a server you let friends
 onto, a box you'd rather not have somebody fill — `LIMITS_PROFILE=hosted` runs a
 published table of numbers, `LIMITS_OVERRIDES` tunes any single one as JSON, and
-`DEFAULT_HOUSEHOLD_TIER` says what a new registration starts on. Being over a
+`DEFAULT_HOUSEHOLD_TIER` says what a new registration starts on. `MAX_HOUSEHOLDS`
+and `MAX_USERS` are the other axis and are also unset by default: they bound how
+many families the box holds rather than what each one costs, so registration
+answers 503 with a waitlist sentence instead of the machine finding its own
+limit. Both sit on `/metrics` next to the counts they bound, which is how you
+see "nearly full" before somebody is turned away. Being over a
 limit blocks only the writes that grow a household; nothing is deleted, nothing
 becomes unreadable, and the shopping list is exempt in every case because the
 iPhone app drains its offline queue through it. Whatever you set, `GET /limits`

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -89,6 +89,20 @@ class Settings(BaseSettings):
     limits_overrides: dict[str, dict[str, int | None]] = {}
     default_household_tier: str = "unlimited"
 
+    # Instance ceilings (planning/08-freemium.md §3, "Per instance"). The
+    # limits above bound what one household costs; these bound how many
+    # households the box holds at all, which is the half that makes capacity
+    # planning real. Unset — the default — a server takes everyone it can fit
+    # and falls over on its own terms, exactly as it always has.
+    #
+    #   MAX_HOUSEHOLDS  registrations that would start household N+1 are
+    #                   refused with a waitlist sentence rather than accepted
+    #                   onto a box with no room for them.
+    #   MAX_USERS       the same for accounts, because an invited member grows
+    #                   the user count without growing the household count.
+    max_households: int | None = None
+    max_users: int | None = None
+
     # Timeout for fetching external recipe pages during ingestion.
     recipe_fetch_timeout_seconds: float = 15.0
     # And a ceiling on how much of one we'll read (issue #55). The URL is the

--- a/backend/app/limits.py
+++ b/backend/app/limits.py
@@ -62,6 +62,17 @@ Counting
 Plain `COUNT`s on the existing `household_id` indexes, and **no locking**: two
 concurrent creates that overshoot a cap by one are cheaper to tolerate than to
 prevent, which is §3's own instruction.
+
+The other axis
+--------------
+
+§3 has a second table, "Per instance", and it is a different question: not what
+one household costs but how many of them the box holds. `MAX_HOUSEHOLDS` and
+`MAX_USERS` live at the bottom of this module under "instance ceilings". They
+share the shape — unset by default, refuse only growth, say what to do next —
+and nothing else: no tier reaches them, no upgrade path leads out of them, and
+they answer 503 because the caller has done nothing wrong and the server is
+simply full.
 """
 
 import json
@@ -467,6 +478,14 @@ def check_settings() -> None:
                     f"LIMITS_OVERRIDES['{name}']['{resource}'] is {value!r}; a limit is a "
                     "non-negative whole number, or null for unlimited"
                 )
+    for name, value in instance_ceilings().items():
+        # A ceiling of zero is meaningful (a server closed to new arrivals but
+        # still serving everyone on it); a negative one is a typo.
+        if value is not None and value < 0:
+            raise ValueError(
+                f"MAX_{name.upper()} is {value!r}; an instance ceiling is a non-negative whole "
+                "number, or unset for no ceiling"
+            )
     # Build the table once so a bad override value fails here rather than later.
     _current_table()
 
@@ -783,6 +802,134 @@ def free_tier_allowances() -> dict[str, int | None]:
     """
     free = limits_for(FREE)
     return {name: getattr(free, name) for name in RESOURCE_NAMES}
+
+
+# ------------------------------------------------------------ instance ceilings
+
+# §3's other half, "Per instance". Everything above bounds what *one household*
+# costs; nothing above says how many households the box can hold, and a server
+# that accepts the two-hundredth family because no number stopped it does not
+# fail politely. `MAX_HOUSEHOLDS` and `MAX_USERS` are that number, and like
+# every other one here they default to unset: a self-hoster who configures
+# nothing is in exactly the position they were before, taking everyone who
+# arrives.
+#
+# Three things make this a different animal from the caps above, and each one
+# shows up in the code:
+#
+# - **It is not about the caller.** No tier lifts it, no upgrade path leads out
+#   of it, and the household reaching it has done nothing wrong — the server is
+#   simply full. So it answers **503**, not 402 or 403: this is capacity, and a
+#   waitlist means "later, yes", which is the one thing a status code can carry
+#   that 403 cannot.
+# - **Only registration can cross it.** `POST /auth/invites/redeem` moves an
+#   existing user between existing households and can only ever *lower* the
+#   household count (`move_user_to_household` collects the one they left), so it
+#   is deliberately not checked — refusing it would block a move that costs the
+#   server nothing.
+# - **Who is knocking changes the sentence.** Somebody starting a household of
+#   their own is a stranger the server has no room for, and the honest answer is
+#   the waitlist. Somebody registering against an invite is expected: a
+#   household here issued them a code and is waiting. Turning them away with a
+#   waitlist sentence would be telling them to queue for something they have
+#   already been let into.
+
+HOUSEHOLDS = "households"
+USERS = "users"
+INSTANCE_RESOURCES = (HOUSEHOLDS, USERS)
+
+
+class InstanceFull(Exception):
+    """This deployment holds as many households, or accounts, as it will.
+
+    Not an `HTTPException` for the same reason `LimitExceeded` isn't: one place
+    in `app/main.py` owns turning it into a response.
+    """
+
+    status_code = 503
+
+    def __init__(self, *, resource: str, limit: int, used: int, detail: str) -> None:
+        super().__init__(detail)
+        self.resource = resource
+        self.limit = limit
+        self.used = used
+        self.detail = detail
+
+    def payload(self) -> dict[str, object]:
+        return {"detail": self.detail, "resource": self.resource, "limit": self.limit, "used": self.used}
+
+
+def instance_ceilings() -> dict[str, int | None]:
+    """What this deployment will hold, `None` for "as much as it can"."""
+    settings = get_settings()
+    return {HOUSEHOLDS: settings.max_households, USERS: settings.max_users}
+
+
+_INSTANCE_MODELS = {HOUSEHOLDS: Household, USERS: User}
+
+#: What each ceiling counts, singular and plural, so "at most 1 account" reads
+#: like English on a server that really is that small.
+_INSTANCE_NOUNS = {HOUSEHOLDS: ("household", "households"), USERS: ("account", "accounts")}
+
+#: One sentence per (resource, was-invited). Every one of them says the server
+#: is full rather than that the caller did something wrong, and none of them
+#: mentions money: a full instance is not something a bigger tier fixes.
+_INSTANCE_REFUSALS = {
+    (HOUSEHOLDS, False): (
+        "This server is full: it holds at most {allowance} and has {used:,}. Nothing here is broken "
+        "and no existing account is affected — ask whoever runs it to put you on the waitlist, and "
+        "register once they say there is room. If you were sent an invite code, register with it "
+        "instead: joining an existing household needs no new one."
+    ),
+    (USERS, False): (
+        "This server is full: it holds at most {allowance} and has {used:,}. Nothing here is broken "
+        "and no existing account is affected — ask whoever runs it to put you on the waitlist, and "
+        "register once they say there is room."
+    ),
+    (USERS, True): (
+        "This server is full: it holds at most {allowance} and has {used:,}, so it cannot open another "
+        "one yet. Your invite code has not been used and the household that sent it is still here — "
+        "ask whoever runs the server to make room, then register with the same code. Nobody needs to "
+        "send you a new one."
+    ),
+}
+
+
+def _instance_refusal(resource: str, *, limit: int, used: int, invited: bool) -> str:
+    singular, plural = _INSTANCE_NOUNS[resource]
+    allowance = f"{limit:,} {singular if limit == 1 else plural}"
+    return _INSTANCE_REFUSALS[(resource, invited)].format(allowance=allowance, used=used)
+
+
+async def admit_registration(db: AsyncSession, *, invited: bool) -> None:
+    """Refuse a registration this server has no room for.
+
+    Called from `POST /auth/register` once the request is known to be otherwise
+    good, and before anything is written — so a refusal leaves no half-made
+    household behind and, for an invited caller, leaves their code unredeemed.
+
+    `invited` decides both what is counted and what the caller is told: a new
+    household needs room for a household *and* an account, while an invited
+    member only ever adds the account.
+    """
+    ceilings = instance_ceilings()
+    resources = INSTANCE_RESOURCES if not invited else (USERS,)
+    for resource in resources:
+        limit = ceilings[resource]
+        if limit is None:
+            continue  # the default everywhere: this server holds what it holds
+        used = await _count(db, _INSTANCE_MODELS[resource])
+        if used < limit:
+            continue
+        # The operator's signal, and the reason it is worth alerting on: by the
+        # time this fires, somebody has already been turned away.
+        log_event("instance.full", outcome=resource, limit=limit, used=used, invited=invited)
+        raise InstanceFull(
+            resource=resource,
+            limit=limit,
+            used=used,
+            detail=_instance_refusal(resource, limit=limit, used=used, invited=invited),
+        )
 
 
 # ------------------------------------------------------------------ ingest quota

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -118,6 +118,21 @@ async def limit_exceeded_handler(_: Request, exc: Exception) -> Response:
     return JSONResponse(status_code=exc.status_code, content=exc.payload())
 
 
+@app.exception_handler(limits.InstanceFull)
+async def instance_full_handler(_: Request, exc: Exception) -> Response:
+    """A deployment that has run out of room, in the same shape as every other
+    refusal.
+
+    503 rather than a 4xx because nothing about the request is wrong: this
+    server is simply full, and a waitlist means "later, yes" (see the instance
+    ceilings section of `app/limits.py`). No `Retry-After` — when room appears
+    is a decision somebody makes, not a duration we can predict, and a number
+    invented here would only send clients back on a schedule.
+    """
+    assert isinstance(exc, limits.InstanceFull)
+    return JSONResponse(status_code=exc.status_code, content=exc.payload())
+
+
 # Registered last so it is the *outermost* middleware (Starlette builds the
 # stack in reverse): the access log must see every response, including 426s
 # the gate above short-circuits, and it is the last resort for exceptions

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -21,6 +21,7 @@ count rows, and read nothing anyone entered.
 
 import asyncio
 import logging
+import math
 
 from prometheus_client import (
     CONTENT_TYPE_LATEST,
@@ -36,6 +37,7 @@ from prometheus_client import (
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import get_settings
 from app.database import SessionLocal
 from app.models import Household, Recipe, User
 
@@ -74,6 +76,19 @@ _USAGE_GAUGES: tuple[tuple[Gauge, type], ...] = (
     (Gauge("meals_recipes_total", "Recipes across all households.", registry=registry), Recipe),
 )
 
+# The instance ceilings beside the counts they bound, so a dashboard can divide
+# one by the other and see "nearly full" before somebody is turned away. An
+# unset ceiling reports `+Inf` rather than 0: a gauge left at its default would
+# read as "this server allows no households", and the ratio would be a division
+# by zero instead of the 0% that is true.
+# Read straight off the settings rather than through app.limits: that module
+# imports app.observability, which imports this one, and closing that loop
+# breaks whichever of the three is imported first.
+_CEILING_GAUGES: tuple[tuple[Gauge, str], ...] = (
+    (Gauge("meals_households_limit", "MAX_HOUSEHOLDS, or +Inf when unset.", registry=registry), "max_households"),
+    (Gauge("meals_users_limit", "MAX_USERS, or +Inf when unset.", registry=registry), "max_users"),
+)
+
 
 def observe_request(method: str, route: str, status: int, client_platform: str | None, duration_seconds: float) -> None:
     _HTTP_REQUESTS.labels(
@@ -90,6 +105,10 @@ async def refresh_usage_gauges(session: AsyncSession) -> None:
     for gauge, model in _USAGE_GAUGES:
         count = (await session.execute(select(func.count()).select_from(model))).scalar_one()
         gauge.set(count)
+    settings = get_settings()
+    for gauge, setting in _CEILING_GAUGES:
+        ceiling = getattr(settings, setting)
+        gauge.set(math.inf if ceiling is None else ceiling)
 
 
 async def usage_gauge_refresher(interval_seconds: float = 60.0) -> None:

--- a/backend/app/provision.py
+++ b/backend/app/provision.py
@@ -7,7 +7,10 @@ answer: an invite shares your recipes and shopping list with whoever redeems it.
 
 This creates a **separate, empty household** with one account in it, the same
 shape `POST /auth/register` produces, straight against the database. It bypasses
-the endpoint, not the model.
+the endpoint, not the model — which also means `MAX_HOUSEHOLDS` and `MAX_USERS`
+do not apply to it. That is deliberate: those refuse *strangers* on the
+operator's behalf, and somebody running this on the box has already made the
+decision they exist to make.
 
 Written for the Apple Review account (App Review has to be able to sign in and
 use the app, and cannot see a real household's data while doing it), but it is

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -96,6 +96,12 @@ async def register(payload: RegisterIn, db: DbSession, _: None = Depends(auth_ra
     A valid invite is honoured even when `REGISTRATION_ENABLED=false`. That's
     the point of the flag — a closed server should still let the household admit
     the people it chose, rather than locking out your own family.
+
+    A deployment that has set `MAX_HOUSEHOLDS` or `MAX_USERS` and reached one
+    answers 503 with what it holds and what to do next. That is a different
+    refusal from `REGISTRATION_ENABLED=false`: the server is full rather than
+    closed, so the answer is a waitlist rather than an invite code, and an
+    invite gets past the closed door but not past a full one.
     """
     email = payload.email.lower()
     invite = await _redeem_invite(db, payload.invite_code) if payload.invite_code else None
@@ -110,6 +116,12 @@ async def register(payload: RegisterIn, db: DbSession, _: None = Depends(auth_ra
     existing = await db.execute(select(User).where(User.email == email))
     if existing.scalar_one_or_none() is not None:
         raise HTTPException(status_code=409, detail="an account with this email already exists; use POST /auth/login")
+
+    # Last, and before anything is written: a refusal here must leave no
+    # half-made household behind and, for an invited caller, must leave their
+    # code unredeemed — `_redeem_invite` only validates, and `accepted_at` is
+    # set further down.
+    await limits.admit_registration(db, invited=invite is not None)
 
     if invite is not None:
         household = invite.household

--- a/backend/tests/integration/test_instance_ceilings.py
+++ b/backend/tests/integration/test_instance_ceilings.py
@@ -1,0 +1,230 @@
+"""How many households and accounts a deployment will hold (issue #96,
+planning/08-freemium.md §3, "Per instance").
+
+The other limits bound what one household costs. These bound how many of them
+the box takes at all, and they are a different animal in three ways this file
+keeps honest: no tier reaches them, only registration can cross them, and who
+is knocking changes the sentence — a stranger is offered the waitlist, while
+somebody holding an invite is expected by a household that is already here.
+
+Unset is the default, and every other test file in this suite runs that way.
+"""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app import metrics as metrics_module
+from app.models import Household, User
+from tests.conftest import register
+
+PASSWORD = "a-strong-password"
+
+
+def headers(auth: dict) -> dict:
+    return {"Authorization": f"Bearer {auth['token']}"}
+
+
+async def sign_up(client, email: str, **extra):
+    """A raw registration, so a refusal can be inspected rather than asserted away."""
+    return await client.post(
+        "/auth/register",
+        json={"email": email, "password": PASSWORD, "display_name": email.split("@")[0], **extra},
+    )
+
+
+async def counts(engine) -> tuple[int, int]:
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        households = len((await session.execute(select(Household))).scalars().all())
+        users = len((await session.execute(select(User))).scalars().all())
+    return households, users
+
+
+class TestUnsetIsUnbounded:
+    async def test_a_server_that_sets_nothing_takes_everyone(self, client):
+        for index in range(4):
+            assert (await sign_up(client, f"person{index}@example.com")).status_code == 201
+
+    async def test_nothing_says_a_ceiling_exists(self, client):
+        """A self-hoster who never heard of these should see no trace of them."""
+        response = await client.get("/client-config")
+        assert "max_households" not in response.text
+        assert "max_users" not in response.text
+
+
+class TestTheHouseholdCeiling:
+    async def test_the_last_place_is_taken_and_the_next_one_waits(self, client, settings_override):
+        settings_override(MAX_HOUSEHOLDS="2")
+        assert (await sign_up(client, "first@example.com")).status_code == 201
+        assert (await sign_up(client, "second@example.com")).status_code == 201
+
+        response = await sign_up(client, "third@example.com")
+        assert response.status_code == 503
+        body = response.json()
+        assert (body["resource"], body["limit"], body["used"]) == ("households", 2, 2)
+        assert body["detail"] == (
+            "This server is full: it holds at most 2 households and has 2. Nothing here is broken and "
+            "no existing account is affected — ask whoever runs it to put you on the waitlist, and "
+            "register once they say there is room. If you were sent an invite code, register with it "
+            "instead: joining an existing household needs no new one."
+        )
+
+    async def test_a_refusal_writes_nothing(self, client, engine, settings_override):
+        settings_override(MAX_HOUSEHOLDS="1")
+        await sign_up(client, "first@example.com")
+        assert (await sign_up(client, "second@example.com")).status_code == 503
+        assert await counts(engine) == (1, 1)  # no half-made household, no orphan user
+
+    async def test_a_ceiling_of_zero_takes_nobody(self, client, settings_override):
+        """Meaningful rather than a typo: a server closed to new arrivals that
+        still serves everyone already on it."""
+        settings_override(MAX_HOUSEHOLDS="0")
+        assert (await sign_up(client, "first@example.com")).status_code == 503
+
+    async def test_being_full_stops_nothing_that_is_already_here(self, client, settings_override):
+        """§5's rule, one level up: a full server is not a broken one."""
+        auth = await register(client)
+        settings_override(MAX_HOUSEHOLDS="1")
+        assert (await sign_up(client, "stranger@example.com")).status_code == 503
+
+        assert (await client.post("/recipes", json={"title": "Dinner"}, headers=headers(auth))).status_code == 201
+        assert (await client.get("/shopping-list", headers=headers(auth))).status_code == 200
+        login = await client.post("/auth/login", json={"email": "marcus@example.com", "password": PASSWORD})
+        assert login.status_code == 200
+
+    async def test_an_invite_gets_past_a_full_house_because_it_adds_no_household(self, client, settings_override):
+        host = await register(client)
+        settings_override(MAX_HOUSEHOLDS="1")
+        code = (await client.post("/auth/invites", json={}, headers=headers(host))).json()["code"]
+
+        joined = await sign_up(client, "partner@example.com", invite_code=code)
+        assert joined.status_code == 201
+        # And a stranger still can't start one of their own.
+        assert (await sign_up(client, "stranger@example.com")).status_code == 503
+
+
+class TestTheUserCeiling:
+    async def test_a_stranger_is_offered_the_waitlist(self, client, settings_override):
+        settings_override(MAX_USERS="1")
+        assert (await sign_up(client, "first@example.com")).status_code == 201
+
+        response = await sign_up(client, "second@example.com")
+        assert response.status_code == 503
+        body = response.json()
+        assert (body["resource"], body["limit"], body["used"]) == ("users", 1, 1)
+        assert "at most 1 account and has 1" in body["detail"]  # not "1 accounts"
+        assert "waitlist" in body["detail"]
+
+    async def test_somebody_holding_an_invite_is_told_something_kinder(self, client, settings_override):
+        """They are not a stranger the server can turn away: a household here
+        issued them a code and is waiting for them."""
+        host = await register(client)
+        code = (await client.post("/auth/invites", json={}, headers=headers(host))).json()["code"]
+        settings_override(MAX_USERS="1")
+
+        response = await sign_up(client, "partner@example.com", invite_code=code)
+        assert response.status_code == 503
+        detail = response.json()["detail"]
+        assert "Your invite code has not been used and the household that sent it is still here" in detail
+        assert "Nobody needs to send you a new one." in detail
+        assert "waitlist" not in detail
+
+    async def test_the_refused_invite_is_still_good_once_there_is_room(self, client, settings_override):
+        """The promise the kinder sentence makes, kept: nothing was consumed."""
+        host = await register(client)
+        code = (await client.post("/auth/invites", json={}, headers=headers(host))).json()["code"]
+        settings_override(MAX_USERS="1")
+        assert (await sign_up(client, "partner@example.com", invite_code=code)).status_code == 503
+
+        settings_override(MAX_USERS="2")
+        joined = await sign_up(client, "partner@example.com", invite_code=code)
+        assert joined.status_code == 201
+        assert joined.json()["user"]["email"] == "partner@example.com"
+
+    async def test_a_full_user_count_stops_a_new_household_too(self, client, settings_override):
+        """The account is what there is no room for, whether or not a household
+        comes with it."""
+        settings_override(MAX_USERS="1")
+        await sign_up(client, "first@example.com")
+        response = await sign_up(client, "second@example.com")
+        assert (response.status_code, response.json()["resource"]) == (503, "users")
+
+
+class TestMovingBetweenHouseholdsIsNeverRefused:
+    """`POST /auth/invites/redeem` moves an existing user between existing
+    households: the user count is unchanged and the household count can only
+    fall, since the one they left is collected when it empties. Refusing it
+    would block a move that costs the server nothing."""
+
+    async def test_a_redeem_works_on_a_completely_full_server(self, client, engine, settings_override):
+        host = await register(client, email="host@example.com", name="Host")
+        joiner = await register(client, email="joiner@example.com", name="Joiner")
+        code = (await client.post("/auth/invites", json={}, headers=headers(host))).json()["code"]
+        before = await counts(engine)
+        settings_override(MAX_HOUSEHOLDS=str(before[0]), MAX_USERS=str(before[1]))
+
+        response = await client.post("/auth/invites/redeem", json={"code": code}, headers=headers(joiner))
+        assert response.status_code == 200
+        # The vacated household went with them, so the server is emptier.
+        assert await counts(engine) == (before[0] - 1, before[1])
+
+
+class TestItIsADifferentRefusalFromBeingClosed:
+    async def test_a_closed_server_says_closed_rather_than_full(self, client, settings_override):
+        """`REGISTRATION_ENABLED=false` is policy and keeps its own 403: the
+        answer there is an invite code, not a waitlist."""
+        settings_override(REGISTRATION_ENABLED="false", MAX_HOUSEHOLDS="10")
+        response = await sign_up(client, "stranger@example.com")
+        assert response.status_code == 403
+        assert "not accepting new households" in response.json()["detail"]
+
+    async def test_a_closed_server_still_honours_an_invite_when_it_has_room(self, client, settings_override):
+        host = await register(client)
+        code = (await client.post("/auth/invites", json={}, headers=headers(host))).json()["code"]
+        settings_override(REGISTRATION_ENABLED="false", MAX_USERS="10")
+        assert (await sign_up(client, "partner@example.com", invite_code=code)).status_code == 201
+
+    async def test_a_duplicate_email_is_still_a_409(self, client, settings_override):
+        """It creates nothing, so "you already have an account" is the more
+        useful answer than "we are full"."""
+        settings_override(MAX_HOUSEHOLDS="1")
+        await sign_up(client, "first@example.com")
+        response = await sign_up(client, "first@example.com")
+        assert response.status_code == 409
+
+    async def test_being_full_is_worth_telling_the_operator_about(self, client, settings_override, caplog):
+        settings_override(MAX_HOUSEHOLDS="1")
+        await sign_up(client, "first@example.com")
+        with caplog.at_level("INFO", logger="meals.events"):
+            assert (await sign_up(client, "second@example.com")).status_code == 503
+        record = next(r for r in caplog.records if r.getMessage() == "instance.full")
+        assert (record.outcome, record.limit, record.used, record.invited) == ("households", 1, 1, False)
+
+
+class TestTheCeilingsAreVisibleBeforeTheyBite:
+    """The point of the gauges: "nearly full" should be a dashboard line, not
+    something learned from the first person who was turned away."""
+
+    async def test_the_ceilings_sit_beside_the_counts_they_bound(self, engine, client, settings_override):
+        settings_override(METRICS_TOKEN="scrape-secret-1", MAX_HOUSEHOLDS="25", MAX_USERS="60")
+        await register(client)
+        maker = async_sessionmaker(engine, expire_on_commit=False)
+        async with maker() as session:
+            await metrics_module.refresh_usage_gauges(session)
+
+        body = (await client.get("/metrics", headers={"Authorization": "Bearer scrape-secret-1"})).text
+        assert "meals_households_limit 25.0" in body
+        assert "meals_users_limit 60.0" in body
+        assert "meals_households_total 1.0" in body
+
+    async def test_an_unset_ceiling_is_infinity_not_zero(self, engine, client, settings_override):
+        """A gauge left at its default would read as "this server allows no
+        households", and the ratio a dashboard wants would divide by zero."""
+        settings_override(METRICS_TOKEN="scrape-secret-1")
+        maker = async_sessionmaker(engine, expire_on_commit=False)
+        async with maker() as session:
+            await metrics_module.refresh_usage_gauges(session)
+
+        body = (await client.get("/metrics", headers={"Authorization": "Bearer scrape-secret-1"})).text
+        assert "meals_households_limit +Inf" in body
+        assert "meals_users_limit +Inf" in body

--- a/backend/tests/integration/test_provision.py
+++ b/backend/tests/integration/test_provision.py
@@ -99,6 +99,20 @@ class TestProvision:
         await provision("review@example.com", "s3cret-passphrase", "Review", "Apple Review", sessions)
         await sign_in(client, "review@example.com", "s3cret-passphrase")
 
+    async def test_it_works_while_the_server_is_full(self, client, sessions, settings_override):
+        """`MAX_HOUSEHOLDS` refuses strangers on the operator's behalf, and
+        somebody running this on the box is the operator making that call
+        themselves — the same reason a closed door does not stop it either."""
+        settings_override(MAX_HOUSEHOLDS="0", MAX_USERS="0")
+        refused = await client.post(
+            "/auth/register",
+            json={"email": "stranger@example.com", "password": "a-strong-password", "display_name": "Stranger"},
+        )
+        assert refused.status_code == 503
+
+        await provision("review@example.com", "s3cret-passphrase", "Review", "Apple Review", sessions)
+        await sign_in(client, "review@example.com", "s3cret-passphrase")
+
     async def test_generated_passwords_are_typeable_and_not_guessable(self):
         """It goes in App Review notes and gets retyped on a phone by someone
         who didn't choose to be here — but it's still a real credential."""

--- a/backend/tests/unit/test_limits.py
+++ b/backend/tests/unit/test_limits.py
@@ -213,6 +213,10 @@ class TestRefusalsSayNothingAboutMoney:
             for kind in ("cap", "ceiling"):
                 for upgradable in (True, False):
                     yield name, limits._refusal(spec, tier="free", limit=50, used=50, kind=kind, upgradable=upgradable)
+        # A full instance is not something money fixes either, and the same
+        # sentence reaches the same screens.
+        for resource, invited in limits._INSTANCE_REFUSALS:
+            yield resource, limits._instance_refusal(resource, limit=25, used=25, invited=invited)
 
     def test_no_refusal_mentions_money_or_points_anywhere(self):
         for name, sentence in self._every_refusal():
@@ -245,6 +249,51 @@ class TestRefusalsSayNothingAboutMoney:
             limits.RESOURCES["members"], tier="free", limit=1, used=1, kind="cap", upgradable=True
         )
         assert "1 member per household" in sentence
+
+
+class TestInstanceCeilings:
+    """§3's other table. No tier reaches these, so nothing about them is a
+    matter of what the caller is paying."""
+
+    def test_unset_by_default(self):
+        assert limits.instance_ceilings() == {"households": None, "users": None}
+
+    def test_they_read_off_the_environment(self, settings_override):
+        settings_override(MAX_HOUSEHOLDS="25", MAX_USERS="60")
+        assert limits.instance_ceilings() == {"households": 25, "users": 60}
+
+    def test_zero_is_a_ceiling_and_not_a_typo(self, settings_override):
+        """A server closed to new arrivals that still serves everyone on it."""
+        settings_override(MAX_HOUSEHOLDS="0")
+        limits.check_settings()
+        assert limits.instance_ceilings()["households"] == 0
+
+    def test_a_negative_ceiling_stops_the_container(self, settings_override):
+        settings_override(MAX_USERS="-1")
+        with pytest.raises(ValueError, match="MAX_USERS"):
+            limits.check_settings()
+
+    def test_every_sentence_says_the_server_is_full_and_what_to_do(self):
+        for resource, invited in limits._INSTANCE_REFUSALS:
+            sentence = limits._instance_refusal(resource, limit=25, used=25, invited=invited)
+            assert sentence.startswith("This server is full"), sentence
+            assert "ask whoever runs" in sentence, sentence
+
+    def test_a_stranger_is_pointed_at_the_waitlist(self):
+        sentence = limits._instance_refusal("households", limit=25, used=25, invited=False)
+        assert "waitlist" in sentence
+        assert "25 households" in sentence
+
+    def test_somebody_expected_is_not_asked_to_queue(self):
+        """A household here issued them a code; telling them to join a waitlist
+        would be queueing them for something they are already inside."""
+        sentence = limits._instance_refusal("users", limit=25, used=25, invited=True)
+        assert "waitlist" not in sentence
+        assert "invite code has not been used" in sentence
+
+    def test_one_of_something_reads_as_singular(self):
+        assert "at most 1 account and" in limits._instance_refusal("users", limit=1, used=1, invited=False)
+        assert "at most 1 household and" in limits._instance_refusal("households", limit=1, used=1, invited=False)
 
 
 class TestTheIngestMonth:


### PR DESCRIPTION
## What and why

Closes [#96](https://github.com/marco308/meals/issues/96) — `planning/08-freemium.md` §3, "Per instance". `MAX_HOUSEHOLDS` and `MAX_USERS` bound how many households the deployment holds, as opposed to what each one costs. Unset by default, so a self-hosted server behaves exactly as it did; set, `POST /auth/register` refuses instead of letting the machine find its own limit, and the founding-cohort cap from `planning/06-marketing.md` §1b becomes a setting rather than a note in a doc.

**It answers 503, not 402/403.** No tier reaches these and no upgrade leads out of them: the caller has done nothing wrong and the server is simply full, and a waitlist means "later, yes" — the one thing a status code can carry that Forbidden cannot. `REGISTRATION_ENABLED=false` is untouched and keeps its own 403, because that server is *closed* rather than *full*; an invite gets past a closed door but not past a full house.

**Who is knocking changes the sentence.** A stranger is offered the waitlist. Somebody registering against an invite is expected — a household here issued them a code — so they are told their code is unspent and still good once room appears. That is a promise the code keeps: the check runs after the duplicate-email 409 and before anything is written, so a refusal leaves no half-made household and no consumed invite.

**Both ceilings ride on `/metrics`** as `meals_households_limit` / `meals_users_limit`, beside the counts they bound, so "nearly full" is a dashboard line rather than something learned from the first person turned away. Unset reports `+Inf`, not 0 — 0 would read as "this server allows no households" and make the ratio a division by zero.

### Two judgement calls worth a look

- **`POST /auth/invites/redeem` is deliberately never checked.** The issue asks for a kinder message when refusing a redeem, but a redeem moves an *existing* user between *existing* households: the account count is unchanged and the household count can only fall, since `move_user_to_household` collects the one they left. So the kinder sentence lives on the path that can actually cross a ceiling — registering with an invite code — and redeem stays unrefusable, with a test pinning that on a completely full server.
- **`app/provision.py` bypasses both ceilings**, as it already bypasses the closed door. Somebody running that CLI on the box is the operator making the very decision these ceilings make on their behalf.

Not done, and not asked for: the instance ceilings are not published on `GET /limits` or `/client-config`. `/limits` is per-household, and how full a server is looked like an operator's number rather than an anonymous caller's. Say the word if you'd rather it were public.

## Checklist

- [x] **API contract stayed additive** — no response field touched. One new refusal on an existing endpoint, reachable only when a deployment opts in by setting a number.
- [x] **Model change has a migration** — n/a, no model change.
- [x] **Shopping-list quantities still derive from `ListItemSource`** — n/a.
- [x] **Every new query filters on `household_id`** — n/a by design: these are whole-server counts, like the existing usage gauges, and they read row counts rather than anything anyone entered.
- [x] **Skill/prompt pack updated** — n/a, no endpoint an assistant drives changed; registration isn't in the playbook, so the version is deliberately unbumped.
- [x] **New 4xx strings say what to do instead** — all three refusals name the ceiling and the count, say nothing is broken, and end with the next move (waitlist, or "your code is still good").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
