### PR TITLE
Say what the money would buy, before there is any

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,10 @@ jobs:
           curl -fsS --max-time 10 http://localhost:8000/privacy > privacy.html
           grep -q '<h1' privacy.html
           curl -fsS --max-time 10 -o /dev/null http://localhost:8000/support
+          # /terms rides the same rails and is COPYed the same way, so it can
+          # be forgotten the same way.
+          curl -fsS --max-time 10 http://localhost:8000/terms > terms.html
+          grep -q '<h1' terms.html
           # The web client is COPYed into the image separately from app/ too —
           # a build that forgets it serves a 404 where the big-screen UI was.
           curl -fsS --max-time 10 http://localhost:8000/app/ > app.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,25 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 
 ### Added
 
+- **`/terms`, a terms and refunds page**
+  ([#98](https://github.com/marco308/meals/issues/98)), shipped exactly the way
+  `/privacy` and `/support` are: a markdown file COPYed into the image,
+  rendered by `routers/pages.py`, exempt from the client gate, curled by CI
+  against the built image, and advertised on the JSON landing at `/`.
+- **It is written to be true on a server that sells nothing**, which is every
+  server today. It opens by saying that almost none of it applies to a
+  self-hosted instance, where the AGPL is the whole agreement, and it states
+  plainly that nothing is on sale yet and nobody has been charged. What it
+  commits to when that changes: £20 a year per household, a full no-questions
+  refund inside 30 days, best effort rather than an SLA from a one-person
+  operation, tested nightly backups, 90 days' notice and a pro-rata refund if
+  the service ever ends, and nothing deleted on cancellation ever.
+- **A billing section in `PRIVACY.md`**, because `/privacy` is a live App Store
+  URL that promises this project holds no payment details. It now says so
+  explicitly: no payment is taken anywhere today, and when it is, it goes
+  through a third-party merchant of record whose name will appear there before
+  the first charge, with card details never reaching this server or its author.
+
 - **`GET /household/export` returns everything a household owns in one request**
   ([#97](https://github.com/marco308/meals/issues/97)) — recipes with their
   lines, the ingredient library, meals, plans, the cooked history, saved

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,11 +315,19 @@ one, so the constraints it adds are load-bearing:
 `{{API_URL}}` substituted from the request's forwarded-proto/host headers.
 Keep `SKILL.md`, `prompt-pack.md` and the API in step when endpoints change.
 
-`PRIVACY.md` and `SUPPORT.md` ship the same way and render at `/privacy` and
-`/support` (`routers/pages.py`). **These are the App Store's privacy and support
-URLs**, so a build that fails to COPY them takes down a live store listing —
-which is why CI curls both against the built image. They're also exempt from the
-client gate: someone stuck on the upgrade screen is exactly who needs them.
+`PRIVACY.md`, `SUPPORT.md` and `TERMS.md` ship the same way and render at
+`/privacy`, `/support` and `/terms` (`routers/pages.py`). **The first two are the
+App Store's privacy and support URLs**, so a build that fails to COPY them takes
+down a live store listing — which is why CI curls all three against the built
+image. They're also exempt from the client gate: someone stuck on the upgrade
+screen is exactly who needs them, and deciding whether to keep paying must not
+require updating an app first. Every deployment serves all three, including the
+ones that sell nothing, so `TERMS.md` opens by saying that almost none of it
+applies to a self-hosted instance — keep it true on a server with no commerce,
+the same test the limit refusals have to pass. Cross-page links are written as
+prose plus a code span (`/privacy`) rather than as markdown links: a
+root-relative link 404s for anyone reading the file on GitHub, and a repo-
+relative one 404s on the served page.
 
 ## Testing
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy policy
 
-**Last updated: 13 August 2026**
+**Last updated: 22 August 2026**
 
 Meals is a meal planner you run on your own server. The iOS app is a client:
 it talks to whichever server you point it at, and to nothing else. There is no
@@ -19,6 +19,8 @@ That shape is the whole privacy story, so it is worth being precise about it.
 - If you run that server, you hold the data and nobody else can read it.
 - You can delete your account, and everything belonging to it, from inside the
   app.
+- **No money changes hands anywhere in this project today**, and no payment
+  details have ever reached it. See [Paying for hosting](#paying-for-hosting).
 
 ## What the app stores on your device
 
@@ -72,6 +74,36 @@ asked for:
 If you connect an AI assistant to the API with a personal token, that assistant
 sees whatever it asks for. That connection is yours to make and yours to revoke
 — delete the token and it stops working immediately.
+
+## Paying for hosting
+
+This section exists because `/privacy` is a published, permanent URL and it
+should be right *before* any money moves, not after.
+
+**Today, nothing here applies to anyone.** No payment is taken for any Meals
+server, no card details have ever reached this project, and there is no
+payment processor. If you self-host, that stays true forever: there is nothing
+to pay and nobody to pay it to.
+
+If the hosted service does open, one thing changes and it is worth stating in
+advance:
+
+- **Payment will go through a third-party merchant of record**, and this
+  section will name them here before a single payment is taken. They will
+  handle the card, the receipt and the VAT. Their privacy policy will cover
+  what they hold, and it will be linked from this page.
+- **Card details will never reach this server or its author.** Not stored, not
+  logged, not seen. The most this server would ever record about money is that
+  a household is paid up, until when, and what it agreed to pay.
+- **Your recipes and lists have nothing to do with it.** No content of any kind
+  is shared with a payment processor, ever. The only thing they would be told is
+  what they need to take a payment.
+
+The terms and refunds page (`/terms` on the same server, and
+[TERMS.md](https://github.com/marco308/meals/blob/main/TERMS.md) in the
+repository) covers the other side of this: what the service costs, what is
+promised, and what happens to your data if you stop paying, which is that
+nothing is deleted.
 
 ## App Store analytics and crash reports
 

--- a/TERMS.md
+++ b/TERMS.md
@@ -1,0 +1,154 @@
+# Terms and refunds
+
+**Last updated: 22 August 2026**
+
+Meals is a meal planner you run on your own server. The software is free and
+open source under the AGPL, and it always will be. Separately from that, the
+author offers to run it for you, and these terms cover that offer.
+
+## If you self-host, almost none of this applies
+
+Running the software yourself is a licence, not a service. What governs it is
+the [AGPL-3.0](https://github.com/marco308/meals/blob/main/LICENSE) and nothing
+here: no fee, no account with anybody, no uptime promise from anyone but you,
+and no way for this project to switch anything off. The only sections below
+that are worth your time are [Acceptable use](#acceptable-use), which is about
+a server you do not own, and [The software itself](#the-software-itself).
+
+Everything else assumes you are paying somebody to run Meals for you.
+
+## What is on offer, and what it costs
+
+The hosted service is the same software as the repository, running on the
+author's hardware, with the database backed up nightly and the backups
+[tested](https://github.com/marco308/meals/tree/main/backup).
+
+| | |
+|---|---|
+| What you get | One household on a shared server: the API, the web app, the iOS app, the MCP endpoint, and the AI skill. No feature is held back for a higher tier. |
+| Price | £20 per year, per household. Annual only, paid up front. |
+| Founding price | Whatever you first paid is what you keep paying, for as long as you keep paying it. It is recorded against your household rather than promised in a document. |
+| Included | Free members of the same household up to the published limit, every endpoint, and unlimited export. |
+
+**Nothing is on sale yet.** The hosted service is waitlist-only, no payment
+mechanism exists, and nobody has been charged. This page is here before the
+money rather than after it, so that what is being agreed to is public first.
+When it does open, the price above is the price.
+
+## Paying
+
+There is no payment processor yet, and this section will name the one that gets
+chosen before a single payment is taken. It will be a merchant of record, which
+means the card details go to them and never to this server or its author: what
+this server would ever hold is the fact that a household is paid up, until when,
+and what it agreed to pay. The privacy policy (`/privacy` on the same server)
+says the same thing from the other direction, and both are updated together.
+
+VAT, where it applies, is included in the price.
+
+## Refunds
+
+**Full refund inside 30 days, for any reason or none.** Ask and it is done.
+There is nothing to argue about at £20, and arguing would cost more than the
+refund.
+
+After 30 days, a year already paid for is not refunded, but you can cancel at
+any time and simply not be charged again. If the service is shut down mid-year,
+see [If the service ends](#if-the-service-ends) below.
+
+## What is actually promised
+
+This is a one-person operation and the promise is sized to match, because a
+number nobody can keep is worth less than an honest one.
+
+- **Best effort, no SLA.** No uptime percentage is promised, because there is no
+  second person to page at three in the morning. In practice it runs on a
+  monitored machine with alerting, and the author uses it daily for his own
+  household, which is the real guarantee.
+- **Nightly backups, and they are tested.** A dump is taken every night and read
+  back before it counts, retained daily and weekly, and copied off the machine
+  encrypted. The restore procedure is written down and has been rehearsed.
+- **Planned downtime is not announced.** Deploys are zero downtime and take
+  seconds. Anything larger will be brief.
+- **Support is GitHub issues**, with a reply within a week, which is what the
+  support page (`/support` on the same server) says too.
+- **Data loss.** Backups exist and are tested precisely because no promise can
+  replace them. Keep your own copy: `GET /household/export` returns everything
+  your household owns in one request, free, on every tier, forever.
+
+## Cancelling, and what happens next
+
+Cancel whenever you like. Nothing about it is designed to be difficult.
+
+- **Nothing is deleted.** Not at cancellation, not at expiry, not later. Your
+  recipes, plans, lists and cooked history stay exactly where they are and stay
+  readable.
+- **There is a grace period of 14 days** after the paid year ends. During it
+  nothing changes at all.
+- **After that, the free limits re-apply.** That blocks only the writes that
+  *grow* the household: no new recipe past the free allowance, no new invite.
+  Everything already there stays readable, the plan stays usable, members stay
+  members, and the shopping list keeps working in full. The published numbers
+  are in
+  [the freemium plan](https://github.com/marco308/meals/blob/main/planning/08-freemium.md).
+- **Export never stops working.** It is free in every tier and is not affected
+  by lapsing, because a service that makes leaving difficult has not earned
+  anybody staying.
+- **Deleting your account is yours to do**, from inside the app, at any time.
+  That one really does delete things, immediately and without undo, as the
+  privacy policy (`/privacy`) spells out.
+
+## If the service ends
+
+If the hosted service is withdrawn, you get **at least 90 days' notice and a
+pro-rata refund of the unused part of your year**. The software is AGPL and the
+export is one request, so the migration path is the same one that has always
+been there: run it yourself, or ask somebody else to.
+
+## Acceptable use
+
+Short, because it is a meal planner.
+
+- Do not use it to break the law, to attack the server, or to store other
+  people's personal data without their say-so.
+- Do not use the recipe importer as a general-purpose web fetcher. It exists to
+  read recipe pages, and it is metered.
+- An invite code admits somebody to your household and everything in it. Who you
+  give one to is your decision and your responsibility.
+- Accounts may be suspended for any of the above. That is the only reason an
+  account gets suspended, and it comes with an explanation and a refund of the
+  unused part of the year.
+
+## The software itself
+
+The software is licensed under the AGPL-3.0 and comes with no warranty, exactly
+as that licence says. These terms cover the service of running it for you, and
+they do not add any warranty to the software or take one away.
+
+If you self-host, the AGPL is the whole agreement. There is nothing to accept
+and nobody to accept it from.
+
+## Changes to these terms
+
+They live in the public source repository, so the full history is public.
+Material changes are noted in the changelog and the date at the top of this file
+changes. A change that affects what you are paying for takes effect at your next
+renewal, never mid-year.
+
+## Who you are dealing with
+
+The hosted service is operated by the author of this project, in the United
+Kingdom. Nothing on this page limits any right you have under UK consumer law,
+including your statutory cancellation rights, which sit alongside the refund
+promise above rather than replacing it.
+
+## Contact
+
+Open an issue at <https://github.com/marco308/meals/issues>, which reaches the
+author directly. For anything you would rather not say in public, including a
+billing question, use GitHub's
+[private reporting form](https://github.com/marco308/meals/security/advisories/new),
+which is private to the two of us and is not only for security reports.
+
+This is a one-person project, not a company with a support desk. Expect a reply
+within a week.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,7 +24,8 @@ COPY skill ./skill
 COPY web ./web
 # The App Store's privacy and support URLs point at /privacy and /support, which
 # render these. If they don't ship, those URLs 404 and the listing is broken.
-COPY PRIVACY.md SUPPORT.md ./
+# TERMS.md rides along for /terms, and is just as easy to forget.
+COPY PRIVACY.md SUPPORT.md TERMS.md ./
 RUN uv sync --frozen --no-dev
 
 # Runs as a normal user, and one that owns nothing it doesn't need to write.

--- a/backend/app/client_gate.py
+++ b/backend/app/client_gate.py
@@ -38,9 +38,12 @@ EXEMPT_PREFIXES = (
     "/openapi.json",
     "/skill",
     "/prompt-pack",
-    # Someone stuck on the upgrade screen is exactly who needs the support page.
+    # Someone stuck on the upgrade screen is exactly who needs the support page,
+    # and somebody deciding whether to keep paying is exactly who needs to be
+    # able to read the terms without updating an app first.
     "/privacy",
     "/support",
+    "/terms",
 )
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -207,6 +207,7 @@ async def root(request: Request) -> Response:
         "health": f"{base}/healthz",
         "privacy": f"{base}/privacy",
         "support": f"{base}/support",
+        "terms": f"{base}/terms",
     }
     if _mcp_attached:
         # This deployment serves the MCP endpoint itself, so an assistant can

--- a/backend/app/routers/pages.py
+++ b/backend/app/routers/pages.py
@@ -1,8 +1,10 @@
-"""Human-readable pages: the privacy policy and the support page.
+"""Human-readable pages: the privacy policy, the support page and the terms.
 
-The App Store requires both to be publicly reachable URLs, and the deployment
-is the only thing this project already hosts — so they are served from here
-rather than from a second piece of infrastructure that could rot independently.
+The App Store requires the first two to be publicly reachable URLs, and the
+deployment is the only thing this project already hosts — so they are served
+from here rather than from a second piece of infrastructure that could rot
+independently. `/terms` joins them on the same rails because taking money needs
+one and because it is the same three lines of code (issue #98).
 
 Rendered from the same markdown that GitHub shows, for the same reason `/skill`
 is served from `skill/SKILL.md`: one copy, so the published page can't drift
@@ -114,3 +116,13 @@ async def privacy_policy() -> str:
 async def support() -> str:
     """The support page, as published to the App Store. No auth required."""
     return _page("SUPPORT.md")
+
+
+@router.get("/terms", response_class=HTMLResponse, include_in_schema=False)
+async def terms() -> str:
+    """Terms and refunds for the hosted service. No auth required.
+
+    Served by every deployment, including the ones that sell nothing, which is
+    why the page opens by saying that almost none of it applies to a
+    self-hosted instance."""
+    return _page("TERMS.md")

--- a/backend/tests/integration/test_client_gate.py
+++ b/backend/tests/integration/test_client_gate.py
@@ -96,11 +96,13 @@ class TestExemptions:
         for path in ("/", "/healthz", "/client-config", "/skill", "/prompt-pack", "/openapi.json"):
             assert (await client.get(path, headers=ios(1))).status_code == 200, path
 
-    async def test_the_support_and_privacy_pages_stay_open(self, client, min_build):
+    async def test_the_public_pages_stay_open(self, client, min_build):
         """Someone staring at the upgrade screen is exactly who needs to read
-        how to get help — gating those pages would close the only door left."""
+        how to get help — gating those pages would close the only door left.
+        The terms are the same argument with money in it: deciding whether to
+        keep paying must not require updating an app first."""
         min_build(99)
-        for path in ("/privacy", "/support"):
+        for path in ("/privacy", "/support", "/terms"):
             assert (await client.get(path, headers=ios(1))).status_code == 200, path
 
 

--- a/backend/tests/integration/test_misc.py
+++ b/backend/tests/integration/test_misc.py
@@ -123,6 +123,30 @@ class TestPublicPages:
         assert response.headers["content-type"].startswith("text/html")
         assert "server URL" in response.text
 
+    async def test_terms_page_renders_as_html(self, client):
+        """Not an App Store URL, but the page somebody reads before paying and
+        the one they reach for when they want to stop."""
+        response = await client.get("/terms")
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/html")
+        assert "<h1" in response.text
+        assert "Terms and refunds" in response.text
+        assert "## What is on offer" not in response.text  # rendered, not dumped
+
+    async def test_the_terms_are_true_on_a_server_that_sells_nothing(self, client):
+        """Every deployment serves this page, including every self-hosted one,
+        so it has to open by saying that almost none of it is about them."""
+        text = (await client.get("/terms")).text
+        assert "If you self-host, almost none of this applies" in text
+        assert "Nothing is on sale yet" in text
+
+    async def test_the_privacy_policy_is_straight_about_money(self, client):
+        """`/privacy` is a live App Store URL and it promises this project holds
+        no payment details. That promise needs a section, not a silence."""
+        text = (await client.get("/privacy")).text
+        assert 'id="paying-for-hosting"' in text
+        assert "Card details will never reach this server" in text
+
     async def test_tables_survive_the_render(self, client):
         """Most of what the privacy policy actually promises lives in its tables,
         so plain commonmark (which has none) would drop the substance."""
@@ -138,7 +162,7 @@ class TestPublicPages:
 
     async def test_pages_need_no_auth(self, client):
         """`client` is unauthenticated — Apple's reviewer opens these in a browser."""
-        for path in ("/privacy", "/support"):
+        for path in ("/privacy", "/support", "/terms"):
             assert (await client.get(path)).status_code == 200, path
 
     async def test_missing_documents_404_not_500(self, client, monkeypatch):
@@ -152,6 +176,7 @@ class TestPublicPages:
         landing = (await client.get("/")).json()
         assert landing["privacy"] == "http://test/privacy"
         assert landing["support"] == "http://test/support"
+        assert landing["terms"] == "http://test/terms"
 
 
 # The playbook's guidance, pinned to the version that announces it. The digest


### PR DESCRIPTION
## What and why

Closes [#98](https://github.com/marco308/meals/issues/98). `TERMS.md` renders at `/terms` on the same rails as `/privacy` and `/support`: COPYed into the image, rendered by `routers/pages.py`, exempt from the client gate, curled by CI against the built image, and advertised on the JSON landing at `/`.

**The page is written to be true on a server that sells nothing**, which today is every server. It opens by saying that almost none of it applies to a self-hosted instance, where the AGPL is the whole agreement and there is nobody to accept terms from. That is the same test the limit refusals have to pass, and it is what stops a page every deployment serves from describing a business most of them are not in.

What it commits to: £20/yr per household with the founding price recorded against the household; a full refund inside 30 days for any reason; **best effort, no SLA**, because there is no second person to page at three in the morning, plus tested nightly backups; 90 days' notice and a pro-rata refund if the service ends; and nothing deleted on cancellation, ever, with export staying free.

## Two judgement calls I'd like you to check

**1. I could not name the payment processor.** The issue asks for a billing section in `PRIVACY.md` naming it, but `planning/08-freemium.md` §7 only says "a merchant of record rather than raw Stripe" and no name has been chosen. Rather than invent one on a live App Store URL, the section says exactly where things stand: no payment is taken anywhere today, no card details have ever reached this project, and when that changes it goes through a merchant of record **named there before the first charge**, with card details never reaching this server or its author. That keeps the page's existing promise honest instead of silent. The name is a one-line edit whenever you pick one.

**2. The page publishes the £20.** `06-marketing.md` §6 says "nothing about pricing goes public while the answer might still be that none of this ships" — but that reads as being about the marketing site's pricing table, and a terms page without a price is not a terms page. I included it, alongside a plain "nothing is on sale yet, nobody has been charged". Say the word and I will strike the number and leave the structure.

## Not done, on purpose

- **`deploy/deploy.sh` still only curls `/privacy` and `/support`.** It is gitignored and outside the worktree, so I did not edit it as part of a PR. CI already curls `/terms` against the built image, which catches a forgotten COPY before a deploy ever runs, so this is belt-and-braces. One line to add at `deploy.sh:271` if you want it:
  ```bash
  curl -fsS --max-time 20 https://meals.marcuslab.uk/terms | grep -q '<h1'
  ```
- **No link from the marketing site**, which today references neither `/privacy` nor `/support`, so adding only `/terms` would be the odd one out.
- **No em dashes in `TERMS.md`**, per `06-marketing.md` §9. The existing public docs do use them, so this one is deliberately the odd file out rather than an oversight.

## Checklist

- [x] **API contract stayed additive** — one new unauthenticated page, plus a new `terms` key on the `/` landing JSON. Nothing removed or changed.
- [x] **Model change has a migration** — n/a.
- [x] **Shopping-list quantities still derive from `ListItemSource`** — n/a.
- [x] **Every new query filters on `household_id`** — n/a, no queries.
- [x] **Skill/prompt pack updated** — n/a, no endpoint an assistant drives changed.
- [x] **New 4xx strings say what to do instead** — the existing "was not shipped with this build" 404 covers a missing `TERMS.md`, and a test pins it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
