### PR TITLE
Tell a household what it is allowed, where there is anything to say

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -47,7 +47,20 @@ Filed, in the order they should be built:
 [#100](https://github.com/marco308/meals/issues/100) keeping the app free of
 commerce. The first five are worth having on a self-hosted instance too, which
 is why they come first: if the hosted business never happens they are not
-wasted.
+wasted. **All seven are done**, and shipped in 1.1.0 and 1.2.0.
+
+What is left is the half a household actually touches, filed 2026-08-23 once
+the backend was finished and the web app turned out to consume none of it:
+[#120](https://github.com/marco308/meals/issues/120) the web app showing a
+household what it is allowed — done, and no commerce in it;
+[#121](https://github.com/marco308/meals/issues/121) the half of the money that
+happens *before* the webhook, since `routers/billing.py` holds one route and
+nothing in this repo can start the checkout it waits for; and
+[#122](https://github.com/marco308/meals/issues/122) what has to exist before
+`REGISTRATION_ENABLED` can be true on a public instance — email verification,
+which does not exist, signup rate limits, and a policy for reaping abandoned
+free households. #122 was a bullet inside #99 and closed with it unbuilt, which
+is why it is now its own line.
 
 **None of it ships unless the waitlist gate in 06 §Phase 3 is passed**, and one
 blocker stays off the tracker because it is deployment topology rather than

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,6 +268,22 @@ it boring to operate:
   strings outside it.
 - Dialog code must not depend on the `close` *event* — some embedded browsers
   never deliver it; `openDialog` patches `close()` to also remove the element.
+- **No inline `style` attributes**: the CSP's `style-src 'self'` forbids them.
+  A computed width (the allowance bars in Settings) travels on a data attribute
+  and is applied through the CSSOM, which CSP deliberately does not police.
+- **It is the only client that shows a household its allowances**, and it shows
+  them only where there is something to show: Settings reads `GET /limits` and
+  the signup screen reads the unauthenticated `GET /client-config`, and on a
+  deployment that has configured nothing both are silent. `limited` is the
+  switch rather than the numbers, so a household comped to the unlimited tier on
+  a server that *does* limit things is still told where it stands. Neither
+  surface names a price or points anywhere to pay one — whether this server
+  sells anything at all is a question neither endpoint answers. `settings.js`
+  carries a label for every resource in `app/limits.py` and the signup note a
+  phrase for every household-wide one, both linted by
+  `tests/unit/test_web_client.py`, because this is the second place that
+  vocabulary is written down. Downloading the household export is here too, on
+  the same footing as everywhere else: free of every limit, in every tier.
 - The 4xx `detail` strings the API writes for AI clients are shown verbatim in
   toasts — another reason to keep them human sentences.
 

--- a/backend/tests/unit/test_web_client.py
+++ b/backend/tests/unit/test_web_client.py
@@ -1,0 +1,75 @@
+"""The web client's half of the limits vocabulary (issue #120).
+
+`web/` ships inside this image and calls `GET /limits` and `GET /client-config`
+to tell a household what it is allowed. Both answer with the resource *names*
+from `app/limits.py`, which makes that module the vocabulary and the web app a
+second place where it is written down — the same shape as the aisle list and
+the skill, and kept in step for the same reason.
+
+Nothing here breaks if a name is missed: `resourceLabel` falls back to the raw
+name with its underscores knocked out, and the signup note simply omits what it
+has no phrase for. This is a lint so that the omission is loud rather than
+shipped, exactly as the export test makes an unlisted column loud.
+
+There is no JavaScript test harness in this repo (no build step is the whole
+point of `web/`), so this reads the source. It asserts what is *listed*, not
+what renders; whether the card looks right is a browser's job.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from app import limits
+
+WEB = Path(__file__).resolve().parents[3] / "web" / "js" / "views"
+
+#: The two allowances that bound one meal or one plan rather than the household.
+#: `GET /limits` reports them with `used: null`, the settings card gives them a
+#: number and no bar, and the signup note leaves them out on purpose: they say
+#: nothing about what an account holds.
+PER_ITEM = ("meal_lines", "plan_meals")
+
+
+def _block(source: Path, opener: str) -> str:
+    """The text of one object or array literal, from its opening brace to the
+    matching close — enough to read the names out of without a JS parser."""
+    text = source.read_text()
+    start = text.index(opener) + len(opener) - 1
+    depth = 0
+    for index in range(start, len(text)):
+        if text[index] in "{[":
+            depth += 1
+        elif text[index] in "}]":
+            depth -= 1
+            if depth == 0:
+                return text[start : index + 1]
+    raise AssertionError(f"{opener} is never closed in {source.name}")
+
+
+def test_settings_labels_every_resource():
+    """A new limit must arrive with a name a person would recognise."""
+    block = _block(WEB / "settings.js", "const RESOURCE_LABELS = {")
+    labelled = set(re.findall(r"^\s*([a-z_]+):", block, re.MULTILINE))
+    assert set(limits.RESOURCE_NAMES) - labelled == set(), (
+        "web/js/views/settings.js RESOURCE_LABELS is missing a resource that app/limits.py enforces"
+    )
+    assert labelled - set(limits.RESOURCE_NAMES) == set(), "RESOURCE_LABELS names something that is not a limit"
+
+
+def test_signup_note_covers_what_an_account_holds():
+    """The signup note lists the household-wide allowances and only those."""
+    block = _block(WEB / "login.js", "const ALLOWANCES = [")
+    listed = set(re.findall(r'\["([a-z_]+)"', block))
+    expected = set(limits.RESOURCE_NAMES) - set(PER_ITEM)
+    assert listed == expected, (
+        "web/js/views/login.js ALLOWANCES should phrase every household-wide limit and no per-meal one"
+    )
+
+
+@pytest.mark.parametrize("name", PER_ITEM)
+def test_per_item_allowances_are_still_per_item(name):
+    """The two the signup note leaves out are left out because of this flag, so
+    if one ever becomes household-wide the note has to gain it."""
+    assert limits.RESOURCES[name].household_wide is False

--- a/planning/08-freemium.md
+++ b/planning/08-freemium.md
@@ -287,6 +287,28 @@ Backend first is deliberate: every one of 1 to 5 is worth having on a
 self-hosted instance too, so if the hosted business never happens they are not
 wasted, which is the same test 06 §Phase 3 applies to the whole plan.
 
+**1 to 7 are done** (1.1.0 and 1.2.0). Finishing them made plain what backend
+first had left out, which is everything a household touches, so the list gained
+three more on 2026-08-23:
+
+8. The web app showing a household what it is allowed, and where to get its data
+   ([#120](https://github.com/marco308/meals/issues/120)). No commerce in it:
+   `limited` from `GET /limits` is the switch, so a server that configures
+   nothing shows nothing.
+9. Web purchase and subscription management
+   ([#121](https://github.com/marco308/meals/issues/121)) — the half of §7 that
+   happens before the webhook. `routers/billing.py` holds one route, so the
+   checkout it waits for is one nothing here can start, and `LimitsOut` cannot
+   describe a subscription it has no `paid_until` for.
+10. Opening registration ([#122](https://github.com/marco308/meals/issues/122)):
+    the email verification this codebase does not have, signup rate limits, and
+    a policy for reaping abandoned free households. Named in §7's last
+    paragraph, carried as a bullet in #99, and closed with it unbuilt.
+
+9 and 10 sit behind §9's gate. 8 does not, because a household on a limited
+server deserves to know where it stands whether or not anything is ever sold,
+and the export button is the same promise §1 makes.
+
 ## 9. Decision metric
 
 Unchanged from 06 §Phase 3: waitlist size one month after the Show HN push.

--- a/web/app.css
+++ b/web/app.css
@@ -823,6 +823,40 @@ dialog .sub { color: var(--ink-mute); font-size: .9rem; margin: .2rem 0 .9rem; }
 
 .market-pick { width: auto; font: inherit; font-size: inherit; color: inherit; background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding: .05rem .35rem; }
 
+/* ── allowances: what this server allows, and the signup note ───────── */
+
+.allow-list { margin-top: .3rem; }
+.allow-row { display: flex; align-items: center; gap: 1rem; padding: .55rem .1rem; border-bottom: 1px dashed var(--line); }
+.allow-row:last-child { border-bottom: 0; }
+.allow-row .a-main { display: flex; flex-direction: column; gap: .1rem; flex: 1; min-width: 0; }
+.allow-row .a-main b { font-family: var(--display); font-size: .98rem; }
+.allow-row .a-cap { font-family: var(--mono); font-size: .82rem; color: var(--ink-mute); flex: none; }
+.allow-row .a-bar {
+  flex: none;
+  width: 140px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--cream-2);
+  overflow: hidden;
+}
+/* The width of the fill is set through the CSSOM in settings.js — a style
+   attribute would need 'unsafe-inline' in the CSP, which is not a trade worth
+   making for a progress bar. */
+.allow-row .a-bar span { display: block; height: 100%; background: var(--leek); border-radius: 999px; }
+.allow-row .a-bar.full span { background: var(--tomato); }
+
+.allow-note {
+  margin-top: 1.1rem;
+  padding: .85rem 1rem;
+  background: var(--cream-2);
+  border-radius: 14px;
+  font-size: .85rem;
+  color: var(--ink-soft);
+}
+.allow-note b { font-family: var(--display); display: block; margin-bottom: .35rem; }
+.allow-note ul { margin: 0; padding-left: 1.1rem; }
+.allow-note li { margin: .12rem 0; }
+
 /* ── responsive ─────────────────────────────────────────────────────── */
 
 @media (max-width: 900px) {

--- a/web/js/api.js
+++ b/web/js/api.js
@@ -60,19 +60,23 @@ function detailText(data, status) {
   return `request failed (${status})`;
 }
 
+function headers(extra) {
+  const out = { "X-Meals-Client": CLIENT_HEADER, ...extra };
+  if (session.token) out["Authorization"] = `Bearer ${session.token}`;
+  return out;
+}
+
 export async function api(path, { method = "GET", body, query } = {}) {
   const url = new URL(".." + path, window.location.href);
   for (const [key, value] of Object.entries(query || {})) {
     if (value !== undefined && value !== null && value !== "") url.searchParams.set(key, value);
   }
 
-  const headers = { "X-Meals-Client": CLIENT_HEADER };
-  if (session.token) headers["Authorization"] = `Bearer ${session.token}`;
-  if (body !== undefined) headers["Content-Type"] = "application/json";
+  const requestHeaders = headers(body === undefined ? {} : { "Content-Type": "application/json" });
 
   const response = await fetch(url, {
     method,
-    headers,
+    headers: requestHeaders,
     body: body === undefined ? undefined : JSON.stringify(body),
   });
 
@@ -92,6 +96,39 @@ export async function api(path, { method = "GET", body, query } = {}) {
     throw new ApiError(response.status, detailText(data, response.status));
   }
   return data;
+}
+
+// A file, not a payload: /household/export streams a whole household and
+// arrives as a download. The bearer token has to travel in a header — never in
+// a URL, which /privacy is a promise about — so the browser cannot simply be
+// pointed at the endpoint. We fetch it, wrap the body in a blob, and click our
+// own link. The CSP needs no `blob:` source for that — a download is not a
+// fetch — and `connect-src 'self'` already covers the request itself.
+export async function download(path) {
+  const response = await fetch(new URL(".." + path, window.location.href), { headers: headers() });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => null);
+    if (response.status === 401 && session.token) {
+      session.clear();
+      window.location.hash = "#/login";
+    }
+    throw new ApiError(response.status, detailText(data, response.status));
+  }
+
+  // The server names the file (Content-Disposition), because it knows the date
+  // it assembled and we would only be guessing it.
+  const named = /filename="?([^";]+)"?/i.exec(response.headers.get("Content-Disposition") || "");
+  const href = URL.createObjectURL(await response.blob());
+  const link = document.createElement("a");
+  link.href = href;
+  link.download = named ? named[1] : path.slice(path.lastIndexOf("/") + 1);
+  document.body.append(link);
+  link.click();
+  link.remove();
+  // Revoking straight away cancels the save in some browsers; the tab keeping
+  // one blob alive for a minute is the cheaper mistake.
+  setTimeout(() => URL.revokeObjectURL(href), 60_000);
 }
 
 let aisleCache = null;

--- a/web/js/views/login.js
+++ b/web/js/views/login.js
@@ -21,6 +21,7 @@ export function renderLogin(root) {
           <button data-mode="register" class="${mode === "register" ? "on" : ""}">Register</button>
         </div>
         <form data-form>${formBody()}</form>
+        <div data-allowances></div>
         <p class="login-foot">${footNote()}</p>
       </div>
     </div>
@@ -55,6 +56,8 @@ export function renderLogin(root) {
     };
   }
 
+  paintAllowances(root);
+
   const form = root.querySelector("[data-form]");
   form.onsubmit = async (event) => {
     event.preventDefault();
@@ -69,6 +72,53 @@ export function renderLogin(root) {
       button.disabled = false;
     }
   };
+}
+
+// ── what an account here includes ────────────────────────────────────────
+//
+// planning/08-freemium.md §4: the numbers ride on the unauthenticated
+// GET /client-config precisely so this page can show them, since a signup page
+// has nobody to log in as yet. On a server that limits nothing every one of
+// them is null and this says nothing at all, which is §1 doing its job.
+//
+// Shown only when starting a household: an invite code joins somebody else's,
+// whose allowances are theirs and not these.
+
+const ALLOWANCES = [
+  // The order is the order the wall is met in: the member limit is the gate.
+  ["members", (n) => `${n} ${n === 1 ? "person" : "people"}`],
+  ["recipes", (n) => `${n} recipes`],
+  ["meals", (n) => `${n} meals`],
+  ["plans", (n) => `${n} plans on the go`],
+  ["ingredients", (n) => `${n} ingredients`],
+  ["supermarkets", (n) => `${n} ${n === 1 ? "supermarket" : "supermarkets"}`],
+  ["api_tokens", (n) => `${n} API ${n === 1 ? "token" : "tokens"}`],
+  ["ingests_per_month", (n) => `${n} recipes read from a URL each month`],
+];
+
+let allowances = null; // null until asked; {} once the answer is in
+
+function paintAllowances(root) {
+  const slot = root.querySelector("[data-allowances]");
+  if (!slot || mode !== "register" || joinMode !== "new") return;
+  if (allowances === null) {
+    allowances = {};
+    api("/client-config")
+      .then((config) => {
+        allowances = config.free_tier_limits || {};
+        paintAllowances(root); // painting a slot, never re-rendering: the form may be half typed
+      })
+      .catch(() => {}); // a server that cannot answer this has a louder problem
+    return;
+  }
+  const rows = ALLOWANCES.filter(([name]) => allowances[name] !== null && allowances[name] !== undefined);
+  if (rows.length === 0) return;
+  render(slot, html`
+    <div class="allow-note">
+      <b>What an account here includes</b>
+      <ul>${rows.map(([name, phrase]) => html`<li>${phrase(allowances[name])}</li>`)}</ul>
+    </div>
+  `);
 }
 
 function formBody() {

--- a/web/js/views/settings.js
+++ b/web/js/views/settings.js
@@ -1,22 +1,24 @@
 // Settings: account, the household and who is in it (Q19/Q23), supermarkets &
-// aisle order, AI access tokens, and the danger zone (Q20). Invite codes and
-// API tokens are shown exactly once — the server stores only hashes.
+// aisle order, AI access tokens, what this server allows, taking your data
+// away, and the danger zone (Q20). Invite codes and API tokens are shown
+// exactly once — the server stores only hashes.
 //
 // The lead is the only member who can invite, remove or rename (Q23), so those
 // controls are hidden rather than shown-and-refused for everyone else. Leaving
 // is nobody's business but your own, so that button is always there.
 
-import { aisles, api, invalidateAisles, session } from "../api.js";
+import { aisles, api, download, invalidateAisles, session } from "../api.js";
 import { confirmDialog, fmtDate, fmtRel, html, openDialog, parseUtc, render, skeleton, toast } from "../dom.js";
 
 export async function renderSettings(root) {
   render(root, skeleton());
-  const [user, household, invites, tokens, markets] = await Promise.all([
+  const [user, household, invites, tokens, markets, allowances] = await Promise.all([
     api("/auth/me"),
     api("/auth/household"),
     api("/auth/invites"),
     api("/auth/tokens"),
     api("/supermarkets"),
+    api("/limits"),
   ]);
   session.saveUser(user);
   const youLead = household.lead_user_id === user.id;
@@ -95,6 +97,8 @@ export async function renderSettings(root) {
           : html`<p class="sub">No invites issued yet.</p>`}
         ${youLead ? html`<div class="dialog-actions"><button class="btn" data-invite>Invite someone</button></div>` : ""}
       </div>
+
+      ${allowancesSection(allowances)}
 
       <div class="section card">
         <h2>Supermarkets &amp; aisle order</h2>
@@ -178,6 +182,19 @@ export async function renderSettings(root) {
           <p class="sub">Other signed-in devices get logged out; API tokens deliberately survive.</p>
           <div class="dialog-actions"><button class="btn" type="submit">Change password</button></div>
         </form>
+      </div>
+
+      <div class="section card">
+        <h2>Take everything with you</h2>
+        <p class="sub">
+          One file holding every recipe, ingredient, meal, plan, cooked shop and
+          saved supermarket this household owns — the whole thing rather than a
+          summary, and readable without joining anything back together.
+          Passwords, API tokens and invite codes are deliberately left out.
+          It is free of every limit on every server, because leaving should
+          never be the hard part.
+        </p>
+        <div class="dialog-actions"><button class="btn ghost" data-export>Download everything</button></div>
       </div>
 
       <div class="section card danger-zone">
@@ -323,7 +340,109 @@ export async function renderSettings(root) {
     }
   };
 
+  // The bars are the one place a width is computed rather than written, and
+  // index.html's `style-src 'self'` forbids a style *attribute*, so the number
+  // rides on a data attribute and is applied through the CSSOM, which CSP
+  // deliberately does not police.
+  for (const fill of root.querySelectorAll("[data-fill]")) fill.style.width = `${fill.dataset.fill}%`;
+
+  root.querySelector("[data-export]").onclick = async (event) => {
+    const button = event.currentTarget;
+    button.disabled = true;
+    try {
+      await download("/household/export");
+      toast("Your household is on its way to your downloads.", "ok");
+    } catch (error) {
+      toast(error.detail || error.message, "error");
+    } finally {
+      button.disabled = false;
+    }
+  };
+
   root.querySelector("[data-delete-account]").onclick = () => deleteAccountDialog();
+}
+
+// ── what this server allows ──────────────────────────────────────────────
+//
+// planning/08-freemium.md §1: a quota on somebody's hosting, never a fence
+// around the tool. On a server that has configured nothing, this card is
+// absent — not empty, not a row of "unlimited", absent — and `limited` from
+// GET /limits is the switch that decides it. Reading the flag rather than
+// inferring it from the numbers is deliberate: a household comped to the
+// unlimited tier on a server that *does* limit things has every number null
+// and still deserves to be told where it stands.
+//
+// Nothing here names a price or points anywhere to pay one. Whether this
+// server sells anything at all is a question GET /limits cannot answer, and
+// answering it is issue #121's job rather than this card's.
+
+const RESOURCE_LABELS = {
+  members: "People in this household",
+  recipes: "Recipes",
+  ingredients: "Ingredients",
+  meals: "Meals",
+  meal_lines: "Lines in one meal",
+  plans: "Plans on the go",
+  plan_meals: "Meals in one plan",
+  supermarkets: "Supermarkets",
+  api_tokens: "API tokens",
+  ingests_per_month: "Recipes read from a URL",
+};
+
+// A server vocabulary, so an unknown name must render rather than vanish —
+// the same rule that keeps aisles and slots out of the iOS enums.
+const resourceLabel = (name) => RESOURCE_LABELS[name] || name.replace(/_/g, " ");
+
+function allowancesSection(allowances) {
+  if (!allowances.limited) return "";
+  const capped = allowances.resources.filter((row) => row.limit !== null);
+  return html`
+    <div class="section card">
+      <h2>What this server allows</h2>
+      <p class="sub">
+        ${capped.length === 0
+          ? "This server sets limits, and none of them apply to this household."
+          : html`Nothing you have already saved is ever removed by a limit, and the shopping list is
+              never limited at all — a cap only ever stops something new being added.`}
+      </p>
+      ${capped.length === 0 ? "" : html`<div class="allow-list">${capped.map(allowanceRow)}</div>`}
+    </div>
+  `;
+}
+
+function allowanceRow(row) {
+  // `used` is null where a household-wide count would mean nothing: the
+  // per-meal and per-plan allowances bound the next one rather than tally what
+  // exists, so they get the number alone and no bar to fill.
+  if (row.used === null) {
+    return html`
+      <div class="allow-row">
+        <div class="a-main"><b>${resourceLabel(row.resource)}</b></div>
+        <span class="a-cap">up to ${row.limit}</span>
+      </div>
+    `;
+  }
+  const percent = Math.min(100, Math.round((row.used / row.limit) * 100));
+  return html`
+    <div class="allow-row">
+      <div class="a-main">
+        <b>${resourceLabel(row.resource)}</b>
+        <span class="sub">${allowanceUsage(row)}</span>
+      </div>
+      <div class="a-bar ${row.remaining === 0 ? "full" : ""}"><span data-fill="${percent}"></span></div>
+    </div>
+  `;
+}
+
+function allowanceUsage(row) {
+  const period = row.scope === "a month" ? " this month" : "";
+  if (row.remaining !== 0) return `${row.used} of ${row.limit} used${period} · ${row.remaining} left`;
+  // At the wall is the one moment the difference between the two kinds of
+  // limit (§4) is worth a sentence: one is this household's tier, the other is
+  // this server's own ceiling, which no tier lifts.
+  return row.upgradable
+    ? `${row.used} of ${row.limit} used${period} — at the limit for this household's tier`
+    : `${row.used} of ${row.limit} used${period} — at the most this server allows`;
 }
 
 function addMarketDialog(root) {


### PR DESCRIPTION
Closes #120.

The backend half of the freemium work is deployed and the web client consumed
none of it. Three surfaces, no commerce in any of them.

**Settings → "What this server allows"**, from `GET /limits`: a row per capped
resource with usage and a bar. `meal_lines` and `plan_meals` come back with
`used: null`, so they get the number alone and no bar — they bound the next
meal rather than tally what exists. At the wall, and only there, the row says
which kind of limit it is: "at the limit for this household's tier" where
`upgradable`, "at the most this server allows" where not (§4).

**The signup screen** lists what an account here includes, from the
unauthenticated `GET /client-config` — which §4 put there for precisely this,
since a signup page has nobody to log in as yet. Shown only when starting a
household: an invite code joins somebody else's, whose allowances are theirs.
It paints into its own slot rather than re-rendering the card, so a late answer
cannot wipe a half-typed form.

**An export button**, above the danger zone. `GET /household/export` has worked
since #97 and was reachable only by someone who knew the API existed, which is
a strange place to leave the one feature whose whole job is being easy to find.

### §1 is the thing to review

On a server that has configured nothing, none of this appears. `limited` from
`GET /limits` is the switch rather than a guess from the numbers, so a
household comped to the unlimited tier on a server that *does* limit things is
still told where it stands. Checked both ways against a local server:

| | `LIMITS_PROFILE=hosted` | unset |
|---|---|---|
| Allowances card | 10 rows, bars, "1 of 1 used — at the limit…" | absent |
| Signup note | 8 lines, members first | absent, slot empty |
| Export card | present | present |

Also exercised in the browser: the export fetch returns 200 with
`filename="meals-export-2026-08-23.json"` and 27KB of real JSON, no CSP
violation, and the note appears and disappears correctly across
register/new → register/invite → sign in → register. The one step I could not
observe is the browser writing the file to disk: the embedded pane sandboxes
downloads.

### Two constraints now written down

The CSP's `style-src 'self'` forbids a style *attribute*, so the one computed
width here rides on a data attribute and is applied through the CSSOM, which
CSP deliberately does not police.

`app/limits.py` is the vocabulary and the web app is now a second place it is
written down, which is the shape that eventually disagrees with itself.
`tests/unit/test_web_client.py` lints both lists against `RESOURCE_NAMES` —
nothing breaks without it (the label falls back to the raw name), but the
omission is loud rather than shipped, the same bargain the export test makes
about a new column. Checked it bites by deleting a label and a phrase.

### Docs

`planning/08-freemium.md` §8 and `BACKLOG.md` gain #120, #121 and #122, filed
once finishing #94 to #100 made plain what backend-first had left out. #122 was
a bullet inside #99 and closed with it unbuilt.

`make lint` clean, `make test-fast` green (869 backend, 67 mcp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
