### PR TITLE
Cut 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,29 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 
 ## Unreleased
 
+Nothing merged since the last deploy.
+
+## 2026-08-23 — the freemium backend, end to end
+
+Deployed to `meals.marcuslab.uk` as **1.2.0**. **Two migrations**
+(`74e2494dfabf`, `508d35134cdc`), both additive: five nullable columns on
+`households` and one new `billing_events` table. Safe under the start-first
+rollout, since neither takes anything away from the outgoing container still
+reading those tables.
+
+**Nothing in this release is switched on here.** The family instance sets no
+`LIMITS_PROFILE`, no `MAX_HOUSEHOLDS`, no `BILLING_PROCESSOR` and no entitlement
+on any household, so every limit is unlimited, the instance ceilings are
+absent, `/billing/webhook` does not exist, and no household has an expiry to
+lapse past. What actually changes for a user of this deployment is two new
+endpoints that answer honestly about having no limits, and a `/terms` page that
+says almost none of it applies to them. That is the whole point of §1: the
+freemium machinery is invisible on a server that sells nothing, and this deploy
+is the first real test of that claim against a live household.
+
+This closes issues #95 through #100, which is the whole of
+`planning/08-freemium.md` §8.
+
 ### Added
 
 - **The billing webhook** ([#99](https://github.com/marco308/meals/issues/99)),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -57,7 +57,7 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(
     lifespan=lifespan,
     title="Meals API",
-    version="1.1.1",
+    version="1.2.0",
     description=(
         "A meal *options* planner (not a rigid Mon–Sun grid) with a recipe library and an "
         "aisle-sorted shopping list. Designed to be driven by any AI assistant: every error "

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meals-backend"
-version = "1.1.1"
+version = "1.2.0"
 description = "Meal options planner backend — recipes, meals, plans, aisle-sorted shopping list, AI-friendly API"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "meals-backend"
-version = "1.1.1"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosmtplib" },
@@ -890,7 +890,7 @@ dev = [
 
 [[package]]
 name = "meals-mcp"
-version = "1.1.1"
+version = "1.2.0"
 source = { directory = "../mcp" }
 dependencies = [
     { name = "httpx" },

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meals-mcp"
-version = "1.1.1"
+version = "1.2.0"
 description = "MCP server wrapping the Meals REST API with task-level tools for AI assistants"
 requires-python = ">=3.12"
 dependencies = [

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -365,7 +365,7 @@ wheels = [
 
 [[package]]
 name = "meals-mcp"
-version = "1.1.1"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Version bump to **1.2.0** in the three places the release job checks (`backend/pyproject.toml`, `mcp/pyproject.toml`, the FastAPI `version=`), plus the changelog release note.

Covers everything merged since v1.1.1: issues #95 through #100, which is the whole of `planning/08-freemium.md` §8.

**Two migrations**, both additive — five nullable columns on `households` and one new `billing_events` table. Neither takes anything away from the outgoing container during a start-first rollout.

**Nothing in this release is switched on for `meals.marcuslab.uk`.** No `LIMITS_PROFILE`, no `MAX_HOUSEHOLDS`, no `BILLING_PROCESSOR`, no household with an expiry. So every limit is unlimited, the instance ceilings are absent, `/billing/webhook` does not exist, and nothing can lapse. What changes for a real user is two endpoints that answer honestly about having no limits, and a `/terms` page that opens by saying almost none of it applies to them.

That is the §1 claim, and this deploy is the first test of it against a live household rather than a test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)