### PR TITLE
Make an entitlement one row, and lapsing something nothing has to run

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,12 @@ AUTH_RATE_LIMIT_PER_MINUTE=10
 # rather than full — and keeps its own message.
 #MAX_HOUSEHOLDS=25
 #MAX_USERS=60
+
+# Entitlements (backend/app/services/entitlements.py). Only ever read for a
+# household that has been given an expiry, which on a self-hosted instance is
+# none of them. ENTITLEMENT_GRACE_DAYS is how long after expiry before the free
+# tier's caps re-apply; DUNNING_WARN_DAYS is how far ahead the first email goes.
+# Comp, extend, revoke and see who is paid with `python -m app.entitlements`;
+# send the two dunning emails from cron with `python -m app.dunning`.
+#ENTITLEMENT_GRACE_DAYS=14
+#DUNNING_WARN_DAYS=7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,42 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 
 ### Added
 
+- **Entitlements: one row says what a household is on and until when**
+  ([#99](https://github.com/marco308/meals/issues/99),
+  `planning/08-freemium.md` §2 and §5). Beside the existing `tier` and price
+  snapshot, a household now carries `paid_until`, where the entitlement came
+  from, and a one-line note. **One migration**, every column nullable.
+- **Lapsing is derived, never written back.** Past its expiry plus
+  `ENTITLEMENT_GRACE_DAYS` (14), a household reads as `free` through
+  `limits.effective_tier`, which is the only reader. Nothing rewrites `tier`,
+  so nothing is deleted, everything already there stays readable, the plan
+  stays usable, the shopping list keeps working, the export stays free, and a
+  renewal is one column rather than a reconstruction. **A null `paid_until`
+  never lapses**, which is every self-hosted household.
+- **Comp tooling from day one**: `python -m app.entitlements` comps, extends,
+  revokes and lists who is paid, ordered with whatever needs attention first.
+  An operator command on the box, like `app/provision.py`, because a
+  spreadsheet is not a source of truth. Extending an active year adds to its
+  end so renewing early costs nothing; extending a lapsed one starts from
+  today so nobody pays for the weeks they were locked out of growing.
+- **The founding price is defended, not just stored.** §6 promises it for life,
+  so `grant` refuses to overwrite an existing price and says why. Revoking
+  keeps it, so coming back costs what it always did.
+- **Dunning**: `python -m app.dunning` from cron sends one email before expiry
+  and one after, through the SMTP password reset already uses. Each is marked
+  once so there is never a third, both marks are cleared when the expiry moves
+  so next year gets its own pair, and a relay failure marks nothing so the next
+  run retries rather than swallowing somebody's only warning. A server with no
+  SMTP does nothing and says so.
+
+### Not included
+
+- **The billing webhook**, deliberately. #99 says to choose a merchant of
+  record before writing it and §7 has not: signature verification, event names
+  and payload shape are all processor-specific, so writing it now would be
+  guessing. Everything above is processor-independent and is what the webhook
+  will call when there is one.
+
 - **`/terms`, a terms and refunds page**
   ([#98](https://github.com/marco308/meals/issues/98)), shipped exactly the way
   `/privacy` and `/support` are: a markdown file COPYed into the image,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,24 @@ instrumentation a new feature usually needs.
   expunged one at a time while streaming** — `expunge_all()` invalidates the
   identity map the open result is still loading through, and everything after
   the first batch is lost.
+- **Entitlement is one row, and lapsing is derived** (`services/entitlements.py`,
+  `planning/08-freemium.md` §5). `households.tier` says which numbers apply;
+  `paid_until`, `entitlement_source` and the price snapshot say until when,
+  where it came from and what was agreed. **A null `paid_until` never lapses**,
+  which is every self-hosted household, and it is what keeps the whole idea
+  invisible on a server that sells nothing. `limits.effective_tier` is the only
+  reader: past expiry plus `ENTITLEMENT_GRACE_DAYS` it answers `free` without
+  anything rewriting `tier` — §5 promises nothing is deleted, so lapsing may
+  change what a household can *grow* and nothing else, and keeping the stored
+  tier is what makes a renewal one column rather than a reconstruction. The
+  founding price is written once and `grant` refuses to overwrite it, because
+  "founding price for life" stored on a row is only worth something if the code
+  defends it. Comp/extend/revoke/list is `python -m app.entitlements` (an
+  operator command on the box, like `app/provision.py`, never an endpoint), and
+  `python -m app.dunning` from cron sends the two emails, each marked once so it
+  never sends a third and never marked on a relay failure so it retries.
+  **There is no billing webhook**: no merchant of record has been chosen (§7),
+  and #99 says decide that before writing it.
 - **Instance ceilings are the other axis** (`MAX_HOUSEHOLDS`, `MAX_USERS`, at the
   bottom of `app/limits.py`). They bound how many households the *box* holds
   rather than what one costs, so no tier reaches them and none of the above

--- a/README.md
+++ b/README.md
@@ -370,7 +370,16 @@ and `MAX_USERS` are the other axis and are also unset by default: they bound how
 many families the box holds rather than what each one costs, so registration
 answers 503 with a waitlist sentence instead of the machine finding its own
 limit. Both sit on `/metrics` next to the counts they bound, which is how you
-see "nearly full" before somebody is turned away. Being over a
+see "nearly full" before somebody is turned away.
+
+If a deployment does charge, the entitlement is one row: `python -m
+app.entitlements` comps, extends, revokes and lists who is paid, and
+`python -m app.dunning` from cron sends one email before an expiry and one
+after. Lapsing is derived rather than written back, so it only ever stops a
+household *growing*: nothing is deleted, everything already there stays
+readable, the plan stays usable, the shopping list keeps working and the export
+stays free. None of it applies to a household with no expiry, which is every
+self-hosted one. Being over a
 limit blocks only the writes that grow a household; nothing is deleted, nothing
 becomes unreadable, and the shopping list is exempt in every case because the
 iPhone app drains its offline queue through it. Whatever you set, `GET /limits`

--- a/backend/alembic/versions/74e2494dfabf_add_household_entitlement_expiry_source_.py
+++ b/backend/alembic/versions/74e2494dfabf_add_household_entitlement_expiry_source_.py
@@ -1,0 +1,63 @@
+"""add household entitlement expiry, source and dunning marks
+
+Revision ID: 74e2494dfabf
+Revises: b1d73e5c9a24
+Create Date: 2026-08-22 23:24:04.173917
+
+Issue #99 / planning/08-freemium.md §2 and §5. `households.tier` (added in
+b1d73e5c9a24) says which set of limits applies; these say until when, where it
+came from, and what has already been said about it.
+
+- `paid_until` — when the tier stops applying. **Null means never**, which is
+  what every existing row gets and what a standing comp gets, so nothing about
+  this is visible on a self-hosted instance. `app/limits.effective_tier` reads
+  a household past this date, plus `ENTITLEMENT_GRACE_DAYS`, as `free`; the
+  stored tier is deliberately left alone, because §5 promises nothing is
+  deleted and a renewal should be one column rather than a reconstruction.
+- `entitlement_source` — 'comp', or the name of the processor a payment came
+  through. A plain string for the same reason `tier` is one: a value a future
+  build introduces must never be an error in an older one.
+- `entitlement_note` — one line of why, for whoever reads the list in a year.
+- `expiry_warned_at` / `lapse_notified_at` — dunning's two one-shot marks, so
+  the email before expiry and the one after each go exactly once. Cleared
+  whenever the expiry moves, so next year gets its own pair.
+
+Everything here is nullable with no default and nothing reads it unless a
+deployment sets an entitlement, so every existing row keeps behaving exactly as
+it did. Safe under the start-first rollout in CLAUDE.md: adding nullable columns
+takes nothing away from the outgoing container still serving from this table.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '74e2494dfabf'
+down_revision: Union[str, Sequence[str], None] = 'b1d73e5c9a24'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Autogenerate also proposed creating ck_meal_recipe_scale on meal_recipes.
+    # That constraint already exists (c4f2a8b19d63); SQLite reflection simply
+    # cannot see it, so it is a false positive and is deliberately not here.
+    with op.batch_alter_table('households', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('paid_until', sa.DateTime(timezone=True), nullable=True))
+        batch_op.add_column(sa.Column('entitlement_source', sa.String(length=40), nullable=True))
+        batch_op.add_column(sa.Column('entitlement_note', sa.String(length=200), nullable=True))
+        batch_op.add_column(sa.Column('expiry_warned_at', sa.DateTime(timezone=True), nullable=True))
+        batch_op.add_column(sa.Column('lapse_notified_at', sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('households', schema=None) as batch_op:
+        batch_op.drop_column('lapse_notified_at')
+        batch_op.drop_column('expiry_warned_at')
+        batch_op.drop_column('entitlement_note')
+        batch_op.drop_column('entitlement_source')
+        batch_op.drop_column('paid_until')

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -103,6 +103,18 @@ class Settings(BaseSettings):
     max_households: int | None = None
     max_users: int | None = None
 
+    # Entitlements (app/services/entitlements.py, planning/08-freemium.md §5).
+    # Only ever read for a household that has a `paid_until`, which on a
+    # self-hosted instance is none of them.
+    #
+    #   ENTITLEMENT_GRACE_DAYS  how long after expiry before the free tier's
+    #                           caps re-apply. Apple's billing grace period has
+    #                           no equivalent here because there is no Apple, so
+    #                           §5 sets it at 14 days.
+    #   DUNNING_WARN_DAYS       how long before expiry the first email goes out.
+    entitlement_grace_days: int = 14
+    dunning_warn_days: int = 7
+
     # Timeout for fetching external recipe pages during ingestion.
     recipe_fetch_timeout_seconds: float = 15.0
     # And a ceiling on how much of one we'll read (issue #55). The URL is the

--- a/backend/app/dunning.py
+++ b/backend/app/dunning.py
@@ -1,0 +1,47 @@
+"""Send the two entitlement emails that are due, and nothing else.
+
+There is no scheduler in this app, on purpose: one process that serves requests
+is easier to reason about than one that also wakes up. So this is a command for
+cron, run daily, at whatever hour suits.
+
+    docker exec -i <api-container> .venv/bin/python -m app.dunning
+    ... -m app.dunning --dry-run     # what would go out, and to whom
+
+Safe to run anywhere, including a self-hosted instance with no mail and no
+entitlements, where it does nothing and says so. Safe to run twice: each notice
+is marked once sent, and a relay failure marks nothing so the next run retries.
+"""
+
+import argparse
+import asyncio
+
+from app.database import SessionLocal
+from app.services import dunning
+
+
+async def _run(dry_run: bool) -> str:
+    async with SessionLocal() as db:
+        notices = await dunning.run(db, dry_run=dry_run)
+        if not notices:
+            pending = await dunning.due(db) if not dry_run else []
+            if pending:
+                return f"{len(pending)} notice(s) due but no SMTP configured on this server; nothing sent."
+            return "Nothing due."
+        verb = "would send" if dry_run else "sent"
+        lines = [f"{verb} {len(notices)}:"]
+        lines += [
+            f"  {notice.kind:<7}  {notice.household_name}  ->  {notice.to}  (expires {notice.paid_until:%Y-%m-%d})"
+            for notice in notices
+        ]
+        return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--dry-run", action="store_true", help="list what is due without sending anything")
+    args = parser.parse_args()
+    print(asyncio.run(_run(args.dry_run)))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/entitlements.py
+++ b/backend/app/entitlements.py
@@ -1,0 +1,178 @@
+"""Comp, extend, revoke, and see who is paid.
+
+The ops surface #99 asks for, in the spirit of `app/provision.py`: a command on
+the box, not an endpoint. You will comp people in week one — early supporters,
+PikaPods, whoever files the good bug — and a spreadsheet is not a source of
+truth.
+
+    docker exec -it <api-container> .venv/bin/python -m app.entitlements list
+    ... -m app.entitlements comp --household 'The Smiths' --days 365 --note 'early supporter'
+    ... -m app.entitlements comp --household 'The Smiths' --forever --note 'PikaPods'
+    ... -m app.entitlements extend --household 'The Smiths' --days 365
+    ... -m app.entitlements revoke --household 'The Smiths' --note 'asked to stop'
+
+`--household` takes a name or an id; a name that matches more than one
+household is refused with the ids, rather than guessed at.
+
+Nothing here is destructive. Revoking puts a household on the free tier and
+takes nothing away: everything already there stays readable, and §5 is the whole
+argument for why. The one thing the module refuses outright is quietly
+repricing somebody, because "founding price for life" is a promise stored on
+their row.
+"""
+
+import argparse
+import asyncio
+import sys
+import uuid
+from dataclasses import replace
+from datetime import UTC, datetime, time, timedelta
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app import limits
+from app.database import SessionLocal
+from app.models import Household, User
+from app.services import entitlements
+from app.services.entitlements import Entitlement, EntitlementError
+
+
+async def _find(db: AsyncSession, wanted: str) -> Household:
+    try:
+        found = await db.get(Household, uuid.UUID(wanted))
+    except ValueError:
+        found = None
+    else:
+        if found is None:
+            raise EntitlementError(f"no household with id {wanted}")
+        return found
+
+    matches = list(
+        (await db.execute(select(Household).where(func.lower(Household.name) == wanted.strip().lower()))).scalars()
+    )
+    if not matches:
+        raise EntitlementError(f"no household called {wanted!r}; 'list --all' shows every one on this server")
+    if len(matches) > 1:
+        ids = "\n  ".join(f"{household.id}  {household.name}" for household in matches)
+        raise EntitlementError(f"{len(matches)} households are called {wanted!r}; use an id:\n  {ids}")
+    return matches[0]
+
+
+def _date(value: str) -> datetime:
+    """A plain YYYY-MM-DD, read as the end of that day in UTC so that
+    `--until 2027-08-22` means the whole of the 22nd rather than its first
+    instant."""
+    try:
+        day = datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"{value!r} is not a date; use YYYY-MM-DD") from exc
+    return datetime.combine(day, time.max, tzinfo=UTC)
+
+
+def _render(rows: list[Entitlement]) -> str:
+    """One line per household, plus the note underneath it.
+
+    Columns are sized to what is actually in them rather than to a guess, since
+    the common case is two or three households and a fixed width would be mostly
+    spaces.
+    """
+    if not rows:
+        return "No household on this server has an entitlement. That is the self-hosted default."
+
+    def tier_of(row: Entitlement) -> str:
+        # The one thing worth shouting about: what is stored is not what applies.
+        if row.effective_tier != row.stored_tier:
+            return f"{row.stored_tier} (reads as {row.effective_tier})"
+        return row.stored_tier
+
+    def until_of(row: Entitlement) -> str:
+        return row.paid_until.strftime("%Y-%m-%d") if row.paid_until else "no expiry"
+
+    def price_of(row: Entitlement) -> str:
+        return f"{row.price_pence / 100:.2f} {row.price_currency}" if row.price_pence is not None else "-"
+
+    cells = [
+        [row.household_name, row.state, tier_of(row), until_of(row), row.source or "-", price_of(row)] for row in rows
+    ]
+    widths = [max(len(cell[column]) for cell in cells) for column in range(len(cells[0]))]
+    lines = []
+    for row, cell in zip(rows, cells, strict=True):
+        padded = "  ".join(value.ljust(width) for value, width in zip(cell, widths, strict=True))
+        lines.append(f"{padded}  {row.lead_email or '-'}")
+        if row.note:
+            lines.append(f"{'':<{widths[0]}}  {row.note}")
+    return "\n".join(lines)
+
+
+async def _run(args: argparse.Namespace, sessions: async_sessionmaker[AsyncSession] | None = None) -> str:
+    async with (sessions or SessionLocal)() as db:
+        if args.command == "list":
+            return _render(await entitlements.listing(db, everyone=args.all))
+
+        household = await _find(db, args.household)
+        # Looked up before the change so the one line printed back carries the
+        # same columns `list` does, rather than a dash where the lead should be.
+        lead = await db.get(User, household.lead_user_id) if household.lead_user_id else None
+        if args.command == "comp":
+            granted = await entitlements.grant(
+                db,
+                household,
+                tier=args.tier,
+                until=None if args.forever else _until(args),
+                source=entitlements.COMP,
+                note=args.note,
+            )
+        elif args.command == "extend":
+            granted = await entitlements.extend(db, household, days=args.days, until=args.until)
+        else:
+            granted = await entitlements.revoke(db, household, note=args.note)
+        return _render([replace(granted, lead_email=lead.email if lead else None)])
+
+
+def _until(args: argparse.Namespace) -> datetime:
+    if args.until is not None:
+        return args.until
+    if args.days is None:
+        raise EntitlementError("give --days, --until or --forever")
+    return datetime.now(UTC) + timedelta(days=args.days)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    listing = commands.add_parser("list", help="who is on what, most urgent first")
+    listing.add_argument("--all", action="store_true", help="include households with no entitlement")
+
+    comp = commands.add_parser("comp", help="put a household on a tier, free")
+    comp.add_argument("--household", required=True, help="name or id")
+    comp.add_argument("--tier", default=limits.PAID, choices=limits.TIERS, help="default: %(default)s")
+    when = comp.add_mutually_exclusive_group(required=True)
+    when.add_argument("--days", type=int, help="from today")
+    when.add_argument("--until", type=_date, help="YYYY-MM-DD")
+    when.add_argument("--forever", action="store_true", help="no expiry, so it never lapses")
+    comp.add_argument("--note", help="why, in one line, for whoever reads this in a year")
+
+    extend = commands.add_parser("extend", help="push the expiry out, from wherever it is")
+    extend.add_argument("--household", required=True, help="name or id")
+    group = extend.add_mutually_exclusive_group(required=True)
+    group.add_argument("--days", type=int)
+    group.add_argument("--until", type=_date, help="YYYY-MM-DD")
+
+    revoke = commands.add_parser("revoke", help="back to the free tier; deletes nothing")
+    revoke.add_argument("--household", required=True, help="name or id")
+    revoke.add_argument("--note", help="why")
+
+    args = parser.parse_args()
+    for name in ("all", "tier", "forever", "days", "until", "note", "household"):
+        args.__dict__.setdefault(name, None)
+    try:
+        print(asyncio.run(_run(args)))
+    except EntitlementError as exc:
+        print(f"refused: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/limits.py
+++ b/backend/app/limits.py
@@ -590,15 +590,38 @@ def _upgradable(tier: str, resource: str, cap: int) -> bool:
     return False
 
 
-def effective_tier(household: Household) -> str:
-    """The tier this household is actually treated as being on.
+def has_lapsed(household: Household, *, now: datetime | None = None) -> bool:
+    """Whether this household's entitlement has run out, grace included.
 
-    A column holding a value this build has not heard of resolves to
-    `unlimited` rather than raising, for the same reason `limits_for` does: a
-    household must never be locked out of its own data by a tier name from a
-    newer deployment.
+    `paid_until` is null for every self-hosted household and for a permanent
+    comp, and a null one never lapses: the tier simply stands, which is what
+    keeps this whole idea invisible to a server that sells nothing.
     """
-    return household.tier if household.tier in TIERS else UNLIMITED
+    if household.paid_until is None:
+        return False
+    grace = timedelta(days=get_settings().entitlement_grace_days)
+    return _as_aware(household.paid_until) + grace < (now or datetime.now(UTC))
+
+
+def effective_tier(household: Household, *, now: datetime | None = None) -> str:
+    """The tier this household is actually treated as being on, and the single
+    place anything asks (#99: entitlement is one source of truth, everything
+    else reads it).
+
+    Two things can move it off the stored `tier`:
+
+    - A value this build has not heard of resolves to `unlimited` rather than
+      raising, for the same reason `limits_for` does: a household must never be
+      locked out of its own data by a tier name from a newer deployment.
+    - An entitlement past its expiry *and* its grace period reads as `free`.
+      Deliberately derived rather than written back: §5 promises nothing is
+      deleted and everything stays readable, so lapsing may change what a
+      household can *grow* and nothing else. A job that rewrote `tier` would
+      also lose the record of what they were on, which is exactly what a
+      renewal needs.
+    """
+    tier = household.tier if household.tier in TIERS else UNLIMITED
+    return FREE if has_lapsed(household, now=now) else tier
 
 
 def _verdict(household: Household, spec: _Spec, resource: str, *, used: int, adding: int) -> LimitExceeded | None:

--- a/backend/app/models/users.py
+++ b/backend/app/models/users.py
@@ -73,6 +73,29 @@ class Household(Base):
     ingest_period_started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
     ingests_used: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
 
+    # ------------------------------------------------------- entitlement
+    # When the tier above stops applying, and where it came from (#99). Null
+    # `paid_until` means "does not expire", which is what every self-hosted
+    # household has and what a permanent comp gets: the tier simply stands.
+    # With a date, `limits.effective_tier` drops the household back to the free
+    # tier once it is past, plus the grace period — and drops it back only for
+    # the purpose of *caps*. Nothing is deleted and nothing becomes unreadable
+    # (planning/08-freemium.md §5), which is why lapsing lives in one derived
+    # function rather than in a job that rewrites `tier`.
+    paid_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
+    # 'comp' or the name of the processor the payment came through. Free text
+    # rather than an enum for the same reason `tier` is: a value this build has
+    # not heard of must never be an error.
+    entitlement_source: Mapped[str | None] = mapped_column(String(40), default=None)
+    # Why, in one line, for whoever is reading the list a year later: "early
+    # supporter", "PikaPods", "found the backup bug".
+    entitlement_note: Mapped[str | None] = mapped_column(String(200), default=None)
+    # Dunning's two one-shot marks (§5: one email before expiry, one after).
+    # Both are cleared whenever the entitlement is extended, so the next year
+    # gets its own pair rather than being silently skipped.
+    expiry_warned_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
+    lapse_notified_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None)
+
     # Two foreign keys now join these tables (a user's household, a household's
     # lead), so both relationships have to say which one they travel.
     users: Mapped[list["User"]] = relationship(back_populates="household", foreign_keys="User.household_id")

--- a/backend/app/services/dunning.py
+++ b/backend/app/services/dunning.py
@@ -1,0 +1,151 @@
+"""Two emails about an expiring entitlement, and never a third.
+
+planning/08-freemium.md §5: "one email before expiry and one after, through the
+SMTP that password reset already uses". That is the whole feature, and its
+smallness is the point — dunning that nags is dunning people filter.
+
+- **Before**, `DUNNING_WARN_DAYS` ahead of the date, so there is time to act.
+- **After**, on the day it expires rather than at the end of the grace period.
+  At expiry the news is useful ("you have 14 days before limits re-apply"); at
+  the end of grace it is only a complaint.
+
+Both are one-shot, marked on the household, and both marks are cleared whenever
+the expiry moves (`entitlements._reset_dunning`), so next year gets its own pair.
+A relay failure leaves the mark unset, so the next run tries again rather than
+silently swallowing the only warning somebody was going to get.
+
+Nothing here runs on a self-hosted instance. There is no scheduler in the app:
+this is `python -m app.dunning` from cron, and with no SMTP configured, or no
+household carrying an expiry, it does nothing and says so.
+"""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import get_settings
+from app.models import Household, User
+from app.observability import log_event
+from app.services.mailer import EmailSendFailed, send_email
+
+WARNING = "warning"
+LAPSE = "lapse"
+
+
+@dataclass(frozen=True)
+class Notice:
+    """One email that is due, or was sent."""
+
+    kind: str
+    household_id: object
+    household_name: str
+    to: str
+    paid_until: datetime
+
+
+def _aware(value: datetime) -> datetime:
+    return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+
+async def due(db: AsyncSession, *, now: datetime | None = None) -> list[Notice]:
+    """Every email that should go out at this moment, and nothing else.
+
+    Households with no expiry are never in here, which is every self-hosted one
+    and every standing comp.
+    """
+    now = now or datetime.now(UTC)
+    warn_from = now + timedelta(days=get_settings().dunning_warn_days)
+    result = await db.execute(
+        select(Household, User)
+        .join(User, Household.lead_user_id == User.id)
+        .where(Household.paid_until.is_not(None))
+        .order_by(Household.paid_until)
+    )
+    notices = []
+    for household, lead in result:
+        expires = _aware(household.paid_until)
+        if expires <= now:
+            if household.lapse_notified_at is None:
+                notices.append(_notice(LAPSE, household, lead, expires))
+        elif expires <= warn_from and household.expiry_warned_at is None:
+            notices.append(_notice(WARNING, household, lead, expires))
+    return notices
+
+
+def _notice(kind: str, household: Household, lead: User, expires: datetime) -> Notice:
+    return Notice(
+        kind=kind, household_id=household.id, household_name=household.name, to=lead.email, paid_until=expires
+    )
+
+
+async def run(db: AsyncSession, *, now: datetime | None = None, dry_run: bool = False) -> list[Notice]:
+    """Send what is due and mark it. Returns what actually went out.
+
+    Silence is the failure mode worth guarding against here, so every send and
+    every failure is an event: `dunning.sent` with the kind, and
+    `dunning.failed` with the reason. A failure marks nothing, so the next run
+    retries rather than dropping somebody's only notice.
+    """
+    settings = get_settings()
+    notices = await due(db, now=now)
+    if dry_run or not notices:
+        return notices
+    if not settings.email_configured:
+        # Not an error: a server with no mail relay is the normal case, and
+        # refusing loudly every night would be noise rather than news.
+        log_event("dunning.skipped", outcome="no_smtp", count=len(notices))
+        return []
+
+    sent = []
+    for notice in notices:
+        subject, body = _message(notice, grace_days=settings.entitlement_grace_days)
+        try:
+            await send_email(notice.to, subject, body)
+        except EmailSendFailed as exc:
+            log_event("dunning.failed", outcome=notice.kind, household_id=notice.household_id, reason=str(exc)[:200])
+            continue
+        household = await db.get(Household, notice.household_id)
+        if household is not None:
+            stamp = datetime.now(UTC)
+            if notice.kind == WARNING:
+                household.expiry_warned_at = stamp
+            else:
+                household.lapse_notified_at = stamp
+        sent.append(notice)
+        log_event("dunning.sent", outcome=notice.kind, household_id=notice.household_id)
+    await db.commit()
+    return sent
+
+
+def _message(notice: Notice, *, grace_days: int) -> tuple[str, str]:
+    """The two emails. Plain, factual, and pointing at the one thing that is
+    true whatever somebody decides: their data is theirs and it is one request
+    away (§1). Neither says anything the terms page does not."""
+    when = notice.paid_until.strftime("%-d %B %Y")
+    if notice.kind == WARNING:
+        return (
+            f"Your Meals household expires on {when}",
+            f"Hello,\n\n"
+            f"The hosted year for your household, {notice.household_name}, ends on {when}.\n\n"
+            f"If you renew, nothing changes. If you do not, nothing is deleted: your recipes, plans, "
+            f"lists and cooked history all stay exactly where they are and stay readable, and the "
+            f"shopping list keeps working. After a grace period of {grace_days} days the free tier's "
+            f"limits re-apply, which only stops the household growing — no new recipes past the free "
+            f"allowance, and no new invites.\n\n"
+            f"You can take a full copy of everything at any time, free, with one request to "
+            f"/household/export. The terms are at /terms on the same server.\n",
+        )
+    return (
+        "Your Meals household has reached the end of its year",
+        f"Hello,\n\n"
+        f"The hosted year for your household, {notice.household_name}, ended on {when}.\n\n"
+        f"Nothing has been deleted and nothing has been switched off. You have {grace_days} days before "
+        f"the free tier's limits re-apply, and even then everything already there stays readable, the "
+        f"plan stays usable and the shopping list keeps working in full. What stops is growth: no new "
+        f"recipes past the free allowance, and no new invites.\n\n"
+        f"Renewing puts it back exactly as it was. If you would rather not, that is fine too, and your "
+        f"data is still yours: one request to /household/export returns all of it, free. The terms are "
+        f"at /terms on the same server.\n",
+    )

--- a/backend/app/services/entitlements.py
+++ b/backend/app/services/entitlements.py
@@ -1,0 +1,259 @@
+"""What a household is entitled to, and the only place that changes it.
+
+Issue #99, planning/08-freemium.md §2 and §5. `households.tier` says which set
+of numbers in `app/limits.py` applies; the columns beside it say until when,
+where it came from, and what was agreed. Everything else *reads* that through
+one function, `limits.effective_tier`, which is what makes this a source of
+truth rather than a second opinion.
+
+Three rules the module exists to hold:
+
+- **Lapsing is derived, never written back.** A household past its expiry and
+  its grace reads as `free`; nothing rewrites `tier`, nothing is deleted, and
+  nothing becomes unreadable (§5). Keeping the stored tier is also what makes a
+  renewal a one-line change rather than a reconstruction.
+- **The founding price is set once.** §6 promises "founding price for life",
+  and a promise stored on the row is only worth something if the code refuses
+  to quietly overwrite it. `grant` writes the price snapshot only when there
+  isn't one; changing it is a separate, deliberate act.
+- **A self-hosted instance never touches any of this.** Every column defaults to
+  null, a `paid_until` of null never expires, and nothing here runs unless
+  somebody runs it.
+
+The write side is deliberately a library rather than an endpoint. Comping
+somebody is an operator action on a box, like `app/provision.py`, and #99 says
+the ops surface comes before the money: a spreadsheet is not a source of truth.
+"""
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import limits
+from app.config import get_settings
+from app.models import Household, User
+from app.observability import log_event
+
+#: `entitlement_source` for anything given rather than bought. A processor's
+#: name goes in the same column when there is one to name.
+COMP = "comp"
+
+#: What a household's entitlement is doing right now. Not stored: derived from
+#: `paid_until` and the clock, so it can never disagree with what the limits
+#: are actually doing.
+PERMANENT = "permanent"  # no expiry: every self-hosted household, and a standing comp
+PAID = "paid"  # in date
+GRACE = "grace"  # past expiry, caps not yet re-applied (§5's 14 days)
+LAPSED = "lapsed"  # past expiry and past grace: the free tier's caps apply
+STATES = (PERMANENT, PAID, GRACE, LAPSED)
+
+
+class EntitlementError(Exception):
+    """A change that would lose something worth keeping. Carries a sentence the
+    operator can act on, in the same spirit as the API's 4xx bodies."""
+
+
+@dataclass(frozen=True)
+class Entitlement:
+    """One household's entitlement, flattened for reporting."""
+
+    household_id: uuid.UUID
+    household_name: str
+    stored_tier: str
+    effective_tier: str
+    state: str
+    paid_until: datetime | None
+    grace_ends_at: datetime | None
+    source: str | None
+    note: str | None
+    price_pence: int | None
+    price_currency: str | None
+    lead_email: str | None
+
+
+def _aware(value: datetime) -> datetime:
+    # SQLite round-trips datetimes naive; stored values are UTC.
+    return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+
+def grace_ends_at(household: Household) -> datetime | None:
+    if household.paid_until is None:
+        return None
+    return _aware(household.paid_until) + timedelta(days=get_settings().entitlement_grace_days)
+
+
+def state(household: Household, *, now: datetime | None = None) -> str:
+    now = now or datetime.now(UTC)
+    if household.paid_until is None:
+        return PERMANENT
+    if now < _aware(household.paid_until):
+        return PAID
+    return GRACE if now < grace_ends_at(household) else LAPSED
+
+
+def describe(household: Household, *, lead_email: str | None = None, now: datetime | None = None) -> Entitlement:
+    return Entitlement(
+        household_id=household.id,
+        household_name=household.name,
+        stored_tier=household.tier,
+        effective_tier=limits.effective_tier(household, now=now),
+        state=state(household, now=now),
+        paid_until=_aware(household.paid_until) if household.paid_until else None,
+        grace_ends_at=grace_ends_at(household),
+        source=household.entitlement_source,
+        note=household.entitlement_note,
+        price_pence=household.price_pence,
+        price_currency=household.price_currency,
+        lead_email=lead_email,
+    )
+
+
+# ---------------------------------------------------------------- the writes
+
+
+async def grant(
+    db: AsyncSession,
+    household: Household,
+    *,
+    tier: str,
+    until: datetime | None,
+    source: str,
+    note: str | None = None,
+    price_pence: int | None = None,
+    price_currency: str | None = None,
+) -> Entitlement:
+    """Put a household on a tier until a date, or forever with `until=None`.
+
+    The price snapshot is written **only if there isn't one**: §6's founding
+    price is for life, and a renewal that quietly repriced somebody would make
+    that sentence untrue while looking like bookkeeping. Repricing on purpose
+    means clearing it first, which is a deliberate act with its own line in the
+    log.
+    """
+    if tier not in limits.TIERS:
+        raise EntitlementError(f"{tier!r} is not a tier; choose one of {', '.join(limits.TIERS)}")
+    if until is not None and _aware(until) <= datetime.now(UTC):
+        raise EntitlementError(
+            f"{until.date()} is not in the future, so this would grant an entitlement that has already "
+            "lapsed. Use a later date, or 'revoke' if that is what you meant."
+        )
+    if price_pence is not None and household.price_pence is not None and household.price_pence != price_pence:
+        raise EntitlementError(
+            f"this household already has a price of {household.price_pence}p and that is theirs for life "
+            "(planning/08-freemium.md §6). Extending keeps it; if you really mean to change it, clear "
+            "the price snapshot first and say why in the note."
+        )
+
+    household.tier = tier
+    household.paid_until = until
+    household.entitlement_source = source
+    if note is not None:
+        household.entitlement_note = note
+    if price_pence is not None and household.price_pence is None:
+        household.price_pence = price_pence
+        household.price_currency = price_currency or "GBP"
+        household.price_set_at = datetime.now(UTC)
+    _reset_dunning(household)
+
+    await db.commit()
+    log_event(
+        "entitlement.granted",
+        outcome=tier,
+        household_id=household.id,
+        source=source,
+        until=until.isoformat() if until else None,
+    )
+    return describe(household)
+
+
+async def extend(
+    db: AsyncSession,
+    household: Household,
+    *,
+    days: int | None = None,
+    until: datetime | None = None,
+) -> Entitlement:
+    """Push the expiry out, from wherever it actually is.
+
+    A household still in date is extended from its own expiry, so nothing is
+    lost by renewing early. One already lapsed is extended from now, so nobody
+    pays for the weeks they were locked out of growing.
+    """
+    if (days is None) == (until is None):
+        raise EntitlementError("give either days or until, not both and not neither")
+    now = datetime.now(UTC)
+    if days is not None:
+        if days <= 0:
+            raise EntitlementError(f"days must be positive; {days} would shorten the entitlement")
+        base = max(now, _aware(household.paid_until)) if household.paid_until else now
+        until = base + timedelta(days=days)
+    elif _aware(until) <= now:
+        raise EntitlementError(f"{until.date()} is not in the future")
+
+    household.paid_until = until
+    _reset_dunning(household)
+    await db.commit()
+    log_event("entitlement.extended", household_id=household.id, until=until.isoformat())
+    return describe(household)
+
+
+async def revoke(db: AsyncSession, household: Household, *, note: str | None = None) -> Entitlement:
+    """Back to the free tier, now.
+
+    Nothing is deleted and nothing becomes unreadable — this only stops the
+    household growing past the free allowance (§5). The price snapshot is kept
+    on purpose: if they come back, the founding price they were promised is
+    still the one on their row.
+    """
+    household.tier = limits.FREE
+    household.paid_until = None
+    household.entitlement_source = None
+    if note is not None:
+        household.entitlement_note = note
+    _reset_dunning(household)
+    await db.commit()
+    log_event("entitlement.revoked", household_id=household.id)
+    return describe(household)
+
+
+def _reset_dunning(household: Household) -> None:
+    """Every change to the expiry starts dunning over. Without this a renewed
+    household would never be warned again, because it was warned once."""
+    household.expiry_warned_at = None
+    household.lapse_notified_at = None
+
+
+# ---------------------------------------------------------------- the reading
+
+
+async def listing(db: AsyncSession, *, everyone: bool = False, now: datetime | None = None) -> list[Entitlement]:
+    """Who is on what, ordered by what needs attention first.
+
+    By default only households with an entitlement worth reporting: anything
+    that was granted, and anything not on the deployment's default tier. On a
+    self-hosted server that is nobody, and the answer is an empty list rather
+    than every household you have.
+    """
+    households = list((await db.execute(select(Household).order_by(Household.created_at, Household.id))).scalars())
+    leads = await _lead_emails(db, households)
+    default = get_settings().default_household_tier
+    rows = [
+        describe(household, lead_email=leads.get(household.lead_user_id), now=now)
+        for household in households
+        if everyone or household.entitlement_source is not None or household.tier != default
+    ]
+    # Lapsed first, then grace, then the ones with a date, then the rest: the
+    # top of the list is what somebody running this actually needs to see.
+    order = {LAPSED: 0, GRACE: 1, PAID: 2, PERMANENT: 3}
+    return sorted(rows, key=lambda row: (order[row.state], row.paid_until or datetime.max.replace(tzinfo=UTC)))
+
+
+async def _lead_emails(db: AsyncSession, households: list[Household]) -> dict[uuid.UUID, str]:
+    lead_ids = [household.lead_user_id for household in households if household.lead_user_id]
+    if not lead_ids:
+        return {}
+    users = (await db.execute(select(User).where(User.id.in_(lead_ids)))).scalars().all()
+    return {user.id: user.email for user in users}

--- a/backend/tests/integration/test_entitlements.py
+++ b/backend/tests/integration/test_entitlements.py
@@ -1,0 +1,482 @@
+"""Entitlements, lapse semantics, comp tooling and dunning (issue #99,
+planning/08-freemium.md §2 and §5).
+
+What is defended here, in order of how much it would cost to get wrong:
+
+1. **A self-hosted server notices none of it.** Every column is null, a null
+   expiry never lapses, and the CLIs do nothing on a server with no entitlements.
+2. **Lapsing takes nothing away.** §5: nothing is deleted, nothing becomes
+   unreadable, plans stay usable, the shopping list keeps working. Only growth
+   stops, and only after the grace period.
+3. **The founding price is for life**, which means the code has to refuse to
+   quietly overwrite it.
+
+There is no webhook here, and no test for one: no merchant of record has been
+chosen (planning/08-freemium.md §7), and the issue says to decide that before
+writing it.
+"""
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app import dunning as dunning_cli
+from app import entitlements as cli
+from app import limits
+from app.models import Household
+from app.services import dunning, entitlements
+from app.services.entitlements import EntitlementError
+from tests.conftest import create_recipe, register
+
+PASSWORD = "a-strong-password"
+
+
+def headers(auth: dict) -> dict:
+    return {"Authorization": f"Bearer {auth['token']}"}
+
+
+@pytest.fixture
+def sessions(engine):
+    return async_sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest.fixture
+def hosted(settings_override):
+    """The hosted numbers, dialled down. Call before registering."""
+
+    def apply(**overrides):
+        settings_override(
+            LIMITS_PROFILE="hosted",
+            DEFAULT_HOUSEHOLD_TIER="free",
+            LIMITS_OVERRIDES=json.dumps(overrides),
+        )
+
+    return apply
+
+
+async def only_household(sessions) -> Household:
+    async with sessions() as db:
+        return (await db.execute(select(Household))).scalars().one()
+
+
+async def reload(sessions, household_id) -> Household:
+    async with sessions() as db:
+        return await db.get(Household, household_id)
+
+
+class TestASelfHostedServerNoticesNothing:
+    async def test_a_new_household_has_no_entitlement_at_all(self, auth_client, sessions):
+        household = await only_household(sessions)
+        assert household.paid_until is None
+        assert household.entitlement_source is None
+        assert entitlements.state(household) == entitlements.PERMANENT
+        assert limits.effective_tier(household) == "unlimited"
+
+    async def test_a_null_expiry_never_lapses(self, auth_client, sessions):
+        """The whole idea has to be invisible on a server that sells nothing,
+        and this is the line that makes it so."""
+        household = await only_household(sessions)
+        far_future = datetime.now(UTC) + timedelta(days=100_000)
+        assert limits.has_lapsed(household, now=far_future) is False
+        assert limits.effective_tier(household, now=far_future) == "unlimited"
+
+    async def test_the_listing_is_empty_rather_than_everyone(self, auth_client, sessions):
+        async with sessions() as db:
+            assert await entitlements.listing(db) == []
+            assert len(await entitlements.listing(db, everyone=True)) == 1
+
+    async def test_dunning_has_nothing_to_say(self, auth_client, sessions):
+        async with sessions() as db:
+            assert await dunning.due(db) == []
+            assert await dunning.run(db) == []
+
+
+class TestLapsingStopsGrowthAndNothingElse:
+    @pytest.fixture
+    async def lapsed(self, client, hosted, sessions):
+        """A paid household whose year ended, and whose grace ran out."""
+        hosted(free={"recipes": 1})
+        auth = await register(client)
+        client.headers["Authorization"] = f"Bearer {auth['token']}"
+        async with sessions() as db:
+            household = (await db.execute(select(Household))).scalars().one()
+            await entitlements.grant(
+                db, household, tier="paid", until=datetime.now(UTC) + timedelta(days=1), source="test"
+            )
+            # Rewind the expiry past the grace period rather than waiting 15 days.
+            household.paid_until = datetime.now(UTC) - timedelta(days=30)
+            await db.commit()
+        return auth
+
+    async def test_the_free_caps_re_apply(self, client, lapsed, sessions):
+        household = await only_household(sessions)
+        assert entitlements.state(household) == entitlements.LAPSED
+        assert household.tier == "paid"  # the stored tier is untouched
+        assert limits.effective_tier(household) == "free"
+
+        await create_recipe(client, title="The one we have")
+        refused = await client.post("/recipes", json={"title": "Another", "ingredients": []})
+        assert refused.status_code == 402
+        assert refused.json()["tier"] == "free"
+
+    async def test_everything_already_there_still_works(self, client, lapsed):
+        """§5, and the reason lapsing is derived rather than written back."""
+        recipe = await create_recipe(client, title="Dinner")
+        assert (await client.get("/recipes")).status_code == 200
+        assert (await client.patch(f"/recipes/{recipe['id']}", json={"title": "Renamed"})).status_code == 200
+        assert (await client.get("/shopping-list")).status_code == 200
+        assert (await client.post("/shopping-list/items", json={"name": "milk"})).status_code == 201
+        assert (await client.post("/plans", json={"label": "This week"})).status_code == 201
+
+    async def test_taking_your_data_out_still_costs_nothing(self, client, lapsed):
+        """The one thing that must never depend on being paid up (§1)."""
+        assert (await client.get("/household/export")).status_code == 200
+
+    async def test_the_grace_period_changes_nothing_while_it_lasts(self, client, hosted, sessions):
+        hosted(free={"recipes": 1})
+        auth = await register(client)
+        client.headers["Authorization"] = f"Bearer {auth['token']}"
+        async with sessions() as db:
+            household = (await db.execute(select(Household))).scalars().one()
+            household.tier = "paid"
+            household.paid_until = datetime.now(UTC) - timedelta(days=3)  # expired, inside 14 days
+            await db.commit()
+
+        household = await only_household(sessions)
+        assert entitlements.state(household) == entitlements.GRACE
+        assert limits.effective_tier(household) == "paid"
+        await create_recipe(client, title="One")
+        assert (await client.post("/recipes", json={"title": "Two", "ingredients": []})).status_code == 201
+
+    async def test_the_grace_period_is_configurable(self, client, hosted, sessions, settings_override):
+        hosted()
+        settings_override(ENTITLEMENT_GRACE_DAYS="0")
+        await register(client)
+        async with sessions() as db:
+            household = (await db.execute(select(Household))).scalars().one()
+            household.tier = "paid"
+            household.paid_until = datetime.now(UTC) - timedelta(minutes=1)
+            await db.commit()
+        assert entitlements.state(await only_household(sessions)) == entitlements.LAPSED
+
+    async def test_renewing_puts_it_straight_back(self, client, lapsed, sessions):
+        async with sessions() as db:
+            household = (await db.execute(select(Household))).scalars().one()
+            await entitlements.extend(db, household, days=365)
+        household = await only_household(sessions)
+        assert entitlements.state(household) == entitlements.PAID
+        assert limits.effective_tier(household) == "paid"
+
+
+class TestTheCompTooling:
+    @pytest.fixture
+    async def household(self, client, sessions):
+        await register(client, email="lead@example.com", name="Lead")
+        return await only_household(sessions)
+
+    async def test_a_comp_with_an_end_date(self, household, sessions):
+        async with sessions() as db:
+            row = await db.get(Household, household.id)
+            granted = await entitlements.grant(
+                db,
+                row,
+                tier="paid",
+                until=datetime.now(UTC) + timedelta(days=365),
+                source=entitlements.COMP,
+                note="early supporter",
+            )
+        assert (granted.stored_tier, granted.state, granted.source) == ("paid", entitlements.PAID, "comp")
+        assert granted.note == "early supporter"
+
+    async def test_a_standing_comp_never_lapses(self, household, sessions):
+        async with sessions() as db:
+            row = await db.get(Household, household.id)
+            granted = await entitlements.grant(db, row, tier="paid", until=None, source=entitlements.COMP)
+        assert granted.state == entitlements.PERMANENT
+        assert granted.paid_until is None
+
+    async def test_extending_an_active_year_adds_to_its_end(self, household, sessions):
+        """Renewing early must not cost somebody the days they had left."""
+        ends = datetime.now(UTC) + timedelta(days=100)
+        async with sessions() as db:
+            row = await db.get(Household, household.id)
+            await entitlements.grant(db, row, tier="paid", until=ends, source="test")
+            extended = await entitlements.extend(db, row, days=365)
+        assert extended.paid_until > ends + timedelta(days=364)
+
+    async def test_extending_a_lapsed_one_starts_from_today(self, household, sessions):
+        """Nobody pays for the weeks they spent locked out of growing."""
+        async with sessions() as db:
+            row = await db.get(Household, household.id)
+            row.paid_until = datetime.now(UTC) - timedelta(days=200)
+            await db.commit()
+            extended = await entitlements.extend(db, row, days=30)
+        assert extended.paid_until < datetime.now(UTC) + timedelta(days=31)
+        assert extended.paid_until > datetime.now(UTC) + timedelta(days=29)
+
+    async def test_revoking_takes_nothing_away(self, household, sessions):
+        async with sessions() as db:
+            row = await db.get(Household, household.id)
+            await entitlements.grant(
+                db,
+                row,
+                tier="paid",
+                until=datetime.now(UTC) + timedelta(days=365),
+                source="test",
+                price_pence=2000,
+            )
+            revoked = await entitlements.revoke(db, row, note="asked to stop")
+        assert (revoked.stored_tier, revoked.state) == ("free", entitlements.PERMANENT)
+        # The founding price survives, so coming back costs what it always did.
+        assert revoked.price_pence == 2000
+
+    async def test_the_founding_price_cannot_be_quietly_changed(self, household, sessions):
+        """§6 stores the promise on the row; it is only worth something if the
+        code refuses to overwrite it."""
+        async with sessions() as db:
+            row = await db.get(Household, household.id)
+            await entitlements.grant(db, row, tier="paid", until=None, source="test", price_pence=2000)
+            with pytest.raises(EntitlementError, match="theirs for life"):
+                await entitlements.grant(db, row, tier="paid", until=None, source="test", price_pence=3000)
+        assert (await reload(sessions, household.id)).price_pence == 2000
+
+    async def test_the_same_price_again_is_not_a_change(self, household, sessions):
+        async with sessions() as db:
+            row = await db.get(Household, household.id)
+            await entitlements.grant(db, row, tier="paid", until=None, source="test", price_pence=2000)
+            again = await entitlements.grant(db, row, tier="paid", until=None, source="test", price_pence=2000)
+        assert again.price_pence == 2000
+
+    async def test_a_date_in_the_past_is_refused(self, household, sessions):
+        async with sessions() as db:
+            row = await db.get(Household, household.id)
+            with pytest.raises(EntitlementError, match="not in the future"):
+                await entitlements.grant(
+                    db, row, tier="paid", until=datetime.now(UTC) - timedelta(days=1), source="test"
+                )
+
+    async def test_an_unknown_tier_is_refused(self, household, sessions):
+        async with sessions() as db:
+            row = await db.get(Household, household.id)
+            with pytest.raises(EntitlementError, match="is not a tier"):
+                await entitlements.grant(db, row, tier="platinum", until=None, source="test")
+
+    async def test_the_listing_puts_what_needs_attention_first(self, client, sessions, settings_override):
+        settings_override(DEFAULT_HOUSEHOLD_TIER="free")
+        await register(client, email="a@example.com", name="A", household_name="Lapsed")
+        await register(client, email="b@example.com", name="B", household_name="Paid")
+        async with sessions() as db:
+            rows = list((await db.execute(select(Household).order_by(Household.name))).scalars())
+            paid = {household.name: household for household in rows}
+            paid["Paid"].tier = "paid"
+            paid["Paid"].paid_until = datetime.now(UTC) + timedelta(days=200)
+            paid["Paid"].entitlement_source = "comp"
+            paid["Lapsed"].tier = "paid"
+            paid["Lapsed"].paid_until = datetime.now(UTC) - timedelta(days=90)
+            paid["Lapsed"].entitlement_source = "comp"
+            await db.commit()
+            listing = await entitlements.listing(db)
+
+        assert [row.household_name for row in listing] == ["Lapsed", "Paid"]
+        assert listing[0].state == entitlements.LAPSED
+        assert listing[0].lead_email == "a@example.com"
+
+
+class TestDunning:
+    @pytest.fixture
+    def smtp(self, settings_override, monkeypatch):
+        """A configured relay that records rather than sends."""
+        settings_override(SMTP_HOST="smtp.example.com", SMTP_FROM="meals@example.com")
+        sent = []
+
+        async def fake_send(to, subject, body):
+            sent.append((to, subject, body))
+
+        monkeypatch.setattr("app.services.dunning.send_email", fake_send)
+        return sent
+
+    @pytest.fixture
+    async def expiring(self, client, sessions):
+        await register(client, email="lead@example.com", name="Lead")
+        return await only_household(sessions)
+
+    async def _set_expiry(self, sessions, household_id, delta):
+        async with sessions() as db:
+            row = await db.get(Household, household_id)
+            row.tier = "paid"
+            row.paid_until = datetime.now(UTC) + delta
+            await db.commit()
+
+    async def test_one_email_before_expiry(self, expiring, sessions, smtp):
+        await self._set_expiry(sessions, expiring.id, timedelta(days=3))
+        async with sessions() as db:
+            sent = await dunning.run(db)
+        assert [notice.kind for notice in sent] == [dunning.WARNING]
+        assert smtp[0][0] == "lead@example.com"
+        assert "expires on" in smtp[0][1]
+        assert "nothing is deleted" in smtp[0][2]
+
+    async def test_and_one_after(self, expiring, sessions, smtp):
+        await self._set_expiry(sessions, expiring.id, timedelta(days=-1))
+        async with sessions() as db:
+            sent = await dunning.run(db)
+        assert [notice.kind for notice in sent] == [dunning.LAPSE]
+        assert "reached the end of its year" in smtp[0][1]
+        # It goes at expiry, not at the end of grace, so it is still useful.
+        assert "14 days before" in smtp[0][2]
+
+    async def test_never_a_third(self, expiring, sessions, smtp):
+        await self._set_expiry(sessions, expiring.id, timedelta(days=3))
+        async with sessions() as db:
+            await dunning.run(db)
+            await dunning.run(db)
+            assert await dunning.due(db) == []
+        assert len(smtp) == 1
+
+    async def test_a_household_far_from_expiry_is_left_alone(self, expiring, sessions, smtp):
+        await self._set_expiry(sessions, expiring.id, timedelta(days=90))
+        async with sessions() as db:
+            assert await dunning.run(db) == []
+        assert smtp == []
+
+    async def test_renewing_arms_it_again(self, expiring, sessions, smtp):
+        """Without clearing the marks, a renewed household would never be
+        warned again because it was warned once."""
+        await self._set_expiry(sessions, expiring.id, timedelta(days=3))
+        async with sessions() as db:
+            await dunning.run(db)
+            row = await db.get(Household, expiring.id)
+            await entitlements.extend(db, row, days=365)
+            assert row.expiry_warned_at is None
+
+            row.paid_until = datetime.now(UTC) + timedelta(days=2)
+            await db.commit()
+            assert [notice.kind for notice in await dunning.run(db)] == [dunning.WARNING]
+        assert len(smtp) == 2
+
+    async def test_a_relay_failure_marks_nothing_so_it_retries(
+        self, expiring, sessions, settings_override, monkeypatch
+    ):
+        settings_override(SMTP_HOST="smtp.example.com", SMTP_FROM="meals@example.com")
+
+        async def refuse(to, subject, body):
+            raise dunning.EmailSendFailed("relay said no")
+
+        monkeypatch.setattr("app.services.dunning.send_email", refuse)
+        await self._set_expiry(sessions, expiring.id, timedelta(days=3))
+        async with sessions() as db:
+            assert await dunning.run(db) == []
+            # Still due: the only warning somebody was going to get is not lost
+            # because a mail server had a bad minute.
+            assert len(await dunning.due(db)) == 1
+
+    async def test_no_smtp_is_not_an_error(self, expiring, sessions):
+        """A server with no mail relay is the normal case, and refusing loudly
+        every night would be noise rather than news."""
+        await self._set_expiry(sessions, expiring.id, timedelta(days=3))
+        async with sessions() as db:
+            assert await dunning.run(db) == []
+            assert len(await dunning.due(db)) == 1  # unmarked, so nothing was faked
+
+    async def test_a_dry_run_sends_nothing(self, expiring, sessions, smtp):
+        await self._set_expiry(sessions, expiring.id, timedelta(days=3))
+        async with sessions() as db:
+            assert len(await dunning.run(db, dry_run=True)) == 1
+        assert smtp == []
+
+
+class TestTheOperatorCommands:
+    """`python -m app.entitlements`, in the spirit of app/provision.py: a
+    command on the box rather than an endpoint, because comping somebody is an
+    operator action and a spreadsheet is not a source of truth."""
+
+    @staticmethod
+    def _args(command: str, **kwargs):
+        from argparse import Namespace
+
+        defaults = dict(all=False, tier="paid", forever=False, days=None, until=None, note=None, household=None)
+        return Namespace(command=command, **{**defaults, **kwargs})
+
+    async def test_list_says_so_plainly_when_there_is_nothing_to_say(self, auth_client, sessions):
+        output = await cli._run(self._args("list"), sessions)
+        assert "That is the self-hosted default" in output
+
+    async def test_comp_extend_and_revoke_round_trip(self, client, sessions):
+        await register(client, email="lead@example.com", name="Lead", household_name="The Smiths")
+
+        comped = await cli._run(self._args("comp", household="The Smiths", days=365, note="early supporter"), sessions)
+        assert "The Smiths" in comped and "paid" in comped and "early supporter" in comped
+
+        await cli._run(self._args("extend", household="The Smiths", days=30), sessions)
+        # describe() is what hands back an aware datetime; SQLite stores them naive.
+        renewed = entitlements.describe(await only_household(sessions))
+        assert renewed.paid_until > datetime.now(UTC) + timedelta(days=390)
+
+        revoked = await cli._run(self._args("revoke", household="The Smiths", note="asked to stop"), sessions)
+        assert "free" in revoked
+        assert limits.effective_tier(await only_household(sessions)) == "free"
+
+    async def test_a_household_can_be_named_or_id_d(self, client, sessions):
+        await register(client, email="lead@example.com", name="Lead", household_name="The Smiths")
+        household = await only_household(sessions)
+        output = await cli._run(self._args("comp", household=str(household.id), forever=True), sessions)
+        assert "no expiry" in output
+
+    async def test_an_ambiguous_name_is_refused_with_the_ids(self, client, sessions):
+        for index in (1, 2):
+            await register(client, email=f"lead{index}@example.com", name="Lead", household_name="Home")
+        with pytest.raises(EntitlementError, match="2 households are called"):
+            await cli._run(self._args("comp", household="Home", forever=True), sessions)
+
+    async def test_an_unknown_household_says_how_to_find_the_right_one(self, auth_client, sessions):
+        with pytest.raises(EntitlementError, match="list --all"):
+            await cli._run(self._args("comp", household="Nobody", forever=True), sessions)
+
+    async def test_the_listing_shows_when_the_stored_tier_is_not_what_applies(self, client, sessions):
+        await register(client, email="lead@example.com", name="Lead", household_name="Lapsed")
+        async with sessions() as db:
+            row = (await db.execute(select(Household))).scalars().one()
+            row.tier = "paid"
+            row.paid_until = datetime.now(UTC) - timedelta(days=90)
+            row.entitlement_source = "comp"
+            await db.commit()
+        output = await cli._run(self._args("list"), sessions)
+        assert "reads as free" in output
+        assert "lapsed" in output
+
+
+class TestTheDunningCommand:
+    async def test_it_says_nothing_is_due_on_a_quiet_server(self, auth_client, sessions, monkeypatch):
+        monkeypatch.setattr("app.dunning.SessionLocal", sessions)
+        assert await dunning_cli._run(dry_run=False) == "Nothing due."
+
+    async def test_a_dry_run_names_who_would_be_written_to(self, client, sessions, monkeypatch):
+        monkeypatch.setattr("app.dunning.SessionLocal", sessions)
+        await register(client, email="lead@example.com", name="Lead", household_name="The Smiths")
+        async with sessions() as db:
+            row = (await db.execute(select(Household))).scalars().one()
+            row.tier = "paid"
+            row.paid_until = datetime.now(UTC) + timedelta(days=2)
+            await db.commit()
+
+        output = await dunning_cli._run(dry_run=True)
+        assert "would send 1" in output
+        assert "lead@example.com" in output
+        assert "warning" in output
+
+    async def test_it_reports_the_notices_it_could_not_send(self, client, sessions, monkeypatch):
+        """Silence is the failure mode worth guarding against: a run that sent
+        nothing because there is no relay must not read like a quiet night."""
+        monkeypatch.setattr("app.dunning.SessionLocal", sessions)
+        await register(client, email="lead@example.com", name="Lead")
+        async with sessions() as db:
+            row = (await db.execute(select(Household))).scalars().one()
+            row.tier = "paid"
+            row.paid_until = datetime.now(UTC) + timedelta(days=2)
+            await db.commit()
+
+        output = await dunning_cli._run(dry_run=False)
+        assert "no SMTP configured" in output

--- a/backend/tests/integration/test_export.py
+++ b/backend/tests/integration/test_export.py
@@ -219,7 +219,10 @@ class TestNothingIsLeftBehind:
 
     #: model → columns that are deliberately not exported, and why.
     EXCLUDED = {
-        # This deployment's bookkeeping about the household, not its data.
+        # This deployment's bookkeeping about the household, not its data:
+        # which tier it is on, what it agreed to pay, when that runs out, and
+        # what it has already been emailed about. All of it means nothing on
+        # the box the household is moving to.
         Household: {
             "tier",
             "price_pence",
@@ -227,6 +230,11 @@ class TestNothingIsLeftBehind:
             "price_set_at",
             "ingest_period_started_at",
             "ingests_used",
+            "paid_until",
+            "entitlement_source",
+            "entitlement_note",
+            "expiry_warned_at",
+            "lapse_notified_at",
         },
         User: {"password_hash", "household_id"},
         Ingredient: {"household_id"},


### PR DESCRIPTION
## What and why

Refs [#99](https://github.com/marco308/meals/issues/99) — **deliberately not `Closes`**, see the blocker below.

A household already said which tier it was on. It now says **until when**, **where that came from**, and **what was agreed**, and `limits.effective_tier` is the only thing that reads any of it.

**Lapsing is derived, never written back**, and that is the load-bearing choice. Past its expiry plus `ENTITLEMENT_GRACE_DAYS` (14) a household reads as `free`; nothing rewrites `tier`, so §5's promise holds by construction rather than by a job remembering to keep it — nothing deleted, everything readable, plan usable, shopping list working, export free. It also makes renewing one column rather than a reconstruction, and keeps the record of what somebody was on through the weeks they lapsed. **A null `paid_until` never expires**, which is every self-hosted household, so a server that sells nothing sees none of this.

**Comp tooling comes first**, because you comp people in week one and a spreadsheet is not a source of truth. `python -m app.entitlements` comps, extends, revokes and lists, most urgent at the top — a command on the box like `app/provision.py`, not an endpoint. Extending an active year adds to its end so renewing early costs nothing; extending a lapsed one starts from today so nobody pays for the weeks they could not grow.

**The founding price is defended, not just stored.** `grant` refuses to overwrite an existing price and says why; `revoke` keeps it, so coming back costs what it always did.

**Dunning** is `python -m app.dunning` from cron: one before expiry, one after (at expiry, where the news is still actionable, not at the end of grace where it is only a complaint). Each marked once, both marks cleared when the expiry moves, and a relay failure marks nothing so the next run retries. No SMTP is not an error.

## The blocker: no merchant of record has been chosen

The issue says **"Decide which before writing the webhook"**, and nothing in the repo names one — `08-freemium.md` §7 says only "a merchant of record rather than raw Stripe", and PR #114 just shipped a privacy section stating no processor exists. Paddle and Lemon Squeezy differ in their signature header, their event names and their payload shape, so writing it now would be guessing at all three.

So **the webhook and its failure alert are not here.** Everything above is processor-independent and is exactly what that webhook will call: `entitlements.grant` / `extend` / `revoke`, with `entitlement_source` taking the processor's name where `comp` goes today. Tell me which one and it is a focused follow-up.

Also not here, and also from the issue's own text: **email verification and reaping abandoned free households**, which the issue itself calls prerequisites for opening `REGISTRATION_ENABLED` rather than parts of this. And **StoreKit**, explicitly out of scope.

## One thing I chose not to do

`GET /limits` could report `paid_until` and the entitlement state, and it would be additive. I left it out because [#100](https://github.com/marco308/meals/issues/100) is specifically about keeping commerce out of the iOS app, and where a renewal date is allowed to surface feels like that issue's call rather than this one's.

## Checklist

- [x] **API contract stayed additive** — no endpoint or response field changed at all.
- [x] **Model change has a migration** — `74e2494dfabf`, five nullable columns, chained onto the single head, up/down/up verified. Autogenerate also proposed re-creating `ck_meal_recipe_scale`; that already exists in `c4f2a8b19d63` and is a SQLite-reflection false positive, so it is excluded with a comment saying so.
- [x] **Shopping-list quantities still derive from `ListItemSource`** — n/a, untouched.
- [x] **Every new query filters on `household_id`** — n/a: the operator commands are whole-server by design, like the usage gauges, and read no household content.
- [x] **Skill/prompt pack updated** — n/a, nothing an assistant drives changed.
- [x] **New 4xx strings say what to do instead** — no new 4xx. `EntitlementError` carries the same shape of sentence for the operator, e.g. refusing a reprice names the stored price and points at §6.

The export's column guard from #97 caught the five new columns immediately and they are now recorded as excluded with the reason: this deployment's bookkeeping about a household means nothing on the box it is moving to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
