### PR TITLE
Add Stripe Managed Payments, and drop a false dichotomy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,12 +49,16 @@ AUTH_RATE_LIMIT_PER_MINUTE=10
 
 # Billing webhook. Off unless BOTH of these are set, and off means the route
 # does not exist (404), not that it exists and refuses — a self-hosted instance
-# must not be able to acquire billing by accident. BILLING_PROCESSOR is 'paddle'
-# or 'lemonsqueezy'; both are merchants of record, which is the point, since EU
-# B2C digital-services VAT applies from the first sale. Point the processor's
-# webhook at POST /billing/webhook and put {"household_id": "<uuid>"} in the
-# checkout's custom data, which is how a payment finds a household.
+# must not be able to acquire billing by accident. BILLING_PROCESSOR is
+# 'stripe', 'paddle' or 'lemonsqueezy'; all three are merchants of record, which
+# is the point, since EU B2C digital-services VAT is due from the first sale.
+# 'stripe' means Stripe **Managed Payments** specifically — ordinary Stripe
+# leaves the tax with you. Point the processor's webhook at
+# POST /billing/webhook and put the household id in the checkout's custom data:
+# {"household_id": "<uuid>"} for Paddle and Lemon Squeezy, and for Stripe
+# subscription_data[metadata][household_id] on the Checkout Session, since
+# metadata on the session itself does not reach the subscription.
 # Alert on: increase(meals_billing_webhooks_total{outcome=~"orphan|refused|bad_signature|unsigned|stale|unreadable"}[1h]) > 0
-#BILLING_PROCESSOR=paddle
+#BILLING_PROCESSOR=stripe
 #BILLING_WEBHOOK_SECRET=
 #BILLING_SIGNATURE_TOLERANCE_SECONDS=300

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,22 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
   exist at all (404, the posture `/metrics` takes without a token), because a
   self-hosted instance has no billing and must not be able to acquire one by
   accident. **One migration**, a new `billing_events` table.
