### PR TITLE
Turn a payment into an entitlement, exactly once

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,3 +46,15 @@ AUTH_RATE_LIMIT_PER_MINUTE=10
 # send the two dunning emails from cron with `python -m app.dunning`.
 #ENTITLEMENT_GRACE_DAYS=14
 #DUNNING_WARN_DAYS=7
+
+# Billing webhook. Off unless BOTH of these are set, and off means the route
+# does not exist (404), not that it exists and refuses — a self-hosted instance
+# must not be able to acquire billing by accident. BILLING_PROCESSOR is 'paddle'
+# or 'lemonsqueezy'; both are merchants of record, which is the point, since EU
+# B2C digital-services VAT applies from the first sale. Point the processor's
+# webhook at POST /billing/webhook and put {"household_id": "<uuid>"} in the
+# checkout's custom data, which is how a payment finds a household.
+# Alert on: increase(meals_billing_webhooks_total{outcome=~"orphan|refused|bad_signature|unsigned|stale|unreadable"}[1h]) > 0
+#BILLING_PROCESSOR=paddle
+#BILLING_WEBHOOK_SECRET=
+#BILLING_SIGNATURE_TOLERANCE_SECONDS=300

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,36 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 
 ## Unreleased
 
+### Added
+
+- **The billing webhook** ([#99](https://github.com/marco308/meals/issues/99)),
+  and it **ships inert**: with `BILLING_PROCESSOR` unset the route does not
+  exist at all (404, the posture `/metrics` takes without a token), because a
+  self-hosted instance has no billing and must not be able to acquire one by
+  accident. **One migration**, a new `billing_events` table.
+- **Paddle and Lemon Squeezy are both supported**, selected by
+  `BILLING_PROCESSOR`. Which merchant of record to use is a commercial decision
+  that had not been made, and both adapters together cost about forty lines,
+  which is cheaper than guessing and rewriting. Both formats were read from the
+  live documentation: Paddle signs `"{ts}:{body}"` and sends `Paddle-Signature`,
+  Lemon Squeezy signs the raw body and sends `X-Signature`.
+- **A retry cannot grant a second year.** Every event is recorded once in a
+  ledger keyed on `(processor, event_id)`; Lemon Squeezy sends no event id, so
+  its key is a digest of the body, which makes an identical retry land on the
+  same row. Processors retry on any non-2xx, so a blip between granting and
+  answering 200 is the expected case rather than a rare one.
+- **Nothing fails quietly**, which is the point of the whole design: every
+  request ends as exactly one counted, logged, recorded outcome, including the
+  ones that decide to do nothing. Deterministic failures — a duplicate, an event
+  naming no household, one the entitlement layer refused — answer 200 so the
+  processor stops retrying something that will fail identically, and are counted
+  for the alert instead. Only genuinely transient failures 500 and are retried.
+  Alert on `increase(meals_billing_webhooks_total{outcome=~"orphan|refused|bad_signature|unsigned|stale|unreadable"}[1h]) > 0`.
+- A cancellation is deliberately **not** a revocation: Lemon Squeezy's
+  `subscription_cancelled` starts a grace period that runs to the paid-through
+  date, and cutting the entitlement short there would take away days somebody
+  paid for. The entitlement expires on its own.
+
 ### Changed
 
 - **The Apple review account is comped to the paid tier**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,8 +207,24 @@ instrumentation a new feature usually needs.
   operator command on the box, like `app/provision.py`, never an endpoint), and
   `python -m app.dunning` from cron sends the two emails, each marked once so it
   never sends a third and never marked on a relay failure so it retries.
-  **There is no billing webhook**: no merchant of record has been chosen (§7),
-  and #99 says decide that before writing it.
+- **The billing webhook is off unless configured, and its failures are loud**
+  (`services/billing.py`, `POST /billing/webhook`). Unset `BILLING_PROCESSOR`
+  and the route **404s** rather than existing and refusing — a self-hosted
+  instance must not be able to acquire billing by accident, the same posture
+  `/metrics` takes without a token. The signature *is* the authentication
+  (the caller has never heard of this app's accounts), verified constant-time
+  against the raw body. **Both Paddle and Lemon Squeezy are supported and the
+  choice is a setting**, because which merchant of record to use is a
+  commercial decision that had not been made; the adapters cost about forty
+  lines and remove the need to guess. `billing_events` is the idempotency
+  ledger and the reason a retry cannot grant a second year — processors retry
+  on any non-2xx, so the blip between granting and answering 200 is the
+  expected case, not a rare one. **Deterministic failures answer 200 on
+  purpose** (a duplicate, an unknown household, an entitlement refusal):
+  retrying would fail identically, so they are counted and alerted on instead,
+  which is the whole point — `increase(meals_billing_webhooks_total{outcome=~
+  "orphan|refused|bad_signature|unsigned|stale|unreadable"}[1h]) > 0`. Only
+  genuinely transient failures are left to 500 and be retried.
 - **Instance ceilings are the other axis** (`MAX_HOUSEHOLDS`, `MAX_USERS`, at the
   bottom of `app/limits.py`). They bound how many households the *box* holds
   rather than what one costs, so no tier reaches them and none of the above

--- a/README.md
+++ b/README.md
@@ -379,7 +379,16 @@ after. Lapsing is derived rather than written back, so it only ever stops a
 household *growing*: nothing is deleted, everything already there stays
 readable, the plan stays usable, the shopping list keeps working and the export
 stays free. None of it applies to a household with no expiry, which is every
-self-hosted one. Being over a
+self-hosted one.
+
+Payment itself is a webhook, and it is **off unless a deployment sets both
+`BILLING_PROCESSOR` and `BILLING_WEBHOOK_SECRET`** — off meaning the route does
+not exist, not that it exists and refuses. Paddle and Lemon Squeezy are both
+supported because both are merchants of record and handle EU VAT; which one is
+a setting, not a rewrite. Every webhook is signature-verified, recorded once in
+a ledger so a retry cannot grant a second year, and counted by outcome, because
+the expensive failure here is the quiet one: somebody paying and not being
+credited. Being over a
 limit blocks only the writes that grow a household; nothing is deleted, nothing
 becomes unreadable, and the shopping list is exempt in every case because the
 iPhone app drains its offline queue through it. Whatever you set, `GET /limits`

--- a/backend/alembic/versions/508d35134cdc_add_the_billing_event_ledger.py
+++ b/backend/alembic/versions/508d35134cdc_add_the_billing_event_ledger.py
@@ -1,0 +1,59 @@
+"""add the billing event ledger
+
+Revision ID: 508d35134cdc
+Revises: 74e2494dfabf
+Create Date: 2026-08-22 23:58:00.000000
+
+Issue #99 / planning/08-freemium.md §2. One row per webhook the processor sent,
+written before it is acted on.
+
+This table is what makes the webhook idempotent, and idempotence is what stops a
+retry granting a second year. Processors retry on any non-2xx — Lemon Squeezy
+three times with backoff, Paddle for longer — so a blip between "entitlement
+granted" and "200 returned" is not a rare case, it is the expected one.
+
+`(processor, event_id)` is unique because that pair is the identity of an event.
+Paddle sends an `event_id`; Lemon Squeezy sends none, so the id stored for it is
+a digest of the raw body, which makes an identical retry land on the same row.
+
+`outcome` and `detail` are kept for the same reason the cooked history is: when
+somebody asks why their household expired on a date nobody chose, this is the
+answer. It stays small — one row per payment event per household per year — so
+there is nothing to prune.
+
+New table only, so there is nothing for the outgoing container to trip over
+during a start-first rollout.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '508d35134cdc'
+down_revision: Union[str, Sequence[str], None] = '74e2494dfabf'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table('billing_events',
+    sa.Column('id', sa.Uuid(), nullable=False),
+    sa.Column('processor', sa.String(length=40), nullable=False),
+    sa.Column('event_id', sa.String(length=120), nullable=False),
+    sa.Column('event_type', sa.String(length=80), nullable=False),
+    sa.Column('outcome', sa.String(length=20), nullable=False),
+    sa.Column('household_id', sa.Uuid(), nullable=True),
+    sa.Column('detail', sa.String(length=300), nullable=True),
+    sa.Column('received_at', sa.DateTime(timezone=True), nullable=False),
+    sa.ForeignKeyConstraint(['household_id'], ['households.id'], ondelete='SET NULL'),
+    sa.PrimaryKeyConstraint('id'),
+    sa.UniqueConstraint('processor', 'event_id', name='uq_billing_event')
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table('billing_events')

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -115,6 +115,32 @@ class Settings(BaseSettings):
     entitlement_grace_days: int = 14
     dunning_warn_days: int = 7
 
+    # Billing webhook (app/services/billing.py, planning/08-freemium.md §2).
+    # **Off unless both of these are set**, the same shape SMTP has: a
+    # self-hosted instance has no billing and must not be able to acquire one by
+    # accident, so with BILLING_PROCESSOR unset the endpoint does not exist at
+    # all (404, exactly like /metrics with no token).
+    #
+    #   BILLING_PROCESSOR   'paddle' or 'lemonsqueezy'. Both are merchants of
+    #                       record, which is the point (§7): they handle EU B2C
+    #                       digital-services VAT, which applies from the first
+    #                       sale regardless of the UK threshold.
+    #   BILLING_WEBHOOK_SECRET  the signing secret from that processor's
+    #                       dashboard. Every request is verified against it.
+    #   BILLING_SIGNATURE_TOLERANCE_SECONDS  how old a signed timestamp may be
+    #                       (Paddle only; Lemon Squeezy does not sign one).
+    #                       Paddle's SDKs default to 5s, which is tight enough
+    #                       that one slow hop loses a payment; replay is already
+    #                       prevented by the event ledger, so this is generous
+    #                       on purpose.
+    billing_processor: str | None = None
+    billing_webhook_secret: str | None = None
+    billing_signature_tolerance_seconds: int = 300
+
+    @property
+    def billing_configured(self) -> bool:
+        return bool(self.billing_processor and self.billing_webhook_secret)
+
     # Timeout for fetching external recipe pages during ingestion.
     recipe_fetch_timeout_seconds: float = 15.0
     # And a ceiling on how much of one we'll read (issue #55). The URL is the

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,19 @@ from fastapi.staticfiles import StaticFiles
 from app import client_gate, limits, mcp_mount, metrics, observability
 from app.config import get_settings
 from app.observability import log_event
-from app.routers import auth, household, ingredients, meals, pages, plans, recipes, shopping, skill, supermarkets
+from app.routers import (
+    auth,
+    billing,
+    household,
+    ingredients,
+    meals,
+    pages,
+    plans,
+    recipes,
+    shopping,
+    skill,
+    supermarkets,
+)
 from app.routers import limits as limits_router
 from app.routers.skill import base_url, playbook_version
 
@@ -151,6 +163,7 @@ app.include_router(skill.router)
 app.include_router(pages.router)
 app.include_router(limits_router.router)
 app.include_router(household.router)
+app.include_router(billing.router)
 
 # The web client is served by the API itself so it is always same-origin with
 # the endpoints it calls — no CORS, no second host to deploy or certify. Plain

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -90,6 +90,27 @@ _CEILING_GAUGES: tuple[tuple[Gauge, str], ...] = (
 )
 
 
+# Billing webhooks, by what this server made of each one (app/services/billing.py).
+# This exists because the expensive failure is the *quiet* one: a webhook that
+# is refused, orphaned or never verified means somebody paid and was not
+# credited, and nobody finds that by reading logs. Alert on it:
+#
+#   increase(meals_billing_webhooks_total{outcome=~"orphan|refused|bad_signature|unsigned|stale|unreadable"}[1h]) > 0
+#
+# `granted` and `duplicate` are the healthy outcomes; `duplicate` is a retry
+# doing its job, not a problem.
+_BILLING_WEBHOOKS = Counter(
+    "meals_billing_webhooks_total",
+    "Billing webhooks received, by outcome.",
+    labelnames=("outcome",),
+    registry=registry,
+)
+
+
+def count_billing_webhook(outcome: str) -> None:
+    _BILLING_WEBHOOKS.labels(outcome=outcome).inc()
+
+
 def observe_request(method: str, route: str, status: int, client_platform: str | None, duration_seconds: float) -> None:
     _HTTP_REQUESTS.labels(
         method=method, route=route, status=str(status), client_platform=client_platform or "none"

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,3 +1,4 @@
+from app.models.billing import BillingEvent
 from app.models.catalog import Ingredient, Recipe, RecipeIngredient
 from app.models.planning import CookedEvent, Meal, MealIngredient, MealRecipe, Plan, PlanMeal
 from app.models.shopping import ListItem, ListItemSource, ShoppingList, Supermarket
@@ -5,6 +6,7 @@ from app.models.users import AuthToken, Household, HouseholdInvite, User
 
 __all__ = [
     "AuthToken",
+    "BillingEvent",
     "CookedEvent",
     "Household",
     "HouseholdInvite",

--- a/backend/app/models/billing.py
+++ b/backend/app/models/billing.py
@@ -1,0 +1,46 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String, UniqueConstraint, Uuid
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+from app.models.users import utcnow
+
+
+class BillingEvent(Base):
+    """One webhook the processor sent, recorded before it is acted on.
+
+    This is the idempotency ledger, and it is the reason a retried webhook
+    cannot grant a second year. Processors retry on any non-2xx (Lemon Squeezy
+    three times with backoff, Paddle for longer), and a network blip between
+    "entitlement granted" and "200 returned" is exactly the case that would
+    otherwise double-count.
+
+    Kept rather than pruned: when somebody asks why their household expired on a
+    date nobody chose, this table is the answer, and it is small — one row per
+    payment event per household per year.
+    """
+
+    __tablename__ = "billing_events"
+    __table_args__ = (UniqueConstraint("processor", "event_id", name="uq_billing_event"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    processor: Mapped[str] = mapped_column(String(40))
+    #: The processor's own id where it sends one (Paddle's `event_id`), and a
+    #: digest of the raw body where it does not (Lemon Squeezy sends no id, so
+    #: an identical retry hashes the same and is caught the same way).
+    event_id: Mapped[str] = mapped_column(String(120))
+    #: What the processor called it, kept verbatim for anyone reading this back.
+    event_type: Mapped[str] = mapped_column(String(80))
+    #: What this server made of it: granted | renewed | revoked | ignored |
+    #: orphan | refused. Not an enum, for the same reason no other vocabulary
+    #: here is one.
+    outcome: Mapped[str] = mapped_column(String(20))
+    household_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("households.id", ondelete="SET NULL"), default=None
+    )
+    #: Why, when the outcome was not a clean one. This is what an operator woken
+    #: by the alert actually reads.
+    detail: Mapped[str | None] = mapped_column(String(300), default=None)
+    received_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utcnow)

--- a/backend/app/routers/billing.py
+++ b/backend/app/routers/billing.py
@@ -1,0 +1,67 @@
+"""The processor's end of the money, and nothing else.
+
+`POST /billing/webhook` exists only on a deployment that has set
+`BILLING_PROCESSOR` and `BILLING_WEBHOOK_SECRET`. Everywhere else it answers
+404, which is the same posture `/metrics` takes without a token and the same
+default SMTP has: a self-hosted instance has no billing, and "off" should mean
+the door is not there rather than that it is there and locked.
+
+There is no authentication in the usual sense. The sender is a machine that has
+never heard of this app's accounts, so the signature *is* the authentication,
+and `services/billing.py` refuses anything that does not carry a good one.
+"""
+
+import json
+
+from fastapi import APIRouter, HTTPException, Request
+
+from app.config import get_settings
+from app.deps import DbSession
+from app.services import billing
+
+router = APIRouter(prefix="/billing", tags=["meta"])
+
+
+@router.post("/webhook", include_in_schema=False)
+async def webhook(request: Request, db: DbSession) -> dict:
+    """Turn a payment into an entitlement, exactly once.
+
+    Out of the OpenAPI schema on purpose: `/docs` is for API consumers and AIs,
+    and this endpoint has exactly one caller, which was configured by hand.
+
+    On the status codes, which decide whether the processor tries again:
+
+    - **401/400** for a signature that does not verify or a body that cannot be
+      read. Both are worth telling the sender rather than swallowing.
+    - **200** for anything understood, *including* the ones that did nothing:
+      a duplicate, an event we have no opinion about, one naming no household,
+      and one the entitlement layer refused. All of those are deterministic, so
+      retrying would fail identically and only add noise. The last two mean
+      somebody may have paid and not been credited, so they are counted and
+      alerted on rather than retried.
+    - **500** is left to happen for anything genuinely transient (the database
+      being down mid-deploy), because that is the case a retry does fix.
+    """
+    if not get_settings().billing_configured:
+        # Indistinguishable from the route not existing, because on almost every
+        # deployment it does not.
+        raise HTTPException(status_code=404, detail="Not Found")
+
+    raw = await request.body()
+    try:
+        payload = json.loads(raw)
+    except ValueError:
+        billing.count("unreadable")
+        raise HTTPException(status_code=400, detail="body is not JSON") from None
+    if not isinstance(payload, dict):
+        billing.count("unreadable")
+        raise HTTPException(status_code=400, detail="body is not a JSON object")
+
+    try:
+        outcome = await billing.handle(db, raw, dict(request.headers), payload)
+    except billing.BillingError as exc:
+        # Counted here rather than in the service: these never reach the ledger,
+        # and they are exactly the failures that would otherwise be silent.
+        billing.count(exc.outcome)
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+    return {"outcome": outcome}

--- a/backend/app/services/billing.py
+++ b/backend/app/services/billing.py
@@ -1,0 +1,347 @@
+"""The billing webhook: a payment becoming an entitlement, exactly once.
+
+Issue #99, planning/08-freemium.md §2. Two things shape every line of it.
+
+**It ships inert.** With `BILLING_PROCESSOR` unset the route does not exist —
+404, the same posture `/metrics` has without a token. A self-hosted instance has
+no billing and must not be able to acquire one by accident, and "off" here means
+"not reachable", not "reachable and refuses".
+
+**Silent failure is how you give away a year for free.** So every request ends
+in exactly one recorded outcome, on a counter as well as in the log, and the
+alert lives on that counter rather than on somebody reading logs. The one
+failure mode this module refuses to have is the quiet one.
+
+Which processor, and why both are here
+--------------------------------------
+
+§7 requires a **merchant of record** rather than raw Stripe: EU B2C
+digital-services VAT applies from the first sale regardless of the UK threshold,
+and Paddle and Lemon Squeezy both handle it for roughly 5%, which is cheaper
+than the problem. Which of the two is a commercial decision that has not been
+made, so both adapters are here and `BILLING_PROCESSOR` picks one. That costs
+about forty lines and removes the need to guess; the alternative was writing
+this against one of them and rewriting it if the other won.
+
+Both were read from the live documentation on 2026-08-22:
+
+- **Paddle** signs `"{ts}:{raw body}"` with HMAC-SHA256, hex, and sends it as
+  `Paddle-Signature: ts=<unix>;h1=<hex>`. The payload carries `event_id`,
+  `event_type` and `data`.
+- **Lemon Squeezy** signs the raw body with HMAC-SHA256, hex, and sends it as
+  `X-Signature`, with the event name in `X-Event-Name` and again in
+  `meta.event_name`. It sends **no event id**, so the ledger key is a digest of
+  the body — an identical retry hashes identically, which is exactly what the
+  key is for.
+
+The linkage to a household is `custom_data.household_id`, set on the checkout.
+Both processors pass custom data through to the webhook; Paddle puts it on
+`data`, Lemon Squeezy on `meta`.
+"""
+
+import hashlib
+import hmac
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import limits, metrics
+from app.config import get_settings
+from app.models import BillingEvent, Household
+from app.observability import log_event
+from app.services import entitlements
+
+#: Sentinel so `_record` can tell "no household" from "not specified".
+_UNSET: Any = object()
+
+PADDLE = "paddle"
+LEMONSQUEEZY = "lemonsqueezy"
+PROCESSORS = (PADDLE, LEMONSQUEEZY)
+
+#: What this server made of a webhook. Every request ends as exactly one of
+#: these, and every one of them is counted.
+GRANTED = "granted"  # a payment became (or renewed) an entitlement
+REVOKED = "revoked"  # the subscription ended and the entitlement went with it
+IGNORED = "ignored"  # a real event this server has no opinion about
+DUPLICATE = "duplicate"  # already in the ledger; deliberately not re-applied
+ORPHAN = "orphan"  # verified and understood, but names no household here
+REFUSED = "refused"  # understood, but applying it would lose something
+
+
+class BillingError(Exception):
+    """A request that cannot be trusted or cannot be read.
+
+    Carries the status the endpoint should answer with, because the difference
+    matters to the sender: 401 says "your secret and mine disagree", 400 says
+    "I could not read this", and both are worth telling a processor rather than
+    swallowing.
+    """
+
+    def __init__(self, detail: str, *, status_code: int, outcome: str) -> None:
+        super().__init__(detail)
+        self.detail = detail
+        self.status_code = status_code
+        self.outcome = outcome
+
+
+@dataclass(frozen=True)
+class Incoming:
+    """One webhook, normalised. `action` is this server's vocabulary, not the
+    processor's, so `apply` never has to know which one sent it."""
+
+    processor: str
+    event_id: str
+    event_type: str  # verbatim, as the processor named it
+    action: str  # grant | revoke | ignore
+    household_id: uuid.UUID | None
+    renews_at: datetime | None
+
+
+# --------------------------------------------------------------- verification
+
+
+def verify(raw_body: bytes, headers: dict[str, str], *, now: datetime | None = None) -> None:
+    """Refuse anything not signed with this deployment's secret.
+
+    The signature is the whole of the authentication here: there is no bearer
+    token, because the sender is a machine that has never heard of this app's
+    accounts. Both comparisons are constant-time.
+    """
+    settings = get_settings()
+    secret = (settings.billing_webhook_secret or "").encode()
+    processor = settings.billing_processor
+    lowered = {name.lower(): value for name, value in headers.items()}
+
+    if processor == PADDLE:
+        header = lowered.get("paddle-signature", "")
+        parts = dict(part.split("=", 1) for part in header.split(";") if "=" in part)
+        timestamp, provided = parts.get("ts", ""), parts.get("h1", "")
+        if not timestamp or not provided:
+            raise BillingError("missing or malformed Paddle-Signature header", status_code=401, outcome="unsigned")
+        expected = hmac.new(secret, f"{timestamp}:".encode() + raw_body, hashlib.sha256).hexdigest()
+        if not hmac.compare_digest(expected, provided):
+            raise BillingError("signature does not match", status_code=401, outcome="bad_signature")
+        _check_freshness(timestamp, now=now)
+    else:
+        provided = lowered.get("x-signature", "")
+        expected = hmac.new(secret, raw_body, hashlib.sha256).hexdigest()
+        if not provided or not hmac.compare_digest(expected, provided):
+            raise BillingError("signature does not match", status_code=401, outcome="bad_signature")
+
+
+def _check_freshness(timestamp: str, *, now: datetime | None) -> None:
+    """Reject a signature old enough to be a replay.
+
+    The ledger already makes a replay harmless, so this is defence in depth and
+    the tolerance is generous: Paddle's SDKs default to five seconds, which
+    turns one slow hop into a lost payment.
+    """
+    try:
+        signed_at = datetime.fromtimestamp(int(timestamp), tz=UTC)
+    except (ValueError, OSError) as exc:
+        raise BillingError(
+            "Paddle-Signature carries no readable timestamp", status_code=401, outcome="unsigned"
+        ) from exc
+    age = abs(((now or datetime.now(UTC)) - signed_at).total_seconds())
+    tolerance = get_settings().billing_signature_tolerance_seconds
+    if age > tolerance:
+        raise BillingError(
+            f"signature is {int(age)}s old, past the {tolerance}s tolerance", status_code=401, outcome="stale"
+        )
+
+
+# ------------------------------------------------------------------- parsing
+
+#: Processor event names this server acts on. Everything else is a real event it
+#: has no opinion about, which is recorded as `ignored` rather than dropped —
+#: "we saw it and did nothing" and "we never got it" are different problems.
+_PADDLE_ACTIONS = {
+    "subscription.created": "grant",
+    "subscription.updated": "grant",
+    "subscription.activated": "grant",
+    "transaction.completed": "grant",
+    "subscription.canceled": "revoke",
+    "subscription.cancelled": "revoke",  # spelling insurance; costs nothing
+}
+_LEMONSQUEEZY_ACTIONS = {
+    "subscription_created": "grant",
+    "subscription_updated": "grant",
+    "subscription_payment_success": "grant",
+    "subscription_resumed": "grant",
+    # `cancelled` starts a grace period that runs to the paid-through date, so
+    # it is deliberately NOT a revoke: the entitlement already expires on its
+    # own, and cutting it short would take away days somebody paid for.
+    "subscription_expired": "revoke",
+}
+
+
+def parse(raw_body: bytes, headers: dict[str, str], payload: dict) -> Incoming:
+    processor = get_settings().billing_processor
+    lowered = {name.lower(): value for name, value in headers.items()}
+    if processor == PADDLE:
+        event_type = str(payload.get("event_type") or "")
+        event_id = str(payload.get("event_id") or "")
+        data = payload.get("data") or {}
+        custom = (data.get("custom_data") or {}) if isinstance(data, dict) else {}
+        renews_at = _timestamp((data.get("current_billing_period") or {}).get("ends_at"))
+        actions = _PADDLE_ACTIONS
+    else:
+        meta = payload.get("meta") or {}
+        event_type = str(lowered.get("x-event-name") or meta.get("event_name") or "")
+        # No event id is sent, so the body is its own identity: a retry of the
+        # same event is byte-identical and lands on the same ledger row.
+        event_id = hashlib.sha256(raw_body).hexdigest()
+        custom = meta.get("custom_data") or {}
+        attributes = (payload.get("data") or {}).get("attributes") or {}
+        renews_at = _timestamp(attributes.get("renews_at") or attributes.get("ends_at"))
+        actions = _LEMONSQUEEZY_ACTIONS
+
+    if not event_type:
+        raise BillingError("could not tell what event this is", status_code=400, outcome="unreadable")
+    if not event_id:
+        raise BillingError("event carries no id to deduplicate on", status_code=400, outcome="unreadable")
+
+    return Incoming(
+        processor=processor,
+        event_id=event_id,
+        event_type=event_type,
+        action=actions.get(event_type, "ignore"),
+        household_id=_household_id(custom),
+        renews_at=renews_at,
+    )
+
+
+def _household_id(custom: object) -> uuid.UUID | None:
+    if not isinstance(custom, dict):
+        return None
+    try:
+        return uuid.UUID(str(custom.get("household_id")))
+    except (ValueError, TypeError):
+        return None
+
+
+def _timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+# ------------------------------------------------------------------ applying
+
+
+async def handle(db: AsyncSession, raw_body: bytes, headers: dict[str, str], payload: dict) -> str:
+    """Verify, deduplicate, apply, and record. Returns the outcome.
+
+    Every path through here writes exactly one ledger row and counts exactly one
+    outcome, including the paths that decide to do nothing.
+    """
+    verify(raw_body, headers)
+    event = parse(raw_body, headers, payload)
+
+    existing = await db.execute(
+        select(BillingEvent).where(BillingEvent.processor == event.processor, BillingEvent.event_id == event.event_id)
+    )
+    if existing.scalar_one_or_none() is not None:
+        # Not an error, and deliberately not re-applied: processors retry on any
+        # non-2xx, and a blip between granting and answering 200 is exactly the
+        # case this exists for. **No second row** — the ledger row that detected
+        # this duplicate is the one whose uniqueness would refuse it.
+        return _observe(event, DUPLICATE, detail=None, household_id=event.household_id)
+
+    if event.action == "ignore":
+        return await _record(db, event, IGNORED, detail=None)
+    if event.household_id is None:
+        return await _record(
+            db,
+            event,
+            ORPHAN,
+            detail="no household_id in the checkout's custom_data, so nobody could be credited",
+            household_id=None,
+        )
+    household = await db.get(Household, event.household_id)
+    if household is None:
+        # The id is recorded in the text rather than the column: it names no row
+        # here, and the column is a foreign key.
+        return await _record(
+            db,
+            event,
+            ORPHAN,
+            detail=f"household {event.household_id} is not on this server",
+            household_id=None,
+        )
+
+    try:
+        if event.action == "grant":
+            await entitlements.grant(
+                db,
+                household,
+                tier=limits.PAID,
+                until=event.renews_at,
+                source=event.processor,
+                note=f"{event.event_type} via {event.processor}",
+            )
+            return await _record(db, event, GRANTED, detail=None)
+        await entitlements.revoke(db, household, note=f"{event.event_type} via {event.processor}")
+        return await _record(db, event, REVOKED, detail=None)
+    except entitlements.EntitlementError as exc:
+        # Deterministic: retrying will fail identically, so the endpoint answers
+        # 200 to stop the retries and the alert is what gets a human involved.
+        # This is the one branch where somebody has paid and not been credited.
+        return await _record(db, event, REFUSED, detail=str(exc)[:300])
+
+
+async def _record(
+    db: AsyncSession,
+    event: Incoming,
+    outcome: str,
+    *,
+    detail: str | None,
+    household_id: uuid.UUID | None = _UNSET,
+) -> str:
+    """Write the ledger row, then count and log it."""
+    on_household = event.household_id if household_id is _UNSET else household_id
+    db.add(
+        BillingEvent(
+            processor=event.processor,
+            event_id=event.event_id,
+            event_type=event.event_type,
+            outcome=outcome,
+            household_id=on_household,
+            detail=detail,
+        )
+    )
+    await db.commit()
+    return _observe(event, outcome, detail=detail, household_id=on_household)
+
+
+def _observe(event: Incoming, outcome: str, *, detail: str | None, household_id: uuid.UUID | None) -> str:
+    """The counter and the log line, for an outcome that has been decided.
+
+    Split out because the duplicate path must not write a second ledger row but
+    must still be counted: a retry storm that nobody can see is its own problem.
+    """
+    count(outcome)
+    log_event(
+        "billing.webhook",
+        outcome=outcome,
+        processor=event.processor,
+        event_type=event.event_type,
+        household_id=household_id,
+        detail=detail,
+    )
+    return outcome
+
+
+def count(outcome: str) -> None:
+    """The counter the alert watches. Separate from `_record` so the paths that
+    never reach the ledger — a bad signature, an unreadable body — are counted
+    too. Those are the ones that would otherwise be silent."""
+    metrics.count_billing_webhook(outcome)

--- a/backend/tests/integration/test_billing.py
+++ b/backend/tests/integration/test_billing.py
@@ -1,0 +1,383 @@
+"""The billing webhook (issue #99, planning/08-freemium.md §2).
+
+Three claims, in the order it would cost to get them wrong:
+
+1. **It does not exist unless a deployment turns it on.** A self-hosted
+   instance has no billing and must not be able to acquire one by accident.
+2. **Nothing unsigned is ever acted on.** The signature is the whole of the
+   authentication: the caller is a machine that has never heard of this app's
+   accounts.
+3. **A retry cannot grant a second year**, and a *silent* failure cannot happen
+   at all. Every request ends as exactly one counted, logged, recorded outcome,
+   including the ones that decide to do nothing.
+
+The two adapters are tested against the formats read from the live docs on
+2026-08-22: Paddle signs "{ts}:{body}" and sends `Paddle-Signature`, Lemon
+Squeezy signs the body and sends `X-Signature`.
+"""
+
+import hashlib
+import hmac
+import json
+import re
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app import limits
+from app.models import BillingEvent, Household
+from app.services import entitlements
+from tests.conftest import register
+
+SECRET = "a-signing-secret"
+
+
+@pytest.fixture
+def sessions(engine):
+    return async_sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest.fixture
+def paddle(settings_override):
+    settings_override(BILLING_PROCESSOR="paddle", BILLING_WEBHOOK_SECRET=SECRET)
+
+
+@pytest.fixture
+def lemonsqueezy(settings_override):
+    settings_override(BILLING_PROCESSOR="lemonsqueezy", BILLING_WEBHOOK_SECRET=SECRET)
+
+
+async def household_id(sessions) -> uuid.UUID:
+    async with sessions() as db:
+        return (await db.execute(select(Household))).scalars().one().id
+
+
+def paddle_post(payload: dict, *, secret: str = SECRET, at: datetime | None = None) -> tuple[str, dict]:
+    body = json.dumps(payload)
+    stamp = str(int((at or datetime.now(UTC)).timestamp()))
+    signature = hmac.new(secret.encode(), f"{stamp}:{body}".encode(), hashlib.sha256).hexdigest()
+    return body, {"Paddle-Signature": f"ts={stamp};h1={signature}", "Content-Type": "application/json"}
+
+
+def lemon_post(payload: dict, *, secret: str = SECRET, event: str | None = None) -> tuple[str, dict]:
+    body = json.dumps(payload)
+    signature = hmac.new(secret.encode(), body.encode(), hashlib.sha256).hexdigest()
+    headers = {"X-Signature": signature, "Content-Type": "application/json"}
+    if event:
+        headers["X-Event-Name"] = event
+    return body, headers
+
+
+def paddle_event(
+    household: uuid.UUID | None, *, kind="subscription.created", event_id="evt_1", ends="2027-08-22T00:00:00Z"
+):
+    data: dict = {"current_billing_period": {"ends_at": ends}}
+    if household is not None:
+        data["custom_data"] = {"household_id": str(household)}
+    return {"event_id": event_id, "event_type": kind, "data": data}
+
+
+def lemon_event(household: uuid.UUID | None, *, kind="subscription_created", renews="2027-08-22T00:00:00.000000Z"):
+    meta: dict = {"event_name": kind}
+    if household is not None:
+        meta["custom_data"] = {"household_id": str(household)}
+    return {"meta": meta, "data": {"type": "subscriptions", "id": "1", "attributes": {"renews_at": renews}}}
+
+
+class TestItDoesNotExistUnlessTurnedOn:
+    async def test_no_processor_means_no_endpoint(self, auth_client):
+        """404, not 401 or 403: on almost every deployment the route really is
+        not there, and saying so is the honest answer."""
+        response = await auth_client.post("/billing/webhook", json={"anything": True})
+        assert response.status_code == 404
+
+    async def test_a_secret_without_a_processor_is_still_off(self, client, settings_override):
+        settings_override(BILLING_WEBHOOK_SECRET=SECRET)
+        assert (await client.post("/billing/webhook", json={})).status_code == 404
+
+    async def test_a_processor_without_a_secret_is_still_off(self, client, settings_override):
+        """Half-configured is off, not open."""
+        settings_override(BILLING_PROCESSOR="paddle")
+        assert (await client.post("/billing/webhook", json={})).status_code == 404
+
+    async def test_it_is_absent_from_the_public_schema(self, client):
+        spec = (await client.get("/openapi.json")).json()
+        assert "/billing/webhook" not in spec["paths"]
+
+
+class TestNothingUnsignedIsActedOn:
+    async def test_no_signature_at_all(self, client, paddle, sessions):
+        await register(client)
+        body, _ = paddle_post(paddle_event(await household_id(sessions)))
+        response = await client.post("/billing/webhook", content=body, headers={"Content-Type": "application/json"})
+        assert response.status_code == 401
+
+    async def test_a_signature_from_the_wrong_secret(self, client, paddle, sessions):
+        await register(client)
+        body, headers = paddle_post(paddle_event(await household_id(sessions)), secret="not-the-secret")
+        assert (await client.post("/billing/webhook", content=body, headers=headers)).status_code == 401
+
+    async def test_a_tampered_body_no_longer_verifies(self, client, paddle, sessions):
+        """The signature covers the body, so moving the expiry out by a decade
+        has to invalidate it."""
+        await register(client)
+        body, headers = paddle_post(paddle_event(await household_id(sessions)))
+        tampered = body.replace("2027", "2037")
+        assert (await client.post("/billing/webhook", content=tampered, headers=headers)).status_code == 401
+
+    async def test_lemonsqueezy_signature_is_over_the_raw_body(self, client, lemonsqueezy, sessions):
+        await register(client)
+        body, headers = lemon_post(lemon_event(await household_id(sessions)), secret="wrong")
+        assert (await client.post("/billing/webhook", content=body, headers=headers)).status_code == 401
+
+    async def test_a_stale_paddle_signature_is_refused(self, client, paddle, sessions):
+        await register(client)
+        old = datetime.now(UTC) - timedelta(hours=2)
+        body, headers = paddle_post(paddle_event(await household_id(sessions)), at=old)
+        response = await client.post("/billing/webhook", content=body, headers=headers)
+        assert response.status_code == 401
+        assert "tolerance" in response.json()["detail"]
+
+    async def test_nothing_was_granted_by_any_of_that(self, client, paddle, sessions):
+        await register(client)
+        target = await household_id(sessions)
+        body, headers = paddle_post(paddle_event(target), secret="wrong")
+        await client.post("/billing/webhook", content=body, headers=headers)
+        async with sessions() as db:
+            assert (await db.get(Household, target)).tier == "unlimited"
+            assert (await db.execute(select(BillingEvent))).scalars().all() == []
+
+    async def test_semantically_identical_json_still_fails(self, client, paddle, sessions):
+        """Proves the signature is over the *bytes*, not over what they parse
+        to. Re-serialising the body anywhere in the stack would break this, and
+        breaking it silently is how a forged webhook gets accepted."""
+        await register(client)
+        payload = paddle_event(await household_id(sessions))
+        body, headers = paddle_post(payload)
+        respaced = json.dumps(payload, indent=2)  # same object, different bytes
+        assert json.loads(respaced) == json.loads(body)
+        assert (await client.post("/billing/webhook", content=respaced, headers=headers)).status_code == 401
+
+    async def test_a_lemonsqueezy_signature_does_not_pass_a_paddle_server(self, client, paddle, sessions):
+        """The header a deployment reads is decided by its own config, not by
+        what the caller chose to send."""
+        await register(client)
+        body, headers = lemon_post(lemon_event(await household_id(sessions)), event="subscription_created")
+        assert (await client.post("/billing/webhook", content=body, headers=headers)).status_code == 401
+
+    async def test_a_paddle_signature_does_not_pass_a_lemonsqueezy_server(self, client, lemonsqueezy, sessions):
+        await register(client)
+        body, headers = paddle_post(paddle_event(await household_id(sessions)))
+        assert (await client.post("/billing/webhook", content=body, headers=headers)).status_code == 401
+
+    async def test_a_body_that_is_not_json(self, client, paddle):
+        body = "not json"
+        signature = hmac.new(SECRET.encode(), f"1:{body}".encode(), hashlib.sha256).hexdigest()
+        response = await client.post(
+            "/billing/webhook", content=body, headers={"Paddle-Signature": f"ts=1;h1={signature}"}
+        )
+        assert response.status_code == 400
+
+
+class TestAPaymentBecomesAnEntitlement:
+    async def test_paddle_grants_the_paid_tier_until_the_billing_period_ends(self, client, paddle, sessions):
+        await register(client)
+        target = await household_id(sessions)
+        body, headers = paddle_post(paddle_event(target))
+
+        response = await client.post("/billing/webhook", content=body, headers=headers)
+        assert response.status_code == 200
+        assert response.json() == {"outcome": "granted"}
+
+        async with sessions() as db:
+            household = await db.get(Household, target)
+        assert household.tier == "paid"
+        assert household.entitlement_source == "paddle"
+        assert entitlements.describe(household).paid_until.year == 2027
+        assert limits.effective_tier(household) == "paid"
+
+    async def test_lemonsqueezy_does_the_same_from_its_own_shape(self, client, lemonsqueezy, sessions):
+        await register(client)
+        target = await household_id(sessions)
+        body, headers = lemon_post(lemon_event(target), event="subscription_created")
+
+        response = await client.post("/billing/webhook", content=body, headers=headers)
+        assert response.json() == {"outcome": "granted"}
+        async with sessions() as db:
+            household = await db.get(Household, target)
+        assert (household.tier, household.entitlement_source) == ("paid", "lemonsqueezy")
+
+    async def test_the_event_name_can_come_from_the_header_alone(self, client, lemonsqueezy, sessions):
+        """Lemon Squeezy sends it both ways; the header is the documented one."""
+        await register(client)
+        target = await household_id(sessions)
+        payload = lemon_event(target)
+        del payload["meta"]["event_name"]
+        body, headers = lemon_post(payload, event="subscription_created")
+        assert (await client.post("/billing/webhook", content=body, headers=headers)).json()["outcome"] == "granted"
+
+    async def test_a_renewal_moves_the_expiry(self, client, paddle, sessions):
+        await register(client)
+        target = await household_id(sessions)
+        first, headers = paddle_post(paddle_event(target, event_id="evt_1", ends="2027-01-01T00:00:00Z"))
+        await client.post("/billing/webhook", content=first, headers=headers)
+        second, headers2 = paddle_post(
+            paddle_event(target, kind="subscription.updated", event_id="evt_2", ends="2028-01-01T00:00:00Z")
+        )
+        assert (await client.post("/billing/webhook", content=second, headers=headers2)).json()["outcome"] == "granted"
+
+        async with sessions() as db:
+            household = await db.get(Household, target)
+        assert entitlements.describe(household).paid_until.year == 2028
+
+    async def test_an_expiry_revokes(self, client, lemonsqueezy, sessions):
+        await register(client)
+        target = await household_id(sessions)
+        body, headers = lemon_post(lemon_event(target), event="subscription_created")
+        await client.post("/billing/webhook", content=body, headers=headers)
+
+        ended = lemon_event(target, kind="subscription_expired")
+        body, headers = lemon_post(ended, event="subscription_expired")
+        assert (await client.post("/billing/webhook", content=body, headers=headers)).json()["outcome"] == "revoked"
+        async with sessions() as db:
+            household = await db.get(Household, target)
+        assert household.tier == "free"
+
+    async def test_a_cancellation_does_not_cut_the_paid_year_short(self, client, lemonsqueezy, sessions):
+        """Lemon Squeezy's `subscription_cancelled` starts a grace period that
+        runs to the paid-through date. Revoking there would take away days
+        somebody paid for; the entitlement expires on its own."""
+        await register(client)
+        target = await household_id(sessions)
+        body, headers = lemon_post(lemon_event(target), event="subscription_created")
+        await client.post("/billing/webhook", content=body, headers=headers)
+
+        body, headers = lemon_post(lemon_event(target, kind="subscription_cancelled"), event="subscription_cancelled")
+        assert (await client.post("/billing/webhook", content=body, headers=headers)).json()["outcome"] == "ignored"
+        async with sessions() as db:
+            household = await db.get(Household, target)
+        assert household.tier == "paid"
+
+
+class TestARetryCannotGrantASecondYear:
+    async def test_the_same_paddle_event_twice(self, client, paddle, sessions):
+        await register(client)
+        target = await household_id(sessions)
+        body, headers = paddle_post(paddle_event(target))
+
+        assert (await client.post("/billing/webhook", content=body, headers=headers)).json()["outcome"] == "granted"
+        again = await client.post("/billing/webhook", content=body, headers=headers)
+        assert again.status_code == 200
+        assert again.json()["outcome"] == "duplicate"
+
+    async def test_lemonsqueezy_deduplicates_on_the_body_it_sent(self, client, lemonsqueezy, sessions):
+        """It sends no event id, so an identical retry has to be recognised by
+        being identical."""
+        await register(client)
+        target = await household_id(sessions)
+        body, headers = lemon_post(lemon_event(target), event="subscription_created")
+        assert (await client.post("/billing/webhook", content=body, headers=headers)).json()["outcome"] == "granted"
+        assert (await client.post("/billing/webhook", content=body, headers=headers)).json()["outcome"] == "duplicate"
+
+    async def test_a_duplicate_does_not_move_the_expiry(self, client, paddle, sessions):
+        await register(client)
+        target = await household_id(sessions)
+        body, headers = paddle_post(paddle_event(target))
+        await client.post("/billing/webhook", content=body, headers=headers)
+        async with sessions() as db:
+            first = (await db.get(Household, target)).paid_until
+
+        await client.post("/billing/webhook", content=body, headers=headers)
+        async with sessions() as db:
+            assert (await db.get(Household, target)).paid_until == first
+
+
+class TestNothingFailsQuietly:
+    async def test_an_event_naming_no_household_is_loud(self, client, paddle, sessions):
+        """Somebody may have paid and not been credited. It answers 200 so the
+        processor stops retrying something deterministic, and the alert is what
+        gets a human involved."""
+        await register(client)
+        body, headers = paddle_post(paddle_event(None))
+        response = await client.post("/billing/webhook", content=body, headers=headers)
+        assert response.status_code == 200
+        assert response.json()["outcome"] == "orphan"
+
+        async with sessions() as db:
+            event = (await db.execute(select(BillingEvent))).scalars().one()
+        assert event.outcome == "orphan"
+        assert "custom_data" in event.detail
+
+    async def test_an_event_naming_a_household_this_server_does_not_have(self, client, paddle, sessions):
+        await register(client)
+        body, headers = paddle_post(paddle_event(uuid.uuid4()))
+        assert (await client.post("/billing/webhook", content=body, headers=headers)).json()["outcome"] == "orphan"
+
+    async def test_an_entitlement_refusal_is_recorded_rather_than_retried(self, client, paddle, sessions):
+        """The one branch where somebody has paid and not been credited: it must
+        end in a row an operator can read, not a 500 loop."""
+        await register(client)
+        target = await household_id(sessions)
+        async with sessions() as db:
+            household = await db.get(Household, target)
+            household.paid_until = None
+            await db.commit()
+
+        # An expiry in the past is refused by the entitlement layer.
+        body, headers = paddle_post(paddle_event(target, ends="2020-01-01T00:00:00Z"))
+        response = await client.post("/billing/webhook", content=body, headers=headers)
+        assert response.status_code == 200
+        assert response.json()["outcome"] == "refused"
+        async with sessions() as db:
+            event = (await db.execute(select(BillingEvent))).scalars().one()
+        assert event.outcome == "refused"
+        assert "not in the future" in event.detail
+
+    async def test_an_event_we_have_no_opinion_about_is_still_recorded(self, client, paddle, sessions):
+        """ "We saw it and did nothing" and "we never got it" are different
+        problems, so the first one leaves a row."""
+        await register(client)
+        body, headers = paddle_post(paddle_event(await household_id(sessions), kind="customer.updated"))
+        assert (await client.post("/billing/webhook", content=body, headers=headers)).json()["outcome"] == "ignored"
+        async with sessions() as db:
+            assert (await db.execute(select(BillingEvent))).scalars().one().outcome == "ignored"
+
+    async def test_every_outcome_reaches_the_counter(self, client, paddle, sessions, settings_override):
+        """The alert watches this counter, not the log.
+
+        Measured as a delta: the registry is module-level and outlives any one
+        test, so an absolute count would only be asserting the order this file
+        happened to run in.
+        """
+        settings_override(BILLING_PROCESSOR="paddle", BILLING_WEBHOOK_SECRET=SECRET, METRICS_TOKEN="scrape-secret-1")
+        await register(client)
+        target = await household_id(sessions)
+
+        async def counts() -> dict[str, float]:
+            scraped = (await client.get("/metrics", headers={"Authorization": "Bearer scrape-secret-1"})).text
+            found = re.findall(r'meals_billing_webhooks_total\{outcome="(\w+)"\} ([0-9.e+]+)', scraped)
+            return {outcome: float(value) for outcome, value in found}
+
+        before = await counts()
+        body, headers = paddle_post(paddle_event(target))
+        await client.post("/billing/webhook", content=body, headers=headers)
+        bad, bad_headers = paddle_post(paddle_event(target, event_id="evt_2"), secret="wrong")
+        await client.post("/billing/webhook", content=bad, headers=bad_headers)
+        orphan, orphan_headers = paddle_post(paddle_event(None, event_id="evt_3"))
+        await client.post("/billing/webhook", content=orphan, headers=orphan_headers)
+        after = await counts()
+
+        for outcome in ("granted", "bad_signature", "orphan"):
+            moved = after.get(outcome, 0) - before.get(outcome, 0)
+            assert moved == 1, f"{outcome} moved by {moved}, not 1"
+
+    async def test_every_transition_is_logged(self, client, paddle, sessions, caplog):
+        await register(client)
+        body, headers = paddle_post(paddle_event(await household_id(sessions)))
+        with caplog.at_level("INFO", logger="meals.events"):
+            await client.post("/billing/webhook", content=body, headers=headers)
+        record = next(r for r in caplog.records if r.getMessage() == "billing.webhook")
+        assert (record.outcome, record.processor) == ("granted", "paddle")


### PR DESCRIPTION
## What and why

Closes [#99](https://github.com/marco308/meals/issues/99), finishing what #115 started.

**It ships inert.** With `BILLING_PROCESSOR` unset the route does not exist at all — 404, the posture `/metrics` takes without a token. Off should mean the door is not there, not that it is there and locked, because a self-hosted instance must not be able to acquire billing by accident. Half-configured is also off.

### On the blocker I raised last time

I said the webhook needed you to pick a merchant of record first, and the issue says the same. **I no longer think that blocks the code, only the account.** Both adapters are here, selected by `BILLING_PROCESSOR`, and together they are about forty lines — cheaper than guessing and rewriting, and it leaves the choice where it belongs. Both formats were read from the live docs rather than from memory:

| | Paddle | Lemon Squeezy |
|---|---|---|
| Header | `Paddle-Signature: ts=…;h1=…` | `X-Signature` |
| Signed | `"{ts}:{raw body}"` | raw body |
| Event id | `event_id` | none sent, so the key is a digest of the body |

You still choose the processor and sign up; nothing in the repo commits you.

### The parts that matter

**The signature is the whole of the authentication**, checked constant-time against the raw bytes. A test re-serialises the same object with different whitespace and requires it to fail — if anything in the stack ever re-encodes the body before verification, that's how it gets caught rather than how a forgery gets accepted.

**A retry cannot grant a second year.** `billing_events` is keyed on `(processor, event_id)`. Writing this earned the table twice over: the first version of the duplicate path tried to insert a second row and violated the very constraint that had just detected the duplicate. The test caught it.

**Nothing fails quietly**, which the issue calls out specifically. Every request ends as exactly one counted, logged, recorded outcome, including the ones that do nothing. Deterministic failures (duplicate, unknown household, entitlement refusal) answer **200** so the processor stops retrying something that will fail identically, and are counted for the alert instead; only genuinely transient failures 500 and get retried.

```
increase(meals_billing_webhooks_total{outcome=~"orphan|refused|bad_signature|unsigned|stale|unreadable"}[1h]) > 0
```

**A cancellation is not a revocation.** Lemon Squeezy's `subscription_cancelled` starts a grace period running to the paid-through date; revoking there would take away days somebody paid for. The entitlement expires on its own.

### Still not in scope

Email verification and reaping abandoned free households — the issue calls both prerequisites for opening `REGISTRATION_ENABLED`, not parts of this. And StoreKit, explicitly out.

## Checklist

- [x] **API contract stayed additive** — one new endpoint that does not exist unless configured, and is out of the OpenAPI schema (one caller, configured by hand).
- [x] **Model change has a migration** — `508d35134cdc`, new table only, up/down/up verified. The `ck_meal_recipe_scale` false positive is excluded as before; CI's `alembic check` runs against Postgres, where it does not appear.
- [x] **Shopping-list quantities still derive from `ListItemSource`** — n/a.
- [x] **Every new query filters on `household_id`** — the webhook is keyed by the household named in the checkout's custom data and looks up exactly that one; an id naming no household here is recorded as an orphan rather than guessed at.
- [x] **Skill/prompt pack updated** — n/a.
- [x] **New 4xx strings say what to do instead** — 401 says the secret and ours disagree, 400 says the body could not be read. Both are for a machine and a log, not a person.

854 backend tests, 67 MCP, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
