### PR TITLE
Keep the app free of commerce, and prove it stays that way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,40 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 
 ## Unreleased
 
+### Changed
+
+- **The Apple review account is comped to the paid tier**
+  ([#100](https://github.com/marco308/meals/issues/100),
+  `planning/08-freemium.md` §6). `python -m app.provision` now puts the
+  household it makes on a permanent comp through `services/entitlements.grant`,
+  on creation and on every re-run, because an aged-out resubmission is exactly
+  when a lapsed entitlement would bite. A reviewer who meets a cap sees broken
+  functionality and files a 2.1 rejection rather than reading the reasoning. No
+  expiry (a dated comp is a rejection scheduled for whenever it passes) and no
+  price (nothing was paid, and a written price would make a later real purchase
+  refuse itself). On a server with no limits it is a column nothing reads.
+- **The App Store description no longer says "no subscription."** Not because
+  it was a call to action, but because it stops being true the day the hosted
+  tier opens, and a description contradicting the operator's own terms page is
+  worse than a missing selling point. The replacement says the parts that stay
+  true: the app is free, the software is free and open source, and you can run
+  it yourself. A unit test now lints the fenced blocks that actually ship, since
+  there is no iOS job in CI to catch it.
+- **Guideline 3.1.3 re-read and recorded** (`planning/08-freemium.md` §6). The
+  case is now numbered **3.1.3(f)** and names web hosting outright. The
+  external-link rules did loosen, but only for the **United States storefront**;
+  one binary and one set of metadata ship worldwide, so the strictest storefront
+  sets the rule and the conservative wording stands unchanged.
+
 ### Added
+
+- **Tests pinning that a cap can never become a wall.** `CommerceFreeTests`
+  in the iOS suite asserts that 402, 403 and 503 arrive as ordinary
+  `.server(status:detail:)` errors shown verbatim, and that **only** a 426 can
+  put the app behind `UpgradeRequiredView`, with the 426 case as the control so
+  the check cannot pass vacuously. This is also the answer to "what do the
+  builds already in the wild do with a 402": the same thing, because nothing
+  special-cases them and nothing ever did.
 
 - **Entitlements: one row says what a household is on and until when**
   ([#99](https://github.com/marco308/meals/issues/99),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,6 +266,24 @@ be recalled. The contract is therefore **additive-only**:
 - Keep the iOS models free of `String`-backed enums for server vocabularies
   (aisles, slots). A new aisle must never be a decode error.
 
+**The iPhone app carries no commerce, and that is a rule about sentences rather
+than about screens** (`planning/08-freemium.md` §6, issue #100). The listing
+rests on guideline 3.1.3(f), which exempts a free companion to a paid web tool
+only while there is "no purchasing inside the app, *or calls to action for
+purchase outside of the app*" — and Apple counts metadata as part of the app,
+so `ios/AppStore/metadata.md` is in scope too (a unit test lints the fenced
+blocks that actually ship). Three things follow. A billing refusal must stay an
+**ordinary inline error**: 402, 403 and 503 fall through `APIClient` to
+`.server(status:detail:)` and are shown verbatim, which is why every build
+already in the wild handles one correctly and why nothing may special-case them.
+**Only a 426 may blank the app** behind `UpgradeRequiredView`; a cap that did
+would read as broken functionality and invite the 2.1 rejection this app has
+already had once. And the server's refusal sentences have to be true on a
+self-hosted box, which is the tell that they point nowhere — `tests/unit/
+test_limits.py` asserts that for every one of them. The US storefront now
+permits calls to action (verified 2026-08-22, §6); one binary ships worldwide,
+so the strictest storefront still sets the rule.
+
 `app/client_gate.py` is the escape hatch for the rare change that can't be
 additive. The app sends `X-Meals-Client: ios/<version> (<build>)`; builds below
 `min_ios_build` get a 426 and a blocking upgrade screen. Two rules:

--- a/backend/app/provision.py
+++ b/backend/app/provision.py
@@ -19,9 +19,18 @@ the general answer to "closed server, one more household".
     docker exec -it <api-container> .venv/bin/python -m app.provision \\
         --email apple.review@example.com --password '…' --household 'Apple Review'
 
+The household is also **comped to the paid tier**, permanently, with no expiry
+(planning/08-freemium.md §6, issue #100). App Review has to be able to use the
+app, and a reviewer who meets a cap sees broken functionality and files a 2.1
+rejection rather than reading any of the reasoning behind it. On a server with
+no limits configured — every self-hosted one — the comp is a column nothing
+reads, so this costs nothing and is not worth a flag to turn off.
+
 Idempotent: run it again with a different password to reset that account's,
 which is what you want when a rejected submission has aged out the credentials
-in the review notes. It never touches any other household.
+in the review notes. Re-running also re-applies the comp, since an aged-out
+submission is exactly when an expired or revoked entitlement would bite. It
+never touches any other household.
 """
 
 import argparse
@@ -32,8 +41,10 @@ import sys
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from app import limits
 from app.database import SessionLocal
 from app.models import Household, User
+from app.services import entitlements
 from app.services.security import hash_password
 
 # Look-alikes off a screen, dropped in whole pairs so neither half can turn up:
@@ -48,6 +59,13 @@ PASSWORD_ALPHABET = "abcdefghjkmnpqrstuvwxyzACDEFGHJKLMNPQRSTUVWXYZ2345679"
 
 def _generate_password() -> str:
     return "-".join("".join(secrets.choice(PASSWORD_ALPHABET) for _ in range(5)) for _ in range(3))
+
+
+#: What the review household is put on, and why it never expires: a comp with a
+#: date on it is a rejection scheduled for whenever that date passes, probably
+#: during a resubmission nobody is watching.
+REVIEW_TIER = limits.PAID
+REVIEW_NOTE = "provisioned account: App Review must never meet a cap (08-freemium.md §6)"
 
 
 async def provision(
@@ -71,6 +89,7 @@ async def provision(
             # Deliberately no token revocation here: this is a rescue hatch, and
             # signing every device out mid-review would be its own small disaster.
             await db.commit()
+            await _comp(db, await db.get(Household, existing.household_id))
             return password, False
 
         household = Household(name=household_name)
@@ -90,7 +109,29 @@ async def provision(
         # means a reviewer meeting a 403 on a button the app still offers.
         household.lead_user_id = user.id
         await db.commit()
+        await _comp(db, household)
         return password, True
+
+
+async def _comp(db: AsyncSession, household: Household | None) -> None:
+    """Put the household on the paid tier for good.
+
+    Goes through `services/entitlements.grant` rather than setting the columns
+    here, so there is still exactly one place an entitlement changes and one
+    `entitlement.granted` line in the log. No price is passed: nothing was paid,
+    and writing one would put a number on a row that a real purchase would then
+    be refused for changing.
+    """
+    if household is None:  # deleted underneath us; nothing to comp
+        return
+    await entitlements.grant(
+        db,
+        household,
+        tier=REVIEW_TIER,
+        until=None,
+        source=entitlements.COMP,
+        note=REVIEW_NOTE,
+    )
 
 
 def main() -> None:
@@ -107,6 +148,7 @@ def main() -> None:
 
     print(f"{'created' if created else 'password reset for'} {args.email}")
     print(f"password: {password}")
+    print(f"tier: {REVIEW_TIER}, no expiry (so App Review never meets a cap)")
     if created:
         print(f"household: {args.household} (new and empty — it shares nothing with any other household)")
     print(

--- a/backend/tests/integration/test_provision.py
+++ b/backend/tests/integration/test_provision.py
@@ -7,8 +7,11 @@ shopping list.
 """
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
+from app import limits
+from app.models import Household
 from app.provision import (
     AMBIGUOUS_CHARACTERS,
     PASSWORD_ALPHABET,
@@ -112,6 +115,47 @@ class TestProvision:
 
         await provision("review@example.com", "s3cret-passphrase", "Review", "Apple Review", sessions)
         await sign_in(client, "review@example.com", "s3cret-passphrase")
+
+    async def test_the_account_is_comped_so_review_never_meets_a_cap(self, client, sessions, settings_override):
+        """planning/08-freemium.md §6: a reviewer who hits a cap sees broken
+        functionality and files a 2.1 rejection rather than reading why."""
+        settings_override(LIMITS_PROFILE="hosted", DEFAULT_HOUSEHOLD_TIER="free")
+        await provision("review@example.com", "s3cret-passphrase", "Review", "Apple Review", sessions)
+
+        async with sessions() as db:
+            household = (await db.execute(select(Household).where(Household.name == "Apple Review"))).scalars().one()
+        assert household.tier == "paid"
+        assert household.entitlement_source == "comp"
+        # No expiry: a dated comp is a rejection scheduled for whenever it passes.
+        assert household.paid_until is None
+        assert limits.effective_tier(household) == "paid"
+        # And nothing was priced, so a real purchase is not refused later for
+        # trying to change a number nobody paid.
+        assert household.price_pence is None
+
+    async def test_rerunning_re_applies_the_comp(self, client, sessions, settings_override):
+        """An aged-out submission is exactly when a revoked entitlement bites."""
+        settings_override(LIMITS_PROFILE="hosted", DEFAULT_HOUSEHOLD_TIER="free")
+        await provision("review@example.com", "first-passphrase", "Review", "Apple Review", sessions)
+        async with sessions() as db:
+            household = (await db.execute(select(Household).where(Household.name == "Apple Review"))).scalars().one()
+            household.tier = "free"
+            household.entitlement_source = None
+            await db.commit()
+
+        _, created = await provision("review@example.com", "second-passphrase", "Review", "Apple Review", sessions)
+        assert created is False
+        async with sessions() as db:
+            household = (await db.execute(select(Household).where(Household.name == "Apple Review"))).scalars().one()
+        assert household.tier == "paid"
+
+    async def test_a_comp_costs_nothing_on_a_server_with_no_limits(self, client, sessions):
+        """Every self-hosted instance: the tier column is one nothing reads."""
+        await provision("review@example.com", "s3cret-passphrase", "Review", "Apple Review", sessions)
+        async with sessions() as db:
+            household = (await db.execute(select(Household).where(Household.name == "Apple Review"))).scalars().one()
+        assert limits.effective_tier(household) == "paid"
+        assert limits.limits_for("paid") == limits.UNLIMITED_LIMITS
 
     async def test_generated_passwords_are_typeable_and_not_guessable(self):
         """It goes in App Review notes and gets retyped on a phone by someone

--- a/backend/tests/unit/test_app_store_metadata.py
+++ b/backend/tests/unit/test_app_store_metadata.py
@@ -1,0 +1,86 @@
+"""The App Store copy has to stay free of commerce (issue #100).
+
+`planning/08-freemium.md` §6 rests the whole listing on guideline 3.1.3(f),
+which exempts a free companion app to a paid web tool "provided there is no
+purchasing inside the app, or calls to action for purchase outside of the app".
+Apple treats an app's metadata as part of the app for that purpose, so the
+description and keywords are as much in scope as any screen.
+
+This is a lint on `ios/AppStore/metadata.md`, and it deliberately reads only the
+fenced blocks that are actually submitted — the prose around them explains the
+rule and has to be free to say the words.
+
+There is no iOS job in CI (macOS runners are billed per minute), so the copy
+that goes to Apple is checked here, in the suite that does run on every push.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+METADATA = Path(__file__).resolve().parents[3] / "ios" / "AppStore" / "metadata.md"
+
+#: Words that would either invite a 3.1.3 problem or stop being true the day the
+#: hosted tier opens. "Subscription" is on the list in both directions: as a
+#: pitch it breaks the exemption, and as a denial it becomes a description that
+#: contradicts the operator's own terms page.
+FORBIDDEN = (
+    "subscription",
+    "subscribe",
+    "upgrade",
+    "premium",
+    "pricing",
+    "per month",
+    "per year",
+    "/mo",
+    "/yr",
+    "£",
+    "$",
+    "€",
+    "paid plan",
+    "free tier",
+    "in-app purchase",
+)
+
+#: The sections whose fenced blocks are submitted verbatim.
+SUBMITTED = ("Name", "Subtitle", "Promotional text", "Description", "Keywords", "What's New")
+
+
+def _blocks() -> dict[str, str]:
+    """The fenced code block under each submitted section."""
+    text = METADATA.read_text(encoding="utf-8")
+    sections = re.split(r"^## ", text, flags=re.MULTILINE)[1:]
+    blocks = {}
+    for section in sections:
+        heading = section.split("\n", 1)[0]
+        name = heading.split("—")[0].strip()
+        fenced = re.search(r"```\n(.*?)```", section, re.DOTALL)
+        if fenced:
+            blocks[name] = fenced.group(1)
+    return blocks
+
+
+def test_the_file_is_still_shaped_the_way_this_test_reads_it():
+    """A rename that quietly emptied the check would be worse than no check."""
+    blocks = _blocks()
+    missing = [name for name in SUBMITTED if name not in blocks]
+    assert not missing, f"no fenced block found for {missing}; this lint is reading nothing for those"
+
+
+@pytest.mark.parametrize("section", SUBMITTED)
+def test_submitted_copy_mentions_no_commerce(section):
+    body = _blocks()[section].lower()
+    for word in FORBIDDEN:
+        assert word not in body, (
+            f"the App Store {section} says {word!r}. planning/08-freemium.md §6: the listing relies on "
+            "guideline 3.1.3(f), which needs no purchasing in the app and no call to action for "
+            "purchase outside it, and Apple counts metadata as part of the app."
+        )
+
+
+def test_the_prose_is_free_to_explain_the_rule():
+    """Guarding the guard: the commentary around the blocks has to be able to
+    use the words, or the rule could not be written down next to the copy."""
+    text = METADATA.read_text(encoding="utf-8").lower()
+    assert "subscription" in text, "the reasoning for this rule should live beside the copy it constrains"

--- a/ios/AppStore/metadata.md
+++ b/ios/AppStore/metadata.md
@@ -53,14 +53,27 @@ Plan meals as options rather than a rigid Mon–Sun grid, and get one aisle-sort
 
 ## Description — 4000 characters max
 
+**Nothing here may mention a subscription, a price, an upgrade or a hosted
+plan** — not even to deny one (issue #100, planning/08-freemium.md §6). The
+exemption this listing relies on, guideline 3.1.3(f), is conditional on there
+being no call to action for purchase outside the app, and the metadata is part
+of the app for that purpose.
+
+Saying "no subscription" is not a call to action, but it was removed anyway for
+a duller reason: it stops being true the day the hosted tier opens, and a
+description that contradicts the operator's own terms page is a worse problem
+than a missing selling point. What replaced it says the same thing about the
+part that will always be true — the app is free, the software is free, and you
+can run it yourself.
+
 ```
 Meals is a meal planner for people who don't want a diary. Pick a handful of
 options for the week, and decide what you actually fancy on the night.
 
-Everything runs on a server you host yourself. There is no company account, no
-subscription and no cloud in the middle: your recipes and your shopping list
-live on your machine, and the app talks to it directly. The server is free and
-open source (AGPL), and starting one is a single command.
+Everything runs on a server you point the app at, and there is no cloud in the
+middle: your recipes and your shopping list live on that server and the app
+talks to it directly. The app is free and asks for nothing. The server is free
+and open source too (AGPL), and starting your own is a single command.
 
 A PLAN, NOT A CALENDAR
 Add four or five meals as this week's options, grouped into dinners and

--- a/ios/Meals/MealsTests/CommerceFreeTests.swift
+++ b/ios/Meals/MealsTests/CommerceFreeTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+@testable import Meals
+
+/// The app must never become a shop (issue #100, planning/08-freemium.md §6).
+///
+/// Guideline 3.1.3(f) exempts a free app acting as a companion to a paid web
+/// tool "provided there is no purchasing inside the app, or calls to action for
+/// purchase outside of the app". The first half is easy and permanent. The
+/// second half is a property of every sentence the *server* can make this app
+/// render, and of how the app chooses to render it.
+///
+/// So two things are pinned here, and both are about the app's behaviour rather
+/// than about any particular wording:
+///
+/// 1. A billing refusal is an ordinary error, shown verbatim and inline. It is
+///    not special-cased, which is exactly why every build already in the wild
+///    handles one correctly: 402 and 403 fall through to `.server`, the same as
+///    a 409 always has.
+/// 2. Only a 426 can put the app behind `UpgradeRequiredView`. A cap that
+///    blanked the app would read as broken functionality and invite the 2.1
+///    rejection this app has already had once.
+final class CommerceFreeTests: XCTestCase {
+    private func client(protocolClass: AnyClass) -> APIClient {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [protocolClass]
+        return APIClient(
+            baseURL: URL(string: "http://testserver")!,
+            token: "meals_test-token",
+            session: URLSession(configuration: config)
+        )
+    }
+
+    /// The exact sentence the server sends for a tier cap. Not asserted on for
+    /// its wording — that is the server's test — but used here so what the app
+    /// renders is a real one rather than a convenient invention.
+    private static let capDetail = """
+        This server's free tier allows 50 recipes per household, and this household has 50. \
+        Nothing has been removed and everything already here still works, so this only stops it growing. \
+        Delete a recipe nobody cooks (DELETE /recipes/{recipe_id}) to make room for this one.
+        """
+
+    private static let ceilingDetail = """
+        This server allows at most 5,000 recipes per household, and this household has 5,000. \
+        No tier on this server goes beyond that, so it is not something this household can change — \
+        going further needs a word with whoever runs the server.
+        """
+
+    func testTierCapIsAnOrdinaryErrorShownVerbatim() async {
+        StubProtocol.handler = { _ in
+            (402, Data(#"{"detail": "\#(Self.capDetail)", "resource": "recipes", "limit": 50}"#.utf8))
+        }
+        do {
+            _ = try await client(protocolClass: StubProtocol.self).fetchAisles()
+            XCTFail("expected an error")
+        } catch let error as APIError {
+            // Not .upgradeRequired, and not a case of its own: the app has no
+            // idea this was about money, which is the point.
+            XCTAssertEqual(error, .server(status: 402, detail: Self.capDetail))
+            XCTAssertEqual(error.errorDescription, Self.capDetail)
+        } catch {
+            XCTFail("unexpected error type: \(error)")
+        }
+    }
+
+    func testFairUseCeilingIsTheSame() async {
+        StubProtocol.handler = { _ in
+            (403, Data(#"{"detail": "\#(Self.ceilingDetail)", "resource": "recipes", "limit": 5000}"#.utf8))
+        }
+        do {
+            _ = try await client(protocolClass: StubProtocol.self).fetchAisles()
+            XCTFail("expected an error")
+        } catch let error as APIError {
+            XCTAssertEqual(error, .server(status: 403, detail: Self.ceilingDetail))
+        } catch {
+            XCTFail("unexpected error type: \(error)")
+        }
+    }
+
+    func testAFullServerIsAlsoJustAnError() async {
+        // MAX_HOUSEHOLDS / MAX_USERS answer 503 (issue #96). Nothing about it is
+        // a purchase either, so it must not be special-cased into one.
+        let detail = "This server is full: it holds at most 25 households and has 25."
+        StubProtocol.handler = { _ in (503, Data(#"{"detail": "\#(detail)"}"#.utf8)) }
+        do {
+            _ = try await client(protocolClass: StubProtocol.self).fetchAisles()
+            XCTFail("expected an error")
+        } catch let error as APIError {
+            XCTAssertEqual(error, .server(status: 503, detail: detail))
+        } catch {
+            XCTFail("unexpected error type: \(error)")
+        }
+    }
+
+    /// The blocker is reachable from exactly one status code. If a future change
+    /// routes anything else into `Session.upgrade`, this fails.
+    func testOnlyAnUpgradeRequiredResponseCanBlankTheApp() async {
+        for status in [402, 403, 409, 503] {
+            var blocked = false
+            let observer = NotificationCenter.default.addObserver(
+                forName: .mealsUpgradeRequired, object: nil, queue: nil
+            ) { _ in blocked = true }
+            defer { NotificationCenter.default.removeObserver(observer) }
+
+            StubProtocol.handler = { _ in (status, Data(#"{"detail": "nope"}"#.utf8)) }
+            _ = try? await client(protocolClass: StubProtocol.self).fetchAisles()
+            XCTAssertFalse(blocked, "status \(status) must not put the app behind the upgrade screen")
+        }
+    }
+
+    func testAnUpgradeRequiredResponseStillDoes() async {
+        // The control: the one status that is allowed to blank the app.
+        var blocked = false
+        let observer = NotificationCenter.default.addObserver(
+            forName: .mealsUpgradeRequired, object: nil, queue: nil
+        ) { _ in blocked = true }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        StubProtocol.handler = { _ in (426, Data(#"{"detail": "update to keep using Meals"}"#.utf8)) }
+        _ = try? await client(protocolClass: StubProtocol.self).fetchAisles()
+        XCTAssertTrue(blocked)
+    }
+}

--- a/planning/08-freemium.md
+++ b/planning/08-freemium.md
@@ -187,11 +187,42 @@ of commerce entirely. StoreKit can be added later if hosted ever grows enough
 for the gap to matter, and Apple explicitly allows honouring purchases made
 elsewhere once you do.
 
-One caveat that is deliberately not resolved here: the external-link rules
-moved during 2025 in the US and the EU, so link-outs are less forbidden than
-they were. **Re-read the live guideline text before submitting the build that
-first carries cap errors**, and keep the conservative version above unless it
-has clearly loosened.
+**Re-read verified 2026-08-22** (issue #100). The caveat above was that the
+external-link rules moved during 2025 and the conservative version should hold
+unless they had clearly loosened. They have loosened, but only for one
+storefront, so it holds.
+
+The case this rests on is now numbered **3.1.3(f)**, and it names web hosting
+outright:
+
+> Free apps acting as a stand-alone companion to a paid web based tool (i.e.
+> VoIP, Cloud Storage, Email Services, Web Hosting) do not need to use in-app
+> purchase, provided there is no purchasing inside the app, or calls to action
+> for purchase outside of the app.
+
+What changed is the preamble to 3.1.3, which now reads "Apps in this section
+cannot, within the app, encourage users to use a purchasing method other than
+in-app purchase, **except for apps on the United States storefront** and as set
+forth in 3.1.1(a) and 3.1.3(a)"; 3.1.1(a) says the same from the other side, that
+the prohibition on buttons, external links and other calls to action applies "in
+all other storefronts, except for the United States storefront, where this
+prohibition does not apply".
+
+So a call to action would be permitted on the US storefront and forbidden
+everywhere else. This app ships worldwide from one binary and one set of
+metadata, which means the strictest storefront sets the rule: **no change, and
+the wording above stands.** If that ever stops being true it will be because
+the app ships storefront-specific copy, which is its own decision and a much
+larger one than a link.
+
+Two things follow for whoever reads this next:
+
+- The exemption is conditional on *both* halves, and the second half is the one
+  a cap error can break. "No purchasing inside the app" is easy; "no calls to
+  action for purchase outside of the app" is a property of every sentence the
+  server can make the app render.
+- Re-read it again anyway before the first submission that carries cap errors.
+  This paragraph is a snapshot, and the last one aged in under a year.
 
 ## 7. What still has to be true before taking money
 


### PR DESCRIPTION
## What and why

Closes [#100](https://github.com/marco308/meals/issues/100). The listing rests on guideline **3.1.3(f)**, which exempts a free companion to a paid web tool only while there is no purchasing inside the app *and no call to action for purchase outside it*. The first half is permanent. The second is a property of every sentence the server can make the app render, so it needs tests rather than a note.

### The audit the issue asked for

**"Check what the builds already in the wild do with a 402 and a 403."** They already do the right thing, by accident of good design: `APIClient` special-cases only 401 and 426 and lets everything else fall through to `.server(status:detail:)`, shown verbatim like any other 4xx. So a cap error renders inline on builds that predate all of this — and since nothing can be recalled from the App Store, that is worth pinning rather than rediscovering. `CommerceFreeTests` asserts 402, 403 and 503 all arrive that way, and that **only** a 426 can reach `UpgradeRequiredView`, with the 426 case as a control so the check cannot pass vacuously.

I also swept the app's own strings: every "premium" is the ingredient value tier (Q17 — whether the posh parmesan is worth it), every "upgrade" is the build gate. Nothing to change.

### The one thing that was actually wrong

**The App Store description said "no subscription."** Not a call to action, but it stops being true the day the hosted tier opens, and a description contradicting the operator's own terms page is a worse problem than a missing selling point. It now says the parts that stay true. A unit test lints the fenced blocks that actually ship — there is no iOS job in CI, and marketing copy gets edited by humans months later.

### The guideline re-read, recorded

§6 said to re-read the live text and keep the conservative wording "unless it has clearly loosened". Done today and written into §6 with the date. It **has** loosened, but only for the **United States storefront** — 3.1.3's preamble and 3.1.1(a) now both carve the US out of the prohibition on calls to action. One binary and one set of metadata ship worldwide, so the strictest storefront sets the rule and nothing changes. The case is also renumbered to 3.1.3(f) and now names web hosting outright, which is a better fit than when this was written.

### Review account

Comped to the paid tier permanently, on creation *and* on every re-run (an aged-out resubmission is exactly when a lapsed entitlement bites). Through `entitlements.grant`, so there is still one place an entitlement changes. No expiry — a dated comp is a rejection scheduled for whenever it passes — and no price, since nothing was paid and writing one would make a later real purchase refuse itself.

## Verification

- **iOS: 146 tests, 0 failures**, including the 5 new ones. Run locally, as `make ios-test` must be — CI has no macOS runner.
- **Backend: 825 tests**, lint clean.

## Checklist

- [x] **API contract stayed additive** — no server behaviour changed at all; this is tests, metadata, one provisioning change and a planning doc.
- [x] **Model change has a migration** — n/a.
- [x] **Shopping-list quantities still derive from `ListItemSource`** — n/a.
- [x] **Every new query filters on `household_id`** — n/a.
- [x] **Skill/prompt pack updated** — n/a.
- [x] **New 4xx strings say what to do instead** — no new ones. The existing cap sentences were already asserted to point nowhere and to read true on a self-hosted box (`tests/unit/test_limits.py`), which is the property this issue depends on.

**Not bumping `CFBundleVersion`.** No build goes to TestFlight from this PR, so there is no ledger row to add. The next upload carries these tests along with whatever else it carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
