### PR TITLE
Hand a household everything it owns, in one request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,33 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 
 ### Added
 
+- **`GET /household/export` returns everything a household owns in one request**
+  ([#97](https://github.com/marco308/meals/issues/97)) — recipes with their
+  lines, the ingredient library, meals, plans, the cooked history, saved
+  supermarkets and every shopping list including the archived ones, as one JSON
+  document. Ids are kept so it is importable in principle; every reference
+  carries the name beside the id so it is readable in practice, without joining
+  anything.
+- **It is free on every tier and always will be** (`planning/08-freemium.md`
+  §1). Nothing in `app/limits.py` touches it: "take your data and go self-host"
+  being one request is what makes hosting somebody's data defensible, and it is
+  the same answer whether or not anyone is paying. It is equally useful with no
+  hosting business at all — the thing to run before a migration, and the
+  per-household complement to the whole-database `backup/` sidecar.
+- **Streamed row by row**, so a 2,000-recipe household starts arriving
+  immediately instead of being assembled in memory. Deterministic ordering
+  throughout, so two exports of an unchanged household are the same bytes and
+  can be diffed.
+- **Credentials and bookkeeping stay behind**: no password hashes, API tokens
+  or invite codes, and none of this server's own record *about* the household
+  (its tier, any price, the ingest counter), which means nothing on the box it
+  is moving to. The field lists are explicit rather than reflected off the
+  table, and a test fails when a new column is neither exported nor written
+  down as deliberately excluded.
+- Import is **not** included, on purpose: id collisions, ingredient folding and
+  unit canonicalisation make it a bigger design question, and it should not have
+  held the export up.
+
 - **`MAX_HOUSEHOLDS` and `MAX_USERS` bound the instance, not the household**
   ([#96](https://github.com/marco308/meals/issues/96),
   `planning/08-freemium.md` §3). The per-household caps say what one family

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,17 @@ instrumentation a new feature usually needs.
   enforced. It answers unlimited rather than 404 on an unconfigured server, and
   counts only what is actually limited, so the "no queries when nothing is set"
   promise holds there too.
+- **Export is free in every tier, forever** (`services/export.py`,
+  `GET /household/export`, `planning/08-freemium.md` §1). Nothing in
+  `app/limits.py` touches it and nothing ever should — "take your data and go
+  self-host" being one request is the whole answer to the hostage objection.
+  Two rules hold it together: **explicit field lists, never
+  `__table__.columns`**, so the next billing column added to `households` can't
+  silently join the file (a test fails when a new column is neither exported
+  nor written down as excluded, so the omission is loud); and **rows are
+  expunged one at a time while streaming** — `expunge_all()` invalidates the
+  identity map the open result is still loading through, and everything after
+  the first batch is lost.
 - **Instance ceilings are the other axis** (`MAX_HOUSEHOLDS`, `MAX_USERS`, at the
   bottom of `app/limits.py`). They bound how many households the *box* holds
   rather than what one costs, so no tier reaches them and none of the above

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -121,9 +121,18 @@ requests.
 - **Be removed from one** — the household's lead can remove any member. That
   ends your access to its recipes, plans and lists, and nothing else: your
   account is untouched and you keep everything signed in on it.
-- **Export your data** — every endpoint the app uses is a documented REST API
-  (`/docs` on your server). Your data is readable with a personal token and a
-  single `curl`.
+- **Export your data** — one request returns everything your household owns as
+  a JSON file: recipes, ingredients, meals, plans, cooked history, saved
+  supermarkets and every shopping list including the archived ones.
+
+  ```
+  curl -H "Authorization: Bearer <your API token>" https://<your server>/household/export -O -J
+  ```
+
+  It costs nothing on any server, and it never will. Passwords, API tokens and
+  invite codes are deliberately left out — they are credentials, and useless
+  anywhere else. Every other endpoint the app uses is a documented REST API
+  too (`/docs` on your server).
 - **Move servers** — change the server URL on the sign-in screen. Nothing ties
   the app to any particular deployment.
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,14 @@ existing one; `REGISTRATION_ENABLED=false` additionally stops new households
 being created while still honouring invite codes, so closing a server doesn't
 lock out your own family.
 
+`GET /household/export` returns everything a household owns — recipes,
+ingredients, meals, plans, cooked history, supermarkets and every shopping list
+including archived ones — as one streamed JSON document. It is free on every
+tier and always will be: taking your data elsewhere is not something a server
+should be able to make difficult, and it is also the thing to run before a
+migration. Import is deliberately not built yet; it is a bigger design question
+(id collisions, ingredient folding) and it should not have held the export up.
+
 Per-household limits exist and are **off**: `LIMITS_PROFILE` is `unlimited`
 unless you change it, every household's `tier` is `unlimited`, and the
 enforcement returns before it runs a query, so an install that sets nothing has

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,7 @@ from fastapi.staticfiles import StaticFiles
 from app import client_gate, limits, mcp_mount, metrics, observability
 from app.config import get_settings
 from app.observability import log_event
-from app.routers import auth, ingredients, meals, pages, plans, recipes, shopping, skill, supermarkets
+from app.routers import auth, household, ingredients, meals, pages, plans, recipes, shopping, skill, supermarkets
 from app.routers import limits as limits_router
 from app.routers.skill import base_url, playbook_version
 
@@ -150,6 +150,7 @@ app.include_router(supermarkets.router)
 app.include_router(skill.router)
 app.include_router(pages.router)
 app.include_router(limits_router.router)
+app.include_router(household.router)
 
 # The web client is served by the API itself so it is always same-origin with
 # the endpoints it calls — no CORS, no second host to deploy or certify. Plain

--- a/backend/app/routers/household.py
+++ b/backend/app/routers/household.py
@@ -1,0 +1,64 @@
+"""The household's own data, on its way out.
+
+`GET /household/export` is the whole of it: one request that returns everything
+the calling household owns. It is deliberately **free in every tier, forever**
+(planning/08-freemium.md §1) — "take your data and go self-host" being one
+request is what makes hosting somebody's data defensible, and it is the same
+answer whether or not anyone is paying. Nothing in `app/limits.py` touches it,
+and nothing ever should.
+"""
+
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Request
+from fastapi.responses import StreamingResponse
+
+from app.deps import CurrentUser, DbSession
+from app.observability import log_event
+from app.services import export
+
+router = APIRouter(prefix="/household", tags=["household"])
+
+
+@router.get(
+    "/export",
+    response_class=StreamingResponse,
+    responses={
+        200: {
+            "content": {"application/json": {}},
+            "description": "The household's entire contents as one JSON document.",
+        }
+    },
+)
+async def export_household(user: CurrentUser, db: DbSession, request: Request) -> StreamingResponse:
+    """Everything your household owns, as one JSON document.
+
+    Recipes with their lines, the ingredient library, meals, plans, the cooked
+    history, saved supermarkets, and every shopping list including the archived
+    ones. Ids are kept so the file can be re-imported in principle, and each
+    reference carries the name beside the id so it can be read without joining
+    anything.
+
+    It is streamed, so a large household starts arriving immediately rather than
+    being assembled in memory first. There is no pagination and no partial
+    export: the point is that one request is the whole of it.
+
+    Free on every tier and never rate-limited by any of the household limits —
+    leaving is not something a server should be able to make difficult.
+
+    What is deliberately **not** here: passwords, API tokens and invite codes
+    (credentials, and useless anywhere else), and this server's own bookkeeping
+    about the household — its tier, any price, the ingest counter — which is
+    what this deployment records *about* you rather than anything you made.
+    """
+    household = user.household
+    # One line, after the fact: an export is a rare and consequential thing to
+    # have happened, and "who pulled the whole household out" is worth being
+    # able to find. Ids only, as everywhere else.
+    log_event("household.exported", household_id=household.id, user_id=user.id)
+    stamp = datetime.now(UTC).strftime("%Y-%m-%d")
+    return StreamingResponse(
+        export.stream_household(db, household, api_version=request.app.version),
+        media_type="application/json",
+        headers={"Content-Disposition": f'attachment; filename="meals-export-{stamp}.json"'},
+    )

--- a/backend/app/services/export.py
+++ b/backend/app/services/export.py
@@ -1,0 +1,346 @@
+"""Everything a household owns, in one streamed JSON document (issue #97).
+
+This is the answer to the only real objection to hosting somebody's data for
+them: "take your data and go" has to be one request, not a support ticket, and
+it stays free in every tier forever (planning/08-freemium.md §1). It is worth
+exactly as much on a server nobody pays for, where it is the thing to run
+before a migration and the per-household complement to the whole-database
+`backup/` sidecar — which deliberately restores whole rather than piecemeal.
+
+Three decisions shape the module:
+
+- **Streamed, row by row.** A 2,000-recipe household is not small, and neither
+  buffering the document nor holding every ORM object is acceptable. Each table
+  is read in batches and each row is serialised and then expunged, so the
+  session's identity map stays flat and bytes reach the client while the
+  database is still reading. `expunge_all()` is *not* the way to do that — it
+  invalidates the identity map the open result is still loading through — so
+  rows are expunged one at a time.
+- **Readable as well as importable.** Children are nested under their parents
+  (a recipe carries its lines, a list carries its items and their provenance)
+  and every reference to an ingredient or a recipe carries the name beside the
+  id, so a human can read the file without joining anything. Ids are kept
+  because they are what makes it importable in principle.
+- **Explicit field lists, never `__table__.columns`.** Reflecting the columns
+  would mean the next column added to `households` — the next billing or quota
+  field — silently joins the export, and one of those days it would be a
+  secret. Everything here is named on purpose; `tests/unit/test_export.py`
+  fails when a new column is neither exported nor written down as excluded, so
+  the omission is loud rather than silent.
+"""
+
+import json
+import uuid
+from collections.abc import AsyncIterator, Callable
+from datetime import UTC, date, datetime
+from typing import Any
+
+from sqlalchemy import Select, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import Base
+from app.models import (
+    CookedEvent,
+    Household,
+    Ingredient,
+    ListItem,
+    Meal,
+    Plan,
+    Recipe,
+    ShoppingList,
+    Supermarket,
+    User,
+)
+
+#: The export document's own version, so an importer written later can tell
+#: what it is holding. Bump it when the shape changes in a way a reader would
+#: have to notice — a new section or a new field is not that.
+EXPORT_VERSION = 1
+
+#: Rows read per round trip. Big enough that a large household is not a
+#: thousand queries, small enough that no batch is a memory problem.
+BATCH = 200
+
+
+def _encode(value: Any) -> str:
+    """One row as JSON. Datetimes are stamped UTC rather than left naive:
+    SQLite round-trips them without a timezone, and a consumer should not have
+    to guess which one the file means."""
+
+    def default(item: Any) -> Any:
+        if isinstance(item, uuid.UUID):
+            return str(item)
+        if isinstance(item, datetime):
+            return (item if item.tzinfo is not None else item.replace(tzinfo=UTC)).isoformat()
+        if isinstance(item, date):
+            return item.isoformat()
+        raise TypeError(f"{type(item).__name__} is not JSON")
+
+    return json.dumps(value, default=default)
+
+
+async def _stream_rows(db: AsyncSession, statement: Select) -> AsyncIterator[Any]:
+    """Every row the statement selects, in batches, forgetting each as it goes.
+
+    The expunge is per row rather than per batch: `Session.expunge_all()` kills
+    the identity map that the still-open streaming result is loading through,
+    which fails on the second batch.
+    """
+    result = await db.stream_scalars(statement)
+    async for batch in result.partitions(BATCH):
+        for row in batch:
+            yield row
+            db.expunge(row)
+
+
+# ------------------------------------------------------------------ the rows
+
+
+def _member(user: User, *, lead_user_id: uuid.UUID | None) -> dict:
+    return {
+        "id": user.id,
+        "email": user.email,
+        "display_name": user.display_name,
+        "is_lead": user.id == lead_user_id,
+        "created_at": user.created_at,
+    }
+
+
+def _ingredient(ingredient: Ingredient) -> dict:
+    return {
+        "id": ingredient.id,
+        "name": ingredient.name,
+        "aisle": ingredient.aisle,
+        "is_staple": ingredient.is_staple,
+        "value_tier": ingredient.value_tier,
+        "value_note": ingredient.value_note,
+        "created_at": ingredient.created_at,
+    }
+
+
+def _recipe(recipe: Recipe) -> dict:
+    return {
+        "id": recipe.id,
+        "title": recipe.title,
+        "source_url": recipe.source_url,
+        "servings": recipe.servings,
+        "prep_minutes": recipe.prep_minutes,
+        "cook_minutes": recipe.cook_minutes,
+        "image_url": recipe.image_url,
+        "instructions": recipe.instructions,
+        "tags": list(recipe.tags or []),
+        "parse_source": recipe.parse_source,
+        "edited": recipe.edited,
+        "times_cooked": recipe.times_cooked,
+        "last_cooked_at": recipe.last_cooked_at,
+        "created_by": recipe.created_by,
+        "created_at": recipe.created_at,
+        "updated_at": recipe.updated_at,
+        "ingredients": [
+            {
+                "ingredient_id": line.ingredient_id,
+                "name": line.ingredient.name,
+                "quantity": line.quantity,
+                "unit": line.unit,
+                "raw_text": line.raw_text,
+                "position": line.position,
+            }
+            for line in recipe.ingredient_links
+        ],
+    }
+
+
+def _meal(meal: Meal) -> dict:
+    return {
+        "id": meal.id,
+        "name": meal.name,
+        "slot": meal.slot,
+        "times_cooked": meal.times_cooked,
+        "last_cooked_at": meal.last_cooked_at,
+        "created_at": meal.created_at,
+        "recipes": [
+            {"recipe_id": link.recipe_id, "title": link.recipe.title, "scale": link.scale} for link in meal.recipe_links
+        ],
+        "loose_ingredients": [
+            {
+                "ingredient_id": link.ingredient_id,
+                "name": link.ingredient.name,
+                "quantity": link.quantity,
+                "unit": link.unit,
+            }
+            for link in meal.ingredient_links
+        ],
+    }
+
+
+def _plan(plan: Plan) -> dict:
+    return {
+        "id": plan.id,
+        "label": plan.label,
+        "starts_on": plan.starts_on,
+        "status": plan.status,
+        "created_at": plan.created_at,
+        "archived_at": plan.archived_at,
+        "meals": [
+            {
+                "id": link.id,
+                "meal_id": link.meal_id,
+                "name": link.meal.name,
+                "cooked_at": link.cooked_at,
+                "created_at": link.created_at,
+            }
+            for link in plan.meal_links
+        ],
+    }
+
+
+def _cooked_event(event: CookedEvent) -> dict:
+    """The household's record of what it actually ate, which outlives the plan,
+    the meal and the recipe by design — so it is exported as its own section
+    rather than folded into any of them."""
+    return {
+        "id": event.id,
+        "subject": event.subject,
+        "meal_id": event.meal_id,
+        "meal_name": event.meal_name,
+        "recipe_id": event.recipe_id,
+        "recipe_title": event.recipe_title,
+        "plan_meal_id": event.plan_meal_id,
+        "scale": event.scale,
+        "cooked_at": event.cooked_at,
+        "created_by": event.created_by,
+        "created_at": event.created_at,
+    }
+
+
+def _supermarket(market: Supermarket) -> dict:
+    return {
+        "id": market.id,
+        "name": market.name,
+        "aisle_order": list(market.aisle_order or []),
+        "is_active": market.is_active,
+        "created_at": market.created_at,
+    }
+
+
+def _shopping_list(shopping_list: ShoppingList) -> dict:
+    return {
+        "id": shopping_list.id,
+        "status": shopping_list.status,
+        "created_at": shopping_list.created_at,
+        "archived_at": shopping_list.archived_at,
+        "items": [_list_item(item) for item in shopping_list.items],
+    }
+
+
+def _list_item(item: ListItem) -> dict:
+    """`quantity` is derived from the sources rather than stored (Q3's cousin:
+    a line's amount is the sum of its contributions), so both are written —
+    the total for a reader, the rows for anything reconstructing it."""
+    return {
+        "id": item.id,
+        "ingredient_id": item.ingredient_id,
+        "name": item.ingredient.name,
+        "quantity": item.quantity,
+        "unit": item.unit,
+        "checked": item.checked,
+        "excluded": item.excluded,
+        "staple_needed": item.staple_needed,
+        "created_at": item.created_at,
+        "updated_at": item.updated_at,
+        "sources": [
+            {
+                "id": source.id,
+                "plan_meal_id": source.plan_meal_id,
+                "recipe_id": source.recipe_id,
+                "quantity": source.quantity,
+                "client_key": source.client_key,
+                "created_at": source.created_at,
+            }
+            for source in item.sources
+        ],
+    }
+
+
+# --------------------------------------------------------------- the document
+
+#: Section name → (statement builder, row builder). Ordered, and every order is
+#: by `created_at` then `id`: two exports of an unchanged household should be
+#: the same bytes, so they can be diffed.
+Section = tuple[str, Callable[[uuid.UUID], Select], Callable[[Any], dict]]
+
+
+def _sections() -> tuple[Section, ...]:
+    return (
+        (
+            "ingredients",
+            lambda hid: select(Ingredient).where(Ingredient.household_id == hid).order_by(*_order(Ingredient)),
+            _ingredient,
+        ),
+        ("recipes", lambda hid: select(Recipe).where(Recipe.household_id == hid).order_by(*_order(Recipe)), _recipe),
+        ("meals", lambda hid: select(Meal).where(Meal.household_id == hid).order_by(*_order(Meal)), _meal),
+        ("plans", lambda hid: select(Plan).where(Plan.household_id == hid).order_by(*_order(Plan)), _plan),
+        (
+            "cooked_events",
+            lambda hid: select(CookedEvent).where(CookedEvent.household_id == hid).order_by(*_order(CookedEvent)),
+            _cooked_event,
+        ),
+        (
+            "supermarkets",
+            lambda hid: select(Supermarket).where(Supermarket.household_id == hid).order_by(*_order(Supermarket)),
+            _supermarket,
+        ),
+        (
+            "shopping_lists",
+            lambda hid: select(ShoppingList).where(ShoppingList.household_id == hid).order_by(*_order(ShoppingList)),
+            _shopping_list,
+        ),
+    )
+
+
+def _order(model: type[Base]) -> tuple:
+    return (model.created_at, model.id)
+
+
+SECTION_NAMES = tuple(name for name, _, _ in _sections())
+
+
+async def stream_household(db: AsyncSession, household: Household, *, api_version: str) -> AsyncIterator[str]:
+    """The whole document, a fragment at a time.
+
+    Everything is scoped to `household.id` — the same rule as every other query
+    in the app, and the one that matters most here, since this endpoint hands
+    back a file rather than a screenful.
+
+    The household row and its members are read up front (both are small and
+    bounded); everything after that is streamed.
+    """
+    household_id = household.id
+    members = (
+        (await db.execute(select(User).where(User.household_id == household_id).order_by(*_order(User))))
+        .scalars()
+        .all()
+    )
+    header = {
+        "export_version": EXPORT_VERSION,
+        "exported_at": datetime.now(UTC),
+        "api_version": api_version,
+        "household": {
+            "id": household.id,
+            "name": household.name,
+            "lead_user_id": household.lead_user_id,
+            "created_at": household.created_at,
+        },
+        "members": [_member(member, lead_user_id=household.lead_user_id) for member in members],
+    }
+    # Written open-ended so the sections can be appended as they are read.
+    yield _encode(header)[:-1]
+
+    for name, statement, row in _sections():
+        yield f", {json.dumps(name)}: ["
+        separator = ""
+        async for entity in _stream_rows(db, statement(household_id)):
+            yield separator + _encode(row(entity))
+            separator = ","
+        yield "]"
+    yield "}"

--- a/backend/tests/integration/test_export.py
+++ b/backend/tests/integration/test_export.py
@@ -1,0 +1,347 @@
+"""`GET /household/export` (issue #97): everything a household owns, in one
+request.
+
+Three things are being defended, and the first two are the reasons this
+endpoint exists at all:
+
+1. **It is complete.** Nothing a household made is left behind, and a column
+   added later that nobody exported is a test failure rather than a silent
+   omission — `TestNothingIsLeftBehind` is that check.
+2. **It is theirs alone.** This hands back a file rather than a screenful, so
+   the household filter is the whole of the security of it.
+3. **It costs nothing.** Free in every tier, forever (planning/08-freemium.md
+   §1) — leaving is not something a server gets to make difficult.
+"""
+
+import json
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.models import (
+    CookedEvent,
+    Household,
+    Ingredient,
+    ListItem,
+    ListItemSource,
+    Meal,
+    MealIngredient,
+    MealRecipe,
+    Plan,
+    PlanMeal,
+    Recipe,
+    RecipeIngredient,
+    ShoppingList,
+    Supermarket,
+    User,
+)
+from app.services import export
+from tests.conftest import create_meal, create_plan, create_recipe, register
+
+PASSWORD = "a-strong-password"
+
+
+def headers(auth: dict) -> dict:
+    return {"Authorization": f"Bearer {auth['token']}"}
+
+
+async def furnish(client, *, extra: dict | None = None) -> dict:
+    """One of everything, so an export has something of every kind in it."""
+    recipe = await create_recipe(client, **(extra or {}))
+    meal = await create_meal(
+        client,
+        name="Monday",
+        recipe_ids=[recipe["id"]],
+        loose_ingredients=[{"name": "peas", "quantity": 200, "unit": "g"}],
+    )
+    plan = await create_plan(client, label="w/c 24 August")
+    added = await client.post(f"/plans/{plan['id']}/meals", json={"meal_id": meal["id"]})
+    assert added.status_code == 201
+    plan_meal = added.json()["meals"][0]  # the response is the whole plan; the link id is in it
+    cooked = await client.post(f"/plans/{plan['id']}/meals/{plan_meal['id']}/cooked")
+    assert cooked.status_code == 200
+    market = await client.post("/supermarkets", json={"name": "Aldi", "aisle_order": ["🧊", "🥬"], "is_active": True})
+    assert market.status_code == 201
+    added_item = await client.post("/shopping-list/items", json={"name": "bin bags", "quantity": 1, "unit": "item"})
+    assert added_item.status_code == 201
+    return {"recipe": recipe, "meal": meal, "plan": plan, "plan_meal": plan_meal}
+
+
+async def exported(client, **kwargs) -> dict:
+    response = await client.get("/household/export", **kwargs)
+    assert response.status_code == 200, response.text
+    return json.loads(response.text)
+
+
+class TestTheWholeHousehold:
+    async def test_every_section_is_there_and_carries_its_rows(self, auth_client):
+        await furnish(auth_client)
+        doc = await exported(auth_client)
+
+        assert doc["export_version"] == export.EXPORT_VERSION
+        assert doc["household"]["name"] == "Home"
+        assert [member["email"] for member in doc["members"]] == ["marcus@example.com"]
+        assert doc["members"][0]["is_lead"] is True
+        for section in export.SECTION_NAMES:
+            assert doc[section], f"{section} came back empty"
+
+    async def test_a_recipe_carries_its_lines_with_the_names_beside_the_ids(self, auth_client):
+        """Readable in practice: you can read the file without joining it."""
+        await furnish(auth_client)
+        recipe = (await exported(auth_client))["recipes"][0]
+        assert recipe["title"] == "Spaghetti Bolognese"
+        line = next(line for line in recipe["ingredients"] if line["name"] == "minced beef")
+        assert (line["quantity"], line["unit"]) == (500.0, "g")
+        assert line["ingredient_id"]
+
+    async def test_a_meal_carries_its_recipes_and_its_loose_ingredients(self, auth_client):
+        await furnish(auth_client)
+        meal = (await exported(auth_client))["meals"][0]
+        assert [link["title"] for link in meal["recipes"]] == ["Spaghetti Bolognese"]
+        assert [line["name"] for line in meal["loose_ingredients"]] == ["peas"]
+
+    async def test_a_list_carries_its_items_and_why_each_is_on_it(self, auth_client):
+        await furnish(auth_client)
+        items = (await exported(auth_client))["shopping_lists"][0]["items"]
+        from_a_meal = next(item for item in items if item["name"] == "minced beef")
+        assert from_a_meal["quantity"] == 500.0  # derived from the sources, and written out
+        assert from_a_meal["sources"][0]["plan_meal_id"]
+        ad_hoc = next(item for item in items if item["name"] == "bin bags")
+        assert ad_hoc["sources"][0]["plan_meal_id"] is None
+
+    async def test_archived_lists_come_too(self, auth_client):
+        await furnish(auth_client)
+        assert (await auth_client.post("/shopping-list/archive")).status_code == 200
+        await auth_client.post("/shopping-list/items", json={"name": "milk"})
+
+        lists = (await exported(auth_client))["shopping_lists"]
+        assert sorted(shop["status"] for shop in lists) == ["active", "archived"]
+
+    async def test_the_cooked_history_outlives_what_was_cooked(self, auth_client):
+        """It survives deleting the meal and the recipe by design, so it is its
+        own section rather than something folded into either."""
+        made = await furnish(auth_client)
+        assert (await auth_client.delete(f"/meals/{made['meal']['id']}")).status_code == 204
+        assert (await auth_client.delete(f"/recipes/{made['recipe']['id']}")).status_code == 204
+
+        doc = await exported(auth_client)
+        assert doc["meals"] == [] and doc["recipes"] == []
+        subjects = sorted(event["subject"] for event in doc["cooked_events"])
+        assert subjects == ["meal", "recipe"]
+        assert doc["cooked_events"][0]["meal_name"] == "Monday"
+
+    async def test_an_empty_household_still_exports_a_whole_document(self, auth_client):
+        doc = await exported(auth_client)
+        assert doc["household"]["id"]
+        assert all(doc[section] == [] for section in export.SECTION_NAMES)
+
+    async def test_it_arrives_as_a_download_with_a_dated_name(self, auth_client):
+        response = await auth_client.get("/household/export")
+        assert response.headers["content-type"].startswith("application/json")
+        assert response.headers["content-disposition"].startswith('attachment; filename="meals-export-20')
+
+    async def test_two_exports_of_an_unchanged_household_are_the_same_bytes(self, auth_client):
+        """Ordered by created_at then id everywhere, so an export is diffable."""
+        await furnish(auth_client)
+        first, second = await exported(auth_client), await exported(auth_client)
+        assert first.pop("exported_at") <= second.pop("exported_at")
+        assert first == second
+
+    async def test_it_needs_a_household_to_export(self, client):
+        assert (await client.get("/household/export")).status_code == 401
+
+
+class TestItIsOnlyEverYourOwn:
+    """This hands back a file rather than a screenful, so the household filter
+    is the whole of the security of it."""
+
+    async def test_another_households_data_is_nowhere_in_it(self, client):
+        theirs = await register(client, email="them@example.com", name="Them")
+        ours = await register(client, email="us@example.com", name="Us")
+        client.headers["Authorization"] = f"Bearer {theirs['token']}"
+        await furnish(client, extra={"title": "Their Secret Chilli"})
+        await client.post("/ingredients", json={"name": "their saffron"})
+
+        doc = await exported(client, headers=headers(ours))
+        assert "Their Secret Chilli" not in json.dumps(doc)
+        assert "their saffron" not in json.dumps(doc)
+        assert "them@example.com" not in json.dumps(doc)
+        assert all(doc[section] == [] for section in export.SECTION_NAMES)
+
+    async def test_every_member_of_a_household_can_export_it(self, client):
+        """There are no per-user permissions inside a household, and leaving
+        with your data is not something the lead gets to gate."""
+        lead = await register(client, email="lead@example.com", name="Lead")
+        code = (await client.post("/auth/invites", json={}, headers=headers(lead))).json()["code"]
+        joiner = await client.post(
+            "/auth/register",
+            json={
+                "email": "joiner@example.com",
+                "password": PASSWORD,
+                "display_name": "Joiner",
+                "invite_code": code,
+            },
+        )
+        assert joiner.status_code == 201
+
+        doc = await exported(client, headers=headers(joiner.json()))
+        assert sorted(member["email"] for member in doc["members"]) == ["joiner@example.com", "lead@example.com"]
+        assert [member["email"] for member in doc["members"] if member["is_lead"]] == ["lead@example.com"]
+
+
+class TestSecretsAndBookkeepingStayBehind:
+    async def test_no_credential_is_in_the_file(self, auth_client):
+        """Password hashes, token hashes and invite codes: all useless
+        elsewhere, and all things a file that gets emailed around must not
+        carry."""
+        await furnish(auth_client)
+        await auth_client.post("/auth/tokens", json={"label": "Claude"})
+        await auth_client.post("/auth/invites", json={})
+
+        body = (await auth_client.get("/household/export")).text.lower()
+        for word in ("password", "token", "code_hash", "invite", "secret"):
+            assert word not in body, f"the export says {word!r}"
+
+    async def test_this_servers_bookkeeping_is_not_the_households_data(self, auth_client, settings_override):
+        """A tier, a price and a quota counter are what this deployment records
+        *about* a household, and they mean nothing on the box it is moving to."""
+        settings_override(LIMITS_PROFILE="hosted", DEFAULT_HOUSEHOLD_TIER="free")
+        doc = await exported(auth_client)
+        assert set(doc["household"]) == {"id", "name", "lead_user_id", "created_at"}
+
+
+class TestNothingIsLeftBehind:
+    """Every column of every exported table is either in the file or written
+    down here as deliberately absent. Explicit field lists are what keep the
+    next billing column out of the export; this is what keeps the next *recipe*
+    column in it."""
+
+    #: model → columns that are deliberately not exported, and why.
+    EXCLUDED = {
+        # This deployment's bookkeeping about the household, not its data.
+        Household: {
+            "tier",
+            "price_pence",
+            "price_currency",
+            "price_set_at",
+            "ingest_period_started_at",
+            "ingests_used",
+        },
+        User: {"password_hash", "household_id"},
+        Ingredient: {"household_id"},
+        Recipe: {"household_id"},
+        # Link rows: their own id and their parent are implied by the nesting.
+        RecipeIngredient: {"id", "recipe_id"},
+        Meal: {"household_id"},
+        MealRecipe: {"id", "meal_id"},
+        MealIngredient: {"id", "meal_id"},
+        Plan: {"household_id"},
+        PlanMeal: {"plan_id"},
+        CookedEvent: {"household_id"},
+        Supermarket: {"household_id"},
+        ShoppingList: {"household_id"},
+        ListItem: {"list_id"},
+        ListItemSource: {"item_id"},
+    }
+
+    @staticmethod
+    def _samples(doc: dict) -> dict:
+        recipe, meal, plan = doc["recipes"][0], doc["meals"][0], doc["plans"][0]
+        item = doc["shopping_lists"][0]["items"][0]
+        return {
+            Household: doc["household"],
+            User: doc["members"][0],
+            Ingredient: doc["ingredients"][0],
+            Recipe: recipe,
+            RecipeIngredient: recipe["ingredients"][0],
+            Meal: meal,
+            MealRecipe: meal["recipes"][0],
+            MealIngredient: meal["loose_ingredients"][0],
+            Plan: plan,
+            PlanMeal: plan["meals"][0],
+            CookedEvent: doc["cooked_events"][0],
+            Supermarket: doc["supermarkets"][0],
+            ShoppingList: doc["shopping_lists"][0],
+            ListItem: item,
+            ListItemSource: item["sources"][0],
+        }
+
+    async def test_every_column_is_exported_or_written_down(self, auth_client):
+        await furnish(auth_client)
+        samples = self._samples(await exported(auth_client))
+        assert set(samples) == set(self.EXCLUDED), "a model gained or lost a sample without its exclusions"
+
+        for model, sample in samples.items():
+            columns = {column.key for column in model.__table__.columns}
+            missing = columns - self.EXCLUDED[model] - set(sample)
+            assert not missing, (
+                f"{model.__name__}.{sorted(missing)} is in the database and not in the export. "
+                "Add it to app/services/export.py, or to this test's EXCLUDED with the reason why "
+                "somebody taking their data elsewhere does not need it."
+            )
+
+
+class TestLeavingIsNeverMadeDifficult:
+    async def test_it_works_with_every_allowance_spent(self, client, settings_override):
+        """Free in every tier, forever (§1). A household that has hit every cap
+        is exactly the one most likely to want its data out."""
+        settings_override(
+            LIMITS_PROFILE="hosted",
+            DEFAULT_HOUSEHOLD_TIER="free",
+            LIMITS_OVERRIDES=json.dumps({"free": {"recipes": 1, "meals": 1, "ingredients": 3, "plans": 1}}),
+        )
+        auth = await register(client)
+        client.headers["Authorization"] = f"Bearer {auth['token']}"
+        await create_recipe(client, ingredients=[{"name": "milk"}])
+        assert (await client.post("/recipes", json={"title": "Another", "ingredients": []})).status_code == 402
+
+        doc = await exported(client)
+        assert [recipe["title"] for recipe in doc["recipes"]] == ["Spaghetti Bolognese"]
+
+
+class TestItIsStreamed:
+    """A 2,000-recipe household is not small, so nothing is assembled in memory
+    first — and the batching that makes that true has a sharp edge in it."""
+
+    @pytest.fixture
+    def tiny_batches(self, monkeypatch):
+        """Force several round trips without creating hundreds of rows. This is
+        the regression the module's comment is about: expunging a whole batch
+        at once invalidates the identity map the open result is still loading
+        through, and everything after the first batch is lost."""
+        monkeypatch.setattr(export, "BATCH", 2)
+
+    async def test_every_row_survives_more_batches_than_one(self, auth_client, tiny_batches):
+        for index in range(5):
+            await create_recipe(auth_client, title=f"Recipe {index}", ingredients=[{"name": f"thing {index}"}])
+
+        doc = await exported(auth_client)
+        assert [recipe["title"] for recipe in doc["recipes"]] == [f"Recipe {index}" for index in range(5)]
+        assert len(doc["ingredients"]) == 5
+        assert all(recipe["ingredients"] for recipe in doc["recipes"])
+
+    async def test_the_document_is_produced_in_fragments(self, engine, auth_client, tiny_batches):
+        """Asserted on the generator rather than through the client: httpx's
+        ASGI transport coalesces the body, so counting chunks there would be
+        testing the test."""
+        for index in range(5):
+            await create_recipe(auth_client, title=f"Recipe {index}")
+
+        maker = async_sessionmaker(engine, expire_on_commit=False)
+        async with maker() as session:
+            household = (await session.execute(select(Household))).scalars().one()
+            fragments = [piece async for piece in export.stream_household(session, household, api_version="test")]
+
+        assert len(fragments) > len(export.SECTION_NAMES)
+        # No single fragment is the document: the first recipe is on the wire
+        # long before the last section is read.
+        assert not any('"recipes"' in piece and '"shopping_lists"' in piece for piece in fragments)
+        assert json.loads("".join(fragments))["recipes"][0]["title"] == "Recipe 0"
+
+    async def test_nothing_is_sized_up_front(self, auth_client):
+        """A buffered response would carry a Content-Length; this one cannot."""
+        async with auth_client.stream("GET", "/household/export") as response:
+            assert response.status_code == 200
+            assert "content-length" not in response.headers
+            await response.aread()


### PR DESCRIPTION
## What and why

Closes [#97](https://github.com/marco308/meals/issues/97). `GET /household/export` returns everything the calling household owns as one JSON document: recipes with their lines, the ingredient library, meals, plans, the cooked history, saved supermarkets, and every shopping list including the archived ones. Ids are kept so it is importable in principle; every reference carries the name beside the id so it is readable in practice, without joining anything.

**Free on every tier, forever** (`planning/08-freemium.md` §1). Nothing in `app/limits.py` touches it, and a test exercises it with every allowance spent — a household that has hit every cap is exactly the one most likely to want its data out.

**Streamed row by row.** That has one sharp edge worth naming: `expunge_all()` between batches invalidates the identity map the open result is still loading through, so everything after the first batch is silently lost. I hit that while building it; rows are expunged one at a time instead, and `TestItIsStreamed` runs with the batch size turned down to two as the regression.

**Explicit field lists, never `__table__.columns`.** Reflection would mean the next column added to `households` — the next billing or quota field — silently joining the export, and one of those days it would be a secret. The cost is a field going missing when a model grows, so `TestNothingIsLeftBehind` walks every exported table and fails with an actionable message when a column is neither exported nor written down as excluded. Verified it bites by deleting a field and watching it fail.

Left out on purpose: password hashes, API tokens, invite codes, and this server's own bookkeeping *about* the household (tier, price, ingest counter) — that is what the deployment records about you, and it means nothing on the box you're moving to.

`PRIVACY.md` gets the concrete version of its "export your data" bullet, since that page is the App Store's privacy URL and the portability right is now one `curl`.

### Scope calls worth a look

- **No import**, as the issue directs — id collisions, ingredient folding and unit canonicalisation are a design question of their own.
- **No MCP tool and no skill line**, so the playbook version is deliberately unbumped: a whole household is the wrong shape for an assistant's context, and it has no way to hand a user a file.
- **No web UI button.** Not asked for, and the endpoint is the deliverable. Happy to add one to Settings if you want the promise visible where people actually look.

## Checklist

- [x] **API contract stayed additive** — one new endpoint, nothing else touched.
- [x] **Model change has a migration** — n/a, no model change.
- [x] **Shopping-list quantities still derive from `ListItemSource`** — the export writes both the derived total and the source rows, and mutates nothing.
- [x] **Every new query filters on `household_id`** — every section does, and `TestItIsOnlyEverYourOwn` pins it; this hands back a file rather than a screenful, so that filter is the whole of the security of it.
- [x] **Skill/prompt pack updated** — deliberately not, see above.
- [x] **New 4xx strings say what to do instead** — no new 4xx; 401 is the existing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