-- **Paddle and Lemon Squeezy are both supported**, selected by
-  `BILLING_PROCESSOR`. Which merchant of record to use is a commercial decision
-  that had not been made, and both adapters together cost about forty lines,
-  which is cheaper than guessing and rewriting. Both formats were read from the
-  live documentation: Paddle signs `"{ts}:{body}"` and sends `Paddle-Signature`,
-  Lemon Squeezy signs the raw body and sends `X-Signature`.
+- **Stripe Managed Payments, Paddle and Lemon Squeezy are all supported**,
+  selected by `BILLING_PROCESSOR`. The requirement is a merchant of record, so
+  that EU B2C digital-services VAT is the seller's to file rather than ours;
+  that is not the same as "not Stripe", since **Managed Payments is Stripe
+  acting as merchant of record** and runs on an existing Stripe account.
+  Ordinary Stripe leaves the tax with you and is deliberately not what
+  `stripe` means here. All three formats were read from the live
+  documentation: Paddle signs `"{ts}:{body}"`, Lemon Squeezy signs the raw
+  body, Stripe signs `"{ts}.{body}"`. Stripe's is the one a hand-rolled
+  verifier gets wrong — several `v1` signatures can be live at once while an
+  endpoint secret rolls, and the `v0` scheme it sends beside test events must
+  be ignored rather than accepted.
+- **No webhook can grant an entitlement with no end date.** A grant without an
+  expiry never lapses, so it would quietly hand out a subscription nobody has
+  to renew; an event carrying no billing period is refused and recorded
+  instead.
 - **A retry cannot grant a second year.** Every event is recorded once in a
   ledger keyed on `(processor, event_id)`; Lemon Squeezy sends no event id, so
   its key is a digest of the body, which makes an identical retry land on the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,10 +213,16 @@ instrumentation a new feature usually needs.
   instance must not be able to acquire billing by accident, the same posture
   `/metrics` takes without a token. The signature *is* the authentication
   (the caller has never heard of this app's accounts), verified constant-time
-  against the raw body. **Both Paddle and Lemon Squeezy are supported and the
-  choice is a setting**, because which merchant of record to use is a
-  commercial decision that had not been made; the adapters cost about forty
-  lines and remove the need to guess. `billing_events` is the idempotency
+  against the raw body. **Stripe Managed Payments, Paddle and Lemon
+  Squeezy are all supported and the choice is a setting.** The requirement is a
+  merchant of record — somebody else being the legal seller, so EU B2C VAT is
+  theirs to file — and that is *not* the same as "not Stripe": Managed Payments
+  is Stripe acting as MoR (ordinary Stripe is not). Stripe's is the scheme a
+  hand-rolled verifier gets wrong: **several `v1` signatures can be live at once**
+  while an endpoint secret rolls, so any match counts, and every other scheme
+  must be ignored because `v0` is a deliberately fake test signature.
+  **No webhook may ever grant without a billing period end** — a grant with no
+  expiry never lapses, so it would hand out a subscription nobody has to renew. `billing_events` is the idempotency
   ledger and the reason a retry cannot grant a second year — processors retry
   on any non-2xx, so the blip between granting and answering 200 is the
   expected case, not a rare one. **Deterministic failures answer 200 on

--- a/README.md
+++ b/README.md
@@ -383,9 +383,9 @@ self-hosted one.
 
 Payment itself is a webhook, and it is **off unless a deployment sets both
 `BILLING_PROCESSOR` and `BILLING_WEBHOOK_SECRET`** — off meaning the route does
-not exist, not that it exists and refuses. Paddle and Lemon Squeezy are both
-supported because both are merchants of record and handle EU VAT; which one is
-a setting, not a rewrite. Every webhook is signature-verified, recorded once in
+not exist, not that it exists and refuses. Stripe Managed Payments, Paddle and
+Lemon Squeezy are all supported because all three are merchants of record and
+handle EU VAT; which one is a setting, not a rewrite. Every webhook is signature-verified, recorded once in
 a ledger so a retry cannot grant a second year, and counted by outcome, because
 the expensive failure here is the quiet one: somebody paying and not being
 credited. Being over a

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -121,10 +121,13 @@ class Settings(BaseSettings):
     # accident, so with BILLING_PROCESSOR unset the endpoint does not exist at
     # all (404, exactly like /metrics with no token).
     #
-    #   BILLING_PROCESSOR   'paddle' or 'lemonsqueezy'. Both are merchants of
-    #                       record, which is the point (§7): they handle EU B2C
-    #                       digital-services VAT, which applies from the first
-    #                       sale regardless of the UK threshold.
+    #   BILLING_PROCESSOR   'stripe', 'paddle' or 'lemonsqueezy'. All three are
+    #                       merchants of record, which is the point (§7): they
+    #                       are the legal seller, so EU B2C digital-services VAT
+    #                       — due from the first sale regardless of the UK
+    #                       threshold — is theirs to file rather than ours.
+    #                       'stripe' means Stripe **Managed Payments**, not
+    #                       ordinary Stripe, which leaves the tax with you.
     #   BILLING_WEBHOOK_SECRET  the signing secret from that processor's
     #                       dashboard. Every request is verified against it.
     #   BILLING_SIGNATURE_TOLERANCE_SECONDS  how old a signed timestamp may be

--- a/backend/app/services/billing.py
+++ b/backend/app/services/billing.py
@@ -15,15 +15,15 @@ failure mode this module refuses to have is the quiet one.
 Which processor, and why both are here
 --------------------------------------
 
-§7 requires a **merchant of record** rather than raw Stripe: EU B2C
-digital-services VAT applies from the first sale regardless of the UK threshold,
-and Paddle and Lemon Squeezy both handle it for roughly 5%, which is cheaper
-than the problem. Which of the two is a commercial decision that has not been
-made, so both adapters are here and `BILLING_PROCESSOR` picks one. That costs
-about forty lines and removes the need to guess; the alternative was writing
-this against one of them and rewriting it if the other won.
+§7 requires a **merchant of record**: EU B2C digital-services VAT applies from
+the first sale regardless of the UK threshold, so somebody has to be the legal
+seller and file in the customer's country. That requirement is what matters, and
+it is not the same as "not Stripe" — **Stripe Managed Payments** (2026) is
+Stripe acting as merchant of record, which means the account this project
+already has can do the job. `BILLING_PROCESSOR` picks between three adapters
+rather than committing the code to one.
 
-Both were read from the live documentation on 2026-08-22:
+All three were read from the live documentation on 2026-08-22 and 2026-08-23:
 
 - **Paddle** signs `"{ts}:{raw body}"` with HMAC-SHA256, hex, and sends it as
   `Paddle-Signature: ts=<unix>;h1=<hex>`. The payload carries `event_id`,
@@ -33,10 +33,20 @@ Both were read from the live documentation on 2026-08-22:
   `meta.event_name`. It sends **no event id**, so the ledger key is a digest of
   the body — an identical retry hashes identically, which is exactly what the
   key is for.
+- **Stripe** signs `"{ts}.{raw body}"` with HMAC-SHA256, hex, and sends it as
+  `Stripe-Signature: t=…,v1=…`. Two details its docs are explicit about and a
+  hand-rolled verifier gets wrong: there can be **several `v1` signatures** at
+  once, because rolling an endpoint secret keeps the old one live for up to 24
+  hours, so any match counts; and every other scheme must be **ignored**,
+  because `v0` is a deliberately fake signature sent alongside test events and
+  accepting it would be a downgrade attack.
 
-The linkage to a household is `custom_data.household_id`, set on the checkout.
-Both processors pass custom data through to the webhook; Paddle puts it on
-`data`, Lemon Squeezy on `meta`.
+The linkage to a household is `household_id` in the checkout's custom data:
+Paddle puts it on `data.custom_data`, Lemon Squeezy on `meta.custom_data`, and
+Stripe on the object's `metadata`. For Stripe subscriptions that means setting
+`subscription_data.metadata.household_id` on the Checkout Session — metadata on
+the *session* does not reach the subscription, and a payment nobody can match to
+a household is recorded as an orphan rather than guessed at.
 """
 
 import hashlib
@@ -60,7 +70,8 @@ _UNSET: Any = object()
 
 PADDLE = "paddle"
 LEMONSQUEEZY = "lemonsqueezy"
-PROCESSORS = (PADDLE, LEMONSQUEEZY)
+STRIPE = "stripe"
+PROCESSORS = (PADDLE, LEMONSQUEEZY, STRIPE)
 
 #: What this server made of a webhook. Every request ends as exactly one of
 #: these, and every one of them is counted.
@@ -126,6 +137,27 @@ def verify(raw_body: bytes, headers: dict[str, str], *, now: datetime | None = N
         if not hmac.compare_digest(expected, provided):
             raise BillingError("signature does not match", status_code=401, outcome="bad_signature")
         _check_freshness(timestamp, now=now)
+    elif processor == STRIPE:
+        header = lowered.get("stripe-signature", "")
+        timestamp = ""
+        offered = []
+        for part in header.split(","):
+            prefix, _, value = part.strip().partition("=")
+            if prefix == "t":
+                timestamp = value
+            elif prefix == "v1":
+                # Only v1. Every other scheme is ignored on purpose: Stripe
+                # sends a deliberately fake `v0` beside test events, and
+                # accepting one would be a downgrade attack.
+                offered.append(value)
+        if not timestamp or not offered:
+            raise BillingError("missing or malformed Stripe-Signature header", status_code=401, outcome="unsigned")
+        expected = hmac.new(secret, f"{timestamp}.".encode() + raw_body, hashlib.sha256).hexdigest()
+        # Any match counts: rolling an endpoint secret leaves the old one live
+        # for up to 24 hours, and Stripe signs once per active secret.
+        if not any(hmac.compare_digest(expected, candidate) for candidate in offered):
+            raise BillingError("signature does not match", status_code=401, outcome="bad_signature")
+        _check_freshness(timestamp, now=now)
     else:
         provided = lowered.get("x-signature", "")
         expected = hmac.new(secret, raw_body, hashlib.sha256).hexdigest()
@@ -179,6 +211,19 @@ _LEMONSQUEEZY_ACTIONS = {
 }
 
 
+#: Stripe's subscription lifecycle. `updated` is the catch-all and carries the
+#: paid-through date, which is the only thing this server needs from it.
+#: Invoice events are deliberately absent: the subscription object is the source
+#: of truth for "paid until when", and acting on both would be two writes for
+#: one payment. `checkout.session.completed` is absent for a sharper reason —
+#: it carries no billing period, and nothing here may grant without one.
+_STRIPE_ACTIONS = {
+    "customer.subscription.created": "grant",
+    "customer.subscription.updated": "grant",
+    "customer.subscription.deleted": "revoke",
+}
+
+
 def parse(raw_body: bytes, headers: dict[str, str], payload: dict) -> Incoming:
     processor = get_settings().billing_processor
     lowered = {name.lower(): value for name, value in headers.items()}
@@ -189,6 +234,13 @@ def parse(raw_body: bytes, headers: dict[str, str], payload: dict) -> Incoming:
         custom = (data.get("custom_data") or {}) if isinstance(data, dict) else {}
         renews_at = _timestamp((data.get("current_billing_period") or {}).get("ends_at"))
         actions = _PADDLE_ACTIONS
+    elif processor == STRIPE:
+        event_type = str(payload.get("type") or "")
+        event_id = str(payload.get("id") or "")
+        obj = (payload.get("data") or {}).get("object") or {}
+        custom = obj.get("metadata") or {}
+        renews_at = _stripe_period_end(obj)
+        actions = _STRIPE_ACTIONS
     else:
         meta = payload.get("meta") or {}
         event_type = str(lowered.get("x-event-name") or meta.get("event_name") or "")
@@ -213,6 +265,22 @@ def parse(raw_body: bytes, headers: dict[str, str], payload: dict) -> Incoming:
         household_id=_household_id(custom),
         renews_at=renews_at,
     )
+
+
+def _stripe_period_end(obj: dict) -> datetime | None:
+    """When the subscription is paid through.
+
+    `current_period_end` sits on the subscription in older API versions and on
+    each subscription *item* in newer ones, so both are read. The latest item
+    end is the one that matters: it is the point after which nothing has been
+    paid for.
+    """
+    ends = [obj.get("current_period_end")]
+    for item in (obj.get("items") or {}).get("data") or []:
+        if isinstance(item, dict):
+            ends.append(item.get("current_period_end"))
+    stamps = [value for value in ends if isinstance(value, int)]
+    return datetime.fromtimestamp(max(stamps), tz=UTC) if stamps else None
 
 
 def _household_id(custom: object) -> uuid.UUID | None:
@@ -276,6 +344,19 @@ async def handle(db: AsyncSession, raw_body: bytes, headers: dict[str, str], pay
             ORPHAN,
             detail=f"household {event.household_id} is not on this server",
             household_id=None,
+        )
+
+    if event.action == "grant" and event.renews_at is None:
+        # A grant with no expiry never lapses, so this would quietly hand out a
+        # subscription that nobody has to renew. Every processor sends the
+        # paid-through date; an event that does not carry one is a shape this
+        # server has not understood, and understanding it wrongly is worse than
+        # refusing it.
+        return await _record(
+            db,
+            event,
+            REFUSED,
+            detail="event carries no billing period end, and a grant without one would never expire",
         )
 
     try:

--- a/backend/tests/integration/test_billing.py
+++ b/backend/tests/integration/test_billing.py
@@ -87,6 +87,57 @@ def lemon_event(household: uuid.UUID | None, *, kind="subscription_created", ren
     return {"meta": meta, "data": {"type": "subscriptions", "id": "1", "attributes": {"renews_at": renews}}}
 
 
+@pytest.fixture
+def stripe(settings_override):
+    settings_override(BILLING_PROCESSOR="stripe", BILLING_WEBHOOK_SECRET=SECRET)
+
+
+def stripe_post(
+    payload: dict,
+    *,
+    secret: str = SECRET,
+    at: datetime | None = None,
+    extra_schemes: str = "",
+    secrets_live: tuple[str, ...] = (),
+) -> tuple[str, dict]:
+    """Sign the way Stripe does: `t=…,v1=…`, over "{t}.{body}".
+
+    `secrets_live` signs once per secret, which is what a rolled endpoint secret
+    looks like for the 24 hours both are active.
+    """
+    body = json.dumps(payload)
+    stamp = str(int((at or datetime.now(UTC)).timestamp()))
+    keys = secrets_live or (secret,)
+    signatures = ",".join(
+        f"v1={hmac.new(key.encode(), f'{stamp}.{body}'.encode(), hashlib.sha256).hexdigest()}" for key in keys
+    )
+    header = f"t={stamp},{signatures}"
+    if extra_schemes:
+        header = f"{header},{extra_schemes}"
+    return body, {"Stripe-Signature": header, "Content-Type": "application/json"}
+
+
+def stripe_event(
+    household: uuid.UUID | None,
+    *,
+    kind="customer.subscription.updated",
+    event_id="evt_stripe_1",
+    period_end: int | None = 1_818_000_000,
+    on_items: bool = False,
+):
+    obj: dict = {"id": "sub_1", "object": "subscription"}
+    if household is not None:
+        obj["metadata"] = {"household_id": str(household)}
+    if period_end is not None:
+        # Newer API versions carry the period on the items rather than the
+        # subscription; both shapes have to work.
+        if on_items:
+            obj["items"] = {"data": [{"id": "si_1", "current_period_end": period_end}]}
+        else:
+            obj["current_period_end"] = period_end
+    return {"id": event_id, "object": "event", "type": kind, "data": {"object": obj}}
+
+
 class TestItDoesNotExistUnlessTurnedOn:
     async def test_no_processor_means_no_endpoint(self, auth_client):
         """404, not 401 or 403: on almost every deployment the route really is
@@ -293,6 +344,122 @@ class TestARetryCannotGrantASecondYear:
         await client.post("/billing/webhook", content=body, headers=headers)
         async with sessions() as db:
             assert (await db.get(Household, target)).paid_until == first
+
+
+class TestStripeManagedPayments:
+    """Stripe is a merchant of record too since Managed Payments, so the account
+    this project already has can do the job. The signature scheme is the one
+    place a hand-rolled verifier goes wrong."""
+
+    async def test_a_subscription_grants_until_the_period_ends(self, client, stripe, sessions):
+        await register(client)
+        target = await household_id(sessions)
+        body, headers = stripe_post(stripe_event(target))
+
+        response = await client.post("/billing/webhook", content=body, headers=headers)
+        assert response.json() == {"outcome": "granted"}
+        async with sessions() as db:
+            household = await db.get(Household, target)
+        assert (household.tier, household.entitlement_source) == ("paid", "stripe")
+        assert entitlements.describe(household).paid_until == datetime.fromtimestamp(1_818_000_000, tz=UTC)
+
+    async def test_the_period_can_live_on_the_subscription_items(self, client, stripe, sessions):
+        """Newer API versions moved `current_period_end` onto each item."""
+        await register(client)
+        target = await household_id(sessions)
+        body, headers = stripe_post(stripe_event(target, on_items=True))
+        assert (await client.post("/billing/webhook", content=body, headers=headers)).json()["outcome"] == "granted"
+
+    async def test_a_deleted_subscription_revokes(self, client, stripe, sessions):
+        await register(client)
+        target = await household_id(sessions)
+        body, headers = stripe_post(stripe_event(target))
+        await client.post("/billing/webhook", content=body, headers=headers)
+
+        ended, ended_headers = stripe_post(
+            stripe_event(target, kind="customer.subscription.deleted", event_id="evt_stripe_2")
+        )
+        assert (await client.post("/billing/webhook", content=ended, headers=ended_headers)).json()[
+            "outcome"
+        ] == "revoked"
+        async with sessions() as db:
+            assert (await db.get(Household, target)).tier == "free"
+
+    async def test_an_invoice_event_is_ignored_rather_than_double_counted(self, client, stripe, sessions):
+        """The subscription object is the source of truth for "paid until when";
+        acting on the invoice too would be two writes for one payment."""
+        await register(client)
+        target = await household_id(sessions)
+        body, headers = stripe_post(stripe_event(target, kind="invoice.paid", event_id="evt_stripe_3"))
+        assert (await client.post("/billing/webhook", content=body, headers=headers)).json()["outcome"] == "ignored"
+
+    async def test_any_live_signature_matches_while_a_secret_is_rolling(self, client, stripe, sessions):
+        """Rolling an endpoint secret keeps the old one live for up to 24 hours,
+        and Stripe signs once per active secret. Checking only the first would
+        break every webhook for a day."""
+        await register(client)
+        target = await household_id(sessions)
+        body, headers = stripe_post(stripe_event(target), secrets_live=("the-previous-secret", SECRET))
+        assert (await client.post("/billing/webhook", content=body, headers=headers)).json()["outcome"] == "granted"
+
+    async def test_a_v0_signature_is_never_accepted(self, client, stripe, sessions):
+        """Stripe sends a deliberately fake `v0` beside test events. Accepting
+        any scheme but v1 is a downgrade attack."""
+        await register(client)
+        target = await household_id(sessions)
+        payload = stripe_event(target)
+        body = json.dumps(payload)
+        stamp = str(int(datetime.now(UTC).timestamp()))
+        # A perfectly good signature, offered under the wrong scheme.
+        forged = hmac.new(SECRET.encode(), f"{stamp}.{body}".encode(), hashlib.sha256).hexdigest()
+        headers = {"Stripe-Signature": f"t={stamp},v0={forged}", "Content-Type": "application/json"}
+        assert (await client.post("/billing/webhook", content=body, headers=headers)).status_code == 401
+
+    async def test_a_wrong_secret_is_refused(self, client, stripe, sessions):
+        await register(client)
+        body, headers = stripe_post(stripe_event(await household_id(sessions)), secret="not-the-secret")
+        assert (await client.post("/billing/webhook", content=body, headers=headers)).status_code == 401
+
+    async def test_a_stale_signature_is_refused(self, client, stripe, sessions):
+        await register(client)
+        old = datetime.now(UTC) - timedelta(hours=2)
+        body, headers = stripe_post(stripe_event(await household_id(sessions)), at=old)
+        assert (await client.post("/billing/webhook", content=body, headers=headers)).status_code == 401
+
+    async def test_a_retry_is_absorbed(self, client, stripe, sessions):
+        await register(client)
+        target = await household_id(sessions)
+        body, headers = stripe_post(stripe_event(target))
+        assert (await client.post("/billing/webhook", content=body, headers=headers)).json()["outcome"] == "granted"
+        # Stripe re-signs every retry, so the header differs while the event id
+        # does not. The ledger keys on the id, which is why this is caught.
+        again, again_headers = stripe_post(stripe_event(target))
+        assert (await client.post("/billing/webhook", content=again, headers=again_headers)).json()[
+            "outcome"
+        ] == "duplicate"
+
+
+class TestAGrantAlwaysHasAnEndDate:
+    """A grant with no expiry never lapses, so a webhook that produced one would
+    quietly hand out a subscription nobody has to renew."""
+
+    async def test_stripe_without_a_period_end(self, client, stripe, sessions):
+        await register(client)
+        target = await household_id(sessions)
+        body, headers = stripe_post(stripe_event(target, period_end=None))
+        response = await client.post("/billing/webhook", content=body, headers=headers)
+        assert response.json()["outcome"] == "refused"
+        async with sessions() as db:
+            household = await db.get(Household, target)
+            event = (await db.execute(select(BillingEvent))).scalars().one()
+        assert household.tier == "unlimited"  # untouched
+        assert "would never expire" in event.detail
+
+    async def test_paddle_without_a_billing_period(self, client, paddle, sessions):
+        await register(client)
+        target = await household_id(sessions)
+        body, headers = paddle_post(paddle_event(target, ends=None))
+        assert (await client.post("/billing/webhook", content=body, headers=headers)).json()["outcome"] == "refused"
 
 
 class TestNothingFailsQuietly:

--- a/planning/06-marketing.md
+++ b/planning/06-marketing.md
@@ -122,8 +122,10 @@ meal planning is a shared family utility with natural yearly cadence.
 **Amended 2026-08-21:** the tier structure, the caps, the payment route and the
 reason the iPhone app never mentions money are decided in
 [`08-freemium.md`](08-freemium.md). Blockers 1 and 2 below are done; blocker 3
-is now a merchant of record rather than Stripe links, because EU B2C digital
-services VAT applies from the first sale.
+is now a merchant of record rather than plain Stripe payment links, because EU
+B2C digital services VAT applies from the first sale. **Corrected 2026-08-23:**
+that does not mean "not Stripe" — Stripe Managed Payments is itself a merchant
+of record, and is the recommendation. See [`08-freemium.md`](08-freemium.md) §7.
 
 Hard blockers before taking anyone's money, in order:
 

--- a/planning/08-freemium.md
+++ b/planning/08-freemium.md
@@ -228,9 +228,34 @@ Two things follow for whoever reads this next:
 
 06 §1b listed four blockers. Three are done: backups with a tested restore
 (2026-08-17), SMTP on the deployment (2026-08-13), and a payment mechanism is
-now scoped as web-only (§6, and a merchant of record rather than raw Stripe,
-because EU B2C digital services VAT applies from the first sale regardless of
-the UK threshold).
+now scoped as web-only (§6) and taken through a **merchant of record**, because
+EU B2C digital services VAT applies from the first sale regardless of the UK
+threshold.
+
+**Corrected 2026-08-23.** This used to read "a merchant of record rather than
+raw Stripe", which stated the requirement and then a false dichotomy. The
+requirement is right and unchanged: somebody has to be the legal seller and file
+in the customer's country, and doing that ourselves means registering for VAT
+OSS, charging 27 rates, keeping two pieces of location evidence per sale and
+filing quarterly, for the sake of the ~3% between a processor's fee and an
+MoR's. At 25 households that difference is about £17 a year.
+
+What was wrong is the implication that an MoR means *not Stripe*. **Stripe
+Managed Payments** (2026) is Stripe acting as merchant of record: it handles
+sales tax, VAT and GST in 80+ countries, plus fraud, disputes and
+transaction-level support, on the Stripe account this project already has. So
+the choice is now between three, and the code supports all three
+(`app/services/billing.py`, `BILLING_PROCESSOR`):
+
+| | Merchant of record | Notes |
+|---|---|---|
+| **Stripe Managed Payments** | Stripe | The recommendation. Uses the existing account. Enabled on Checkout or Payment Links; **does not support creating a subscription outside those**, which is fine for a web-only flow and rules out a bespoke checkout later. |
+| Paddle | Paddle | The independent option, if an MoR that is not also the payment processor is worth something. |
+| Lemon Squeezy | Lemon Squeezy | **Do not start here.** Stripe acquired it in 2024 and its founder confirmed in January 2026 that migration paths *off* it and into Managed Payments are being built. The adapter stays for anyone already on it. |
+
+Still to confirm before the first sale: Managed Payments pricing (reported at
+5% + $0.50, not read off Stripe's own pricing page), and an accountant's five
+minutes on the UK-seller position. The adapter is written either way.
 
 The fourth is not, and freemium makes it worse rather than better, because free
 households arrive faster than paying ones: **strangers' data should not share a


### PR DESCRIPTION
## What and why

Follows the question on [#99](https://github.com/marco308/meals/issues/99): why an MoR over the Stripe account you already have.

The planning docs said **"a merchant of record rather than raw Stripe"**, which stated a requirement and then an implication that does not follow. The requirement is right and unchanged: somebody has to be the legal seller so EU B2C digital-services VAT, due from the first sale regardless of the UK threshold, is theirs to file. Doing it yourself means VAT OSS registration, 27 rates, two pieces of location evidence per sale and quarterly returns, to save the ~3% between a processor's fee and an MoR's. At 25 households that is about £17 a year.

What did not follow is *so not Stripe*. **Stripe Managed Payments** is Stripe acting as merchant of record ([their docs](https://docs.stripe.com/managed-payments)): sales tax, VAT and GST in 80+ countries, plus fraud, disputes and transaction-level support, on the account you already have. So it is here and it is the recommendation. Paddle stays as the independent option. Lemon Squeezy is now documented as the one **not** to start on: Stripe acquired it in 2024 and its founder confirmed in January 2026 that migration paths off it are being built; the adapter stays for anyone already there.

## The two things a hand-rolled Stripe verifier gets wrong

Both are explicit in [Stripe's docs](https://docs.stripe.com/webhooks) and both are tested:

- **Several `v1` signatures can be live at once.** Rolling an endpoint secret keeps the previous one active for 24 hours and Stripe signs once per secret, so any match counts. Checking only the first would break every webhook for a day, at the exact moment you were doing security hygiene.
- **Every other scheme must be ignored.** `v0` is a deliberately fake signature sent beside test events; accepting one is a downgrade attack. The test offers a *valid* HMAC under `v0` and requires a 401.

## A gap this turned up, not Stripe-specific

Reading Stripe's payload shapes surfaced something the existing adapters shared: an event carrying **no billing period** would have granted an entitlement with no expiry. A null `paid_until` never lapses by design, so that is a subscription nobody has to renew, handed out silently. No webhook can now grant without an end date, on any processor, and Paddle's version of the case is tested too.

Also handled: `current_period_end` sits on the subscription in older API versions and on each item in newer ones. Both are read, latest wins.

## Docs corrected

`08-freemium.md` §7 and `06-marketing.md` both carried the old framing. §7 now has the reasoning, the three-way comparison and what is still unconfirmed.

## Still yours to confirm

- **Managed Payments pricing.** Reported at 5% + $0.50, but from secondary sources, not Stripe's own pricing page.
- **One real constraint**: Managed Payments cannot create a subscription outside Checkout or Payment Links. Fine for the web-only flow in §6; it does rule out a bespoke checkout later.
- I am not your accountant.

## Checklist

- [x] **API contract stayed additive** — no schema or response change; one new value accepted for an existing setting.
- [x] **Model change has a migration** — n/a, no model change.
- [x] **Shopping-list quantities still derive from `ListItemSource`** — n/a.
- [x] **Every new query filters on `household_id`** — unchanged: the webhook looks up exactly the household named in the checkout metadata, and an unmatched id is an orphan rather than a guess.
- [x] **Skill/prompt pack updated** — n/a.
- [x] **New 4xx strings say what to do instead** — no new ones.

865 backend tests, 67 MCP, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
