### PR TITLE
Let somebody actually pay, and say what they are paying for

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,3 +62,22 @@ AUTH_RATE_LIMIT_PER_MINUTE=10
 #BILLING_PROCESSOR=stripe
 #BILLING_WEBHOOK_SECRET=
 #BILLING_SIGNATURE_TOLERANCE_SECONDS=300
+
+# Selling one, which is a second switch: with the two above alone this server
+# can be *told* about payments but holds no key that can charge anybody, and
+# POST /billing/checkout does not exist. BILLING_PRICE_ID is a Stripe price id,
+# a Paddle price id, or a Lemon Squeezy variant id (which also wants
+# BILLING_STORE_ID). BILLING_MANAGE_URL is the processor's own customer portal —
+# with a merchant of record, changing a card, reading an invoice and asking for
+# a refund are all theirs. BILLING_PRICE_PENCE is only what to *say* it costs on
+# the one screen that offers it; unset, no price is shown.
+# Also set DEFAULT_HOUSEHOLD_TIER=free: a server whose households start on the
+# top tier has nothing to sell them, and it refuses to boot rather than sell
+# nothing quietly.
+#BILLING_API_KEY=
+#BILLING_PRICE_ID=
+#BILLING_STORE_ID=
+#BILLING_MANAGE_URL=
+#BILLING_PRICE_PENCE=2000
+#BILLING_PRICE_CURRENCY=GBP
+#BILLING_API_BASE=https://sandbox-api.paddle.com

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -54,8 +54,9 @@ the backend was finished and the web app turned out to consume none of it:
 [#120](https://github.com/marco308/meals/issues/120) the web app showing a
 household what it is allowed — done, and no commerce in it;
 [#121](https://github.com/marco308/meals/issues/121) the half of the money that
-happens *before* the webhook, since `routers/billing.py` holds one route and
-nothing in this repo can start the checkout it waits for; and
+happens *before* the webhook — done, and inert: a checkout exists but no
+deployment holds a key to open one, and switching that on is still gated on §7's
+two confirmations and the Postgres separation; and
 [#122](https://github.com/marco308/meals/issues/122) what has to exist before
 `REGISTRATION_ENABLED` can be true on a public instance — email verification,
 which does not exist, signup rate limits, and a policy for reaping abandoned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,42 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 
 ## Unreleased
 
-Nothing merged since the last deploy.
+The web half of the money, and the web half of the limits. Two issues, both of
+them the same shape: the freemium machinery existed and nothing a household
+could see used it.
+
+### Added
+
+- **The web app shows a household what it is allowed**
+  ([#120](https://github.com/marco308/meals/issues/120)). Settings gains a
+  usage panel from `GET /limits`, the signup screen lists what an account here
+  includes from the unauthenticated `GET /client-config`, and there is finally a
+  button for `GET /household/export`, which had worked since #97 and been
+  reachable only by somebody who knew the API existed. `limited` is the switch:
+  on a server that has configured nothing, none of it appears.
+- **A checkout can be started** ([#121](https://github.com/marco308/meals/issues/121)).
+  `POST /billing/checkout` opens a hosted checkout with the household id where
+  the webhook will look for it, and `GET /billing/subscription` says what a
+  household has, until when, where it came from and where to manage it. Stripe,
+  Paddle and Lemon Squeezy, as before. Web only: the iPhone app carries no price,
+  no button and no link to one (`planning/08-freemium.md` §6).
+- **`GET /client-config` publishes `billing_enabled`**, the single answer to
+  whether this server sells anything at all — a different question from whether
+  it limits anything, and one a client would otherwise have to infer from a 404.
+- **`PRIVACY.md` names the processor**, which that section promised to do before
+  any money moved: Stripe Managed Payments for the author's hosted service, with
+  what is sent to them when a checkout starts (an email address and a household
+  id, and nothing else).
+
+### Notes for whoever deploys this
+
+- **Still inert.** `BILLING_API_KEY` and `BILLING_PRICE_ID` are unset here, so
+  `POST /billing/checkout` does not exist, and `billing_enabled` is false.
+- **A server that sells must set `DEFAULT_HOUSEHOLD_TIER=free`** and it now
+  refuses to boot otherwise: households starting on the top tier already have
+  everything a subscription would buy, so every checkout would be refused with a
+  409 that reads like a bug rather than a setting.
+- No migrations.
 
 ## 2026-08-23 — the freemium backend, end to end
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,26 @@ instrumentation a new feature usually needs.
   operator command on the box, like `app/provision.py`, never an endpoint), and
   `python -m app.dunning` from cron sends the two emails, each marked once so it
   never sends a third and never marked on a relay failure so it retries.
+- **Taking a payment is two switches, and both are off by default**
+  (`services/billing.py`, `routers/billing.py`). `BILLING_PROCESSOR` +
+  `BILLING_WEBHOOK_SECRET` let this server be *told* about payments;
+  `BILLING_API_KEY` + `BILLING_PRICE_ID` (`billing_sells`) let it start one, and
+  until both halves are set `POST /billing/checkout` does not exist either. The
+  split is the point: a box can receive webhooks while holding no credential
+  that could charge anybody. `POST /billing/checkout` is the household lead's
+  alone, which is the one place Q23 gates on them, and it **grants nothing** —
+  only a verified webhook with a billing period end does that, so an abandoned
+  checkout leaves no trace. The household id rides in the checkout's custom data
+  and has to land where the webhook reads it (`subscription_data[metadata]` for
+  Stripe, `custom_data` for Paddle, `checkout_data.custom` for Lemon Squeezy);
+  a payment that names no household is an orphan and somebody has paid for
+  nothing. **`managed_payments[enabled]=true` is what makes Stripe the merchant
+  of record** — omit it and the payment still succeeds, with the EU VAT silently
+  back on us, which is the whole reason §7 chose an MoR. Managing or cancelling
+  belongs to the processor (`BILLING_MANAGE_URL`), because they are the seller.
+  `GET /client-config` publishes `billing_enabled`, the single answer to "does
+  this server sell anything", which is a different question from whether it
+  limits anything.
 - **The billing webhook is off unless configured, and its failures are loud**
   (`services/billing.py`, `POST /billing/webhook`). Unset `BILLING_PROCESSOR`
   and the route **404s** rather than existing and refusing — a self-hosted

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -81,23 +81,32 @@ This section exists because `/privacy` is a published, permanent URL and it
 should be right *before* any money moves, not after.
 
 **Today, nothing here applies to anyone.** No payment is taken for any Meals
-server, no card details have ever reached this project, and there is no
-payment processor. If you self-host, that stays true forever: there is nothing
-to pay and nobody to pay it to.
+server, and no card details have ever reached this project. If you self-host,
+that stays true forever: the software takes no payments unless whoever runs it
+configures a processor, and with none configured there is not even an endpoint
+to take one — there is nothing to pay and nobody to pay it to.
 
 If the hosted service does open, one thing changes and it is worth stating in
-advance:
+advance. The processor is now chosen and named here, which is what this section
+promised to do before any money moved:
 
-- **Payment will go through a third-party merchant of record**, and this
-  section will name them here before a single payment is taken. They will
-  handle the card, the receipt and the VAT. Their privacy policy will cover
-  what they hold, and it will be linked from this page.
-- **Card details will never reach this server or its author.** Not stored, not
-  logged, not seen. The most this server would ever record about money is that
-  a household is paid up, until when, and what it agreed to pay.
+- **Payment goes through a third-party merchant of record**, which for the
+  author's hosted service is **Stripe Managed Payments** — Stripe acting as the
+  legal seller. They handle the card, the receipt and the VAT, and what they
+  hold is covered by Stripe's own privacy policy at `stripe.com/privacy`. A
+  different operator running this software may configure a different one
+  (Paddle and Lemon Squeezy are also supported), so if you are paying somebody
+  else, ask them which.
+- **Card details never reach this server or its author.** Not stored, not
+  logged, not seen. Paying means leaving for a page the processor hosts, and
+  the most this server ever records about money is that a household is paid up,
+  until when, what it agreed to pay, and which processor said so.
+- **One thing is sent to the processor when you start a checkout**: the email
+  address of the account doing it, so the receipt has somewhere to go, and an
+  internal id for the household so the payment can be matched back to it. That
+  is the whole of it.
 - **Your recipes and lists have nothing to do with it.** No content of any kind
-  is shared with a payment processor, ever. The only thing they would be told is
-  what they need to take a payment.
+  is shared with a payment processor, ever.
 
 The terms and refunds page (`/terms` on the same server, and
 [TERMS.md](https://github.com/marco308/meals/blob/main/TERMS.md) in the

--- a/README.md
+++ b/README.md
@@ -383,7 +383,11 @@ self-hosted one.
 
 Payment itself is a webhook, and it is **off unless a deployment sets both
 `BILLING_PROCESSOR` and `BILLING_WEBHOOK_SECRET`** — off meaning the route does
-not exist, not that it exists and refuses. Stripe Managed Payments, Paddle and
+not exist, not that it exists and refuses. Starting a payment is a second switch
+again (`BILLING_API_KEY` and `BILLING_PRICE_ID`): a server can be told about
+payments while holding no key that could charge anybody, and until it does,
+`POST /billing/checkout` is not there either. Nothing about any of this reaches
+the iPhone app, which carries no price, no button and no link to one. Stripe Managed Payments, Paddle and
 Lemon Squeezy are all supported because all three are merchants of record and
 handle EU VAT; which one is a setting, not a rewrite. Every webhook is signature-verified, recorded once in
 a ledger so a retry cannot grant a second year, and counted by outcome, because

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -140,9 +140,54 @@ class Settings(BaseSettings):
     billing_webhook_secret: str | None = None
     billing_signature_tolerance_seconds: int = 300
 
+    # Starting a checkout (issue #121). The webhook is the *end* of a payment;
+    # these are what it takes to begin one, and they are deliberately separate
+    # settings: a deployment can take webhooks with no key on the box that can
+    # charge anybody, which is the safer half to turn on first.
+    #
+    #   BILLING_API_KEY     the processor's secret key. The only credential here
+    #                       that can create a charge, so it is never logged and
+    #                       never reaches a client.
+    #   BILLING_PRICE_ID    what is being sold: a Stripe price id, a Paddle
+    #                       price id, or a Lemon Squeezy *variant* id.
+    #   BILLING_STORE_ID    Lemon Squeezy only, which wants the store beside the
+    #                       variant.
+    #   BILLING_API_BASE    override the processor's API host. Paddle's sandbox
+    #                       is a different one (sandbox-api.paddle.com), and it
+    #                       is how the tests point at a stub.
+    #   BILLING_MANAGE_URL  where a household goes to change a card, read an
+    #                       invoice or cancel. With a merchant of record that is
+    #                       the processor's own portal, so it is a URL out of
+    #                       their dashboard rather than anything served here.
+    #   BILLING_PRICE_PENCE / BILLING_PRICE_CURRENCY  what to *say* it costs, on
+    #                       the one screen that offers it. No default, like every
+    #                       other number in this project: a deployment that has
+    #                       not set one shows no price rather than someone
+    #                       else's.
+    billing_api_key: str | None = None
+    billing_price_id: str | None = None
+    billing_store_id: str | None = None
+    billing_api_base: str | None = None
+    billing_manage_url: str | None = None
+    billing_price_pence: int | None = None
+    billing_price_currency: str = "GBP"
+    billing_api_timeout_seconds: float = 20.0
+
     @property
     def billing_configured(self) -> bool:
         return bool(self.billing_processor and self.billing_webhook_secret)
+
+    @property
+    def billing_sells(self) -> bool:
+        """Whether this deployment can actually take money.
+
+        Deliberately stricter than `billing_configured`: a server that can only
+        *receive* webhooks has no checkout to offer, and offering one it cannot
+        create would be a button that 500s. This is the single answer to "does
+        this server sell anything", published on `/client-config` so no client
+        has to infer it from a 404 or, worse, from the shape of the limits.
+        """
+        return bool(self.billing_configured and self.billing_api_key and self.billing_price_id)
 
     # Timeout for fetching external recipe pages during ingestion.
     recipe_fetch_timeout_seconds: float = 15.0
@@ -174,6 +219,30 @@ class Settings(BaseSettings):
     @property
     def email_sender(self) -> str:
         return self.smtp_from or self.smtp_username or "meals@localhost"
+
+    @model_validator(mode="after")
+    def _a_server_that_sells_needs_somebody_to_sell_to(self) -> Self:
+        # A household that starts on the top tier already has everything a
+        # subscription would buy, so `POST /billing/checkout` correctly refuses
+        # it — and a deployment that enabled billing and left this alone would
+        # have a checkout nobody on it can ever use, with no error to explain
+        # why. Fail at boot instead, where it is one line to fix.
+        if self.billing_sells and self.default_household_tier != "free":
+            raise ValueError(
+                f"billing is configured but DEFAULT_HOUSEHOLD_TIER is {self.default_household_tier!r}: "
+                "a new household would already have everything a subscription buys, so nothing could be sold. "
+                "Set DEFAULT_HOUSEHOLD_TIER=free."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _lemonsqueezy_needs_its_store(self) -> Self:
+        # Lemon Squeezy is the one processor whose checkout names two things,
+        # and a missing store id fails at the API rather than at boot, which is
+        # to say at the first person trying to pay.
+        if self.billing_processor == "lemonsqueezy" and self.billing_price_id and not self.billing_store_id:
+            raise ValueError("BILLING_STORE_ID is required with lemonsqueezy: its checkout names a store and a variant")
+        return self
 
     @model_validator(mode="after")
     def _client_floor_must_be_reachable(self) -> Self:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -274,7 +274,14 @@ async def client_config() -> dict:
     `free_tier_limits` is what an account costs nothing here, so a signup page
     can show it before anyone has an account to authenticate with. Every value
     is null on a server that limits nothing, which is the same thing an
-    authenticated `GET /limits` says in more detail."""
+    authenticated `GET /limits` says in more detail.
+
+    `billing_enabled` says whether this deployment sells anything at all, which
+    is a different question from whether it limits anything: a server can cap
+    what one household holds and have no way to take a penny, and almost every
+    one does. It is the single answer to that question — a client that inferred
+    it from the shape of the limits, or from a 404, would eventually disagree
+    with the server about it."""
     config = get_settings()
     return {
         "api_version": app.version,
@@ -283,6 +290,7 @@ async def client_config() -> dict:
         "upgrade_url": config.ios_upgrade_url,
         "password_reset_enabled": config.email_configured,
         "free_tier_limits": limits.free_tier_allowances(),
+        "billing_enabled": config.billing_sells,
     }
 
 

--- a/backend/app/routers/billing.py
+++ b/backend/app/routers/billing.py
@@ -1,25 +1,129 @@
-"""The processor's end of the money, and nothing else.
+"""The money, from both ends: the processor's, and the household's.
 
-`POST /billing/webhook` exists only on a deployment that has set
-`BILLING_PROCESSOR` and `BILLING_WEBHOOK_SECRET`. Everywhere else it answers
-404, which is the same posture `/metrics` takes without a token and the same
-default SMTP has: a self-hosted instance has no billing, and "off" should mean
-the door is not there rather than that it is there and locked.
+Every route here exists only on a deployment that has set `BILLING_PROCESSOR`
+and `BILLING_WEBHOOK_SECRET`. Everywhere else they answer 404, which is the same
+posture `/metrics` takes without a token and the same default SMTP has: a
+self-hosted instance has no billing, and "off" should mean the door is not there
+rather than that it is there and locked. `POST /checkout` is stricter again — it
+needs a key that can actually create one (`billing_sells`), because a button
+that 500s is worse than no button.
 
-There is no authentication in the usual sense. The sender is a machine that has
-never heard of this app's accounts, so the signature *is* the authentication,
-and `services/billing.py` refuses anything that does not carry a good one.
+`POST /webhook` has no authentication in the usual sense: the sender is a
+machine that has never heard of this app's accounts, so the signature *is* the
+authentication. The other two are ordinary authenticated endpoints, and
+`/checkout` is the household lead's alone, because Q23 gates on the lead exactly
+when money is involved and never otherwise.
+
+**Nothing in here is for the iPhone app** (§6). Commerce lives on the web, the
+app never calls these routes, and no error from them is ever rendered in it.
 """
 
 import json
 
 from fastapi import APIRouter, HTTPException, Request
 
+from app import limits
 from app.config import get_settings
-from app.deps import DbSession
-from app.services import billing
+from app.deps import CurrentUser, DbSession
+from app.models import Household, User
+from app.routers.skill import base_url
+from app.schemas.billing import CheckoutOut, SubscriptionOut
+from app.services import billing, entitlements
 
 router = APIRouter(prefix="/billing", tags=["meta"])
+
+
+def _require_billing(*, selling: bool = False) -> None:
+    """404 unless this deployment does the thing being asked for.
+
+    Indistinguishable from the route not existing, because on almost every
+    deployment it does not.
+    """
+    settings = get_settings()
+    if not (settings.billing_sells if selling else settings.billing_configured):
+        raise HTTPException(status_code=404, detail="Not Found")
+
+
+async def _require_lead(db: DbSession, user: User, household: Household) -> None:
+    """Q23: the lead is the member a household is billed to, so the money is
+    theirs. This is the one gate that exists for that reason, and the refusal
+    names them because the person reading it needs to know who to ask."""
+    if household.lead_user_id == user.id:
+        return
+    lead = await db.get(User, household.lead_user_id) if household.lead_user_id else None
+    who = f"Ask {lead.display_name} to do it." if lead is not None else "Ask whoever leads it."
+    raise HTTPException(status_code=403, detail=f"only your household's lead can set up billing. {who}")
+
+
+@router.get("/subscription", response_model=SubscriptionOut)
+async def subscription(user: CurrentUser) -> SubscriptionOut:
+    """What your household's subscription is doing, and what can be done to it.
+
+    Read-only, and honest about the cases that are not a purchase: a comped
+    household reads `source: "comp"`, and one with no expiry reads
+    `state: "permanent"` and never lapses.
+
+    Lapsing changes only what a household can *grow* — nothing is deleted,
+    everything already here stays readable, and the shopping list is exempt from
+    every billing block. `GET /limits` is where the numbers are.
+    """
+    _require_billing()
+    settings = get_settings()
+    household = user.household
+    entitlement = entitlements.describe(household)
+    return SubscriptionOut(
+        tier=entitlement.stored_tier,
+        state=entitlement.state,
+        paid_until=entitlement.paid_until,
+        grace_ends_at=entitlement.grace_ends_at,
+        source=entitlement.source,
+        price_pence=entitlement.price_pence,
+        price_currency=entitlement.price_currency,
+        offer_price_pence=settings.billing_price_pence,
+        offer_price_currency=settings.billing_price_currency if settings.billing_price_pence else None,
+        manage_url=settings.billing_manage_url,
+        # Already entitled means there is nothing to buy: a second subscription
+        # would be a second charge for the same year.
+        can_checkout=settings.billing_sells and limits.effective_tier(household) == limits.FREE,
+    )
+
+
+@router.post("/checkout", response_model=CheckoutOut, status_code=201)
+async def checkout(user: CurrentUser, db: DbSession, request: Request) -> CheckoutOut:
+    """Open a checkout for your household and answer with where to send them.
+
+    The lead's alone (Q23). The URL is the processor's, is single-use, and is
+    bound to this household by an id in the checkout's custom data — which is
+    the only thread tying a payment back here, so the webhook and this endpoint
+    have to agree about where it rides.
+
+    **This is not a payment.** Nothing is granted until the processor says the
+    money arrived, and it says so with a billing period end that a grant cannot
+    happen without. An abandoned checkout leaves nothing behind.
+    """
+    _require_billing(selling=True)
+    household = user.household
+    await _require_lead(db, user, household)
+
+    if limits.effective_tier(household) != limits.FREE:
+        entitlement = entitlements.describe(household)
+        until = f" until {entitlement.paid_until:%-d %B %Y}" if entitlement.paid_until else ", and it does not run out"
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"this household is already on the {entitlement.stored_tier} tier{until}, so there is nothing "
+                "to buy. GET /billing/subscription has the details, including where to manage it."
+            ),
+        )
+
+    # Back to the web app's settings page either way: a checkout that was
+    # abandoned should land somewhere that makes sense, not on a dead end.
+    return_url = f"{base_url(request)}/app/#/settings"
+    try:
+        url = await billing.start_checkout(household, email=user.email, return_url=return_url)
+    except billing.CheckoutError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+    return CheckoutOut(url=url)
 
 
 @router.post("/webhook", include_in_schema=False)
@@ -42,10 +146,7 @@ async def webhook(request: Request, db: DbSession) -> dict:
     - **500** is left to happen for anything genuinely transient (the database
       being down mid-deploy), because that is the case a retry does fix.
     """
-    if not get_settings().billing_configured:
-        # Indistinguishable from the route not existing, because on almost every
-        # deployment it does not.
-        raise HTTPException(status_code=404, detail="Not Found")
+    _require_billing()
 
     raw = await request.body()
     try:

--- a/backend/app/schemas/billing.py
+++ b/backend/app/schemas/billing.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class SubscriptionOut(BaseModel):
+    """What this household's subscription is doing, on a server that has one."""
+
+    tier: str = Field(description="The stored tier. What it actually buys you is in GET /limits.")
+    state: str = Field(
+        description=(
+            "'permanent' (no expiry, which is every self-hosted household and a standing comp), "
+            "'paid' (in date), 'grace' (past expiry, caps not yet re-applied) or 'lapsed'."
+        )
+    )
+    paid_until: datetime | None = Field(description="When this runs out. Null means it never does.")
+    grace_ends_at: datetime | None = Field(
+        description="When the free tier's caps come back after expiry. Nothing is ever deleted at either point."
+    )
+    source: str | None = Field(description="Where the entitlement came from: 'comp', or the processor's name.")
+    price_pence: int | None = Field(
+        description="What this household agreed to pay, snapshotted when it started. A founding price stays this."
+    )
+    price_currency: str | None = Field(description="Currency of price_pence.")
+    offer_price_pence: int | None = Field(
+        description="What a new subscription would cost here, or null on a server that has not said."
+    )
+    offer_price_currency: str | None = Field(description="Currency of offer_price_pence.")
+    manage_url: str | None = Field(
+        description=(
+            "Where to change a card, read an invoice or cancel. It belongs to the merchant of record rather "
+            "than to this server, which is also who a refund is asked of."
+        )
+    )
+    can_checkout: bool = Field(
+        description=(
+            "Whether a subscription can be started from here right now: false on a server that sells nothing, "
+            "and false for a household that already has one."
+        )
+    )
+
+
+class CheckoutOut(BaseModel):
+    """Where to send somebody to pay."""
+
+    url: str = Field(description="The processor's hosted checkout. Single-use, and bound to this household.")

--- a/backend/app/services/billing.py
+++ b/backend/app/services/billing.py
@@ -503,31 +503,38 @@ async def start_checkout(household: Household, *, email: str, return_url: str) -
             else:
                 url = await _lemonsqueezy_checkout(client, base, settings, household, email, return_url)
     except httpx.HTTPError as exc:
-        log_event("billing.checkout_failed", household_id=household.id, processor=processor, outcome="unreachable")
+        log_event("billing.checkout_failed", household_id=household.id, outcome="unreachable")
         raise CheckoutError(
             "the payment processor did not answer, so nothing was charged. Try again in a minute."
         ) from exc
 
-    log_event("billing.checkout_started", household_id=household.id, processor=processor)
+    log_event("billing.checkout_started", household_id=household.id)
     return url
 
 
-def _fail(processor: str, household: Household, response: httpx.Response) -> CheckoutError:
-    """One place for "the processor said no": a counted, findable log line, and
-    a sentence for whoever pressed the button.
+def _fail(household: Household, response: httpx.Response) -> CheckoutError:
+    """One place for "the processor said no": a findable log line, and a sentence
+    for whoever pressed the button.
 
-    **The response body is deliberately not logged.** It reads like operator
-    business — price ids, API versions — but a processor that rejects a request
-    commonly quotes the offending parameter back, and one of the parameters here
-    is the customer's email address. `/privacy` promises this server does not
-    write those down, and CodeQL is right to call the shortcut what it is. The
-    status and the processor are enough to find the request in their dashboard,
-    which holds the whole exchange anyway.
+    Two things are deliberately *not* in that line.
+
+    **The response body.** It reads like operator business — a bad price id, an
+    API version — but a processor rejecting a request commonly quotes the
+    offending parameter back, and one of the parameters here is the customer's
+    email address. `/privacy` promises this server does not write those down.
+
+    **Which processor it was.** That is `BILLING_PROCESSOR`, one value for the
+    whole deployment, so repeating it on every event says nothing the settings do
+    not already say. (CodeQL also reads any field whose name contains "billing"
+    as personal data, which it is not; dropping a redundant field was the
+    cheaper answer to that than arguing.)
+
+    The status and the timestamp are enough to find the exchange in the
+    processor's own dashboard, which has all of it.
     """
     log_event(
         "billing.checkout_failed",
         household_id=household.id,
-        processor=processor,
         outcome="refused",
         status=response.status_code,
     )
@@ -559,10 +566,10 @@ async def _stripe_checkout(
         auth=(settings.billing_api_key, ""),
     )
     if response.status_code >= 400:
-        raise _fail(STRIPE, household, response)
+        raise _fail(household, response)
     url = (response.json() or {}).get("url")
     if not url:
-        raise _fail(STRIPE, household, response)
+        raise _fail(household, response)
     return str(url)
 
 
@@ -582,12 +589,12 @@ async def _paddle_checkout(client: httpx.AsyncClient, base: str, settings, house
         headers={"Authorization": f"Bearer {settings.billing_api_key}", "Paddle-Version": "1"},
     )
     if response.status_code >= 400:
-        raise _fail(PADDLE, household, response)
+        raise _fail(household, response)
     url = (((response.json() or {}).get("data") or {}).get("checkout") or {}).get("url")
     if not url:
         # Paddle answers 200 with a null checkout url when no default payment
         # link is set, which is a dashboard setting rather than a bad request.
-        raise _fail(PADDLE, household, response)
+        raise _fail(household, response)
     return str(url)
 
 
@@ -617,8 +624,8 @@ async def _lemonsqueezy_checkout(
         },
     )
     if response.status_code >= 400:
-        raise _fail(LEMONSQUEEZY, household, response)
+        raise _fail(household, response)
     url = (((response.json() or {}).get("data") or {}).get("attributes") or {}).get("url")
     if not url:
-        raise _fail(LEMONSQUEEZY, household, response)
+        raise _fail(household, response)
     return str(url)

--- a/backend/app/services/billing.py
+++ b/backend/app/services/billing.py
@@ -1,6 +1,8 @@
-"""The billing webhook: a payment becoming an entitlement, exactly once.
+"""Both ends of a payment: opening a checkout, and a payment becoming an
+entitlement exactly once.
 
-Issue #99, planning/08-freemium.md §2. Two things shape every line of it.
+Issues #99 and #121, planning/08-freemium.md §2 and §7. Two things shape every
+line of it.
 
 **It ships inert.** With `BILLING_PROCESSOR` unset the route does not exist —
 404, the same posture `/metrics` has without a token. A self-hosted instance has
@@ -56,6 +58,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
+import httpx
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -426,3 +429,190 @@ def count(outcome: str) -> None:
     never reach the ledger — a bad signature, an unreadable body — are counted
     too. Those are the ones that would otherwise be silent."""
     metrics.count_billing_webhook(outcome)
+
+
+# ------------------------------------------------------- starting a checkout
+#
+# The webhook above is the *end* of a payment. This is the beginning, and issue
+# #121 exists because the beginning was missing: the route waited for a checkout
+# that nothing in this repo could start.
+#
+# Three things shape every line of it.
+#
+# **The household id has to land where the webhook reads it.** That link is the
+# only one there is — a payment that names no household is recorded as an orphan
+# and somebody has paid for nothing. Stripe carries it on
+# `subscription_data[metadata]`, because metadata on the *session* does not reach
+# the subscription and the subscription is what the webhook sees; Paddle on
+# `custom_data`, which it copies onto the subscription for recurring items; Lemon
+# Squeezy on `checkout_data.custom`, which comes back as `meta.custom_data`.
+#
+# **Managed Payments is a parameter, not just a setting.** `managed_payments
+# [enabled]=true` on the Checkout Session is what makes Stripe the merchant of
+# record for that sale. Leave it off and the payment still succeeds, the customer
+# still gets their subscription, and *you* are the seller of record with the EU
+# VAT to file — the exact thing §7 chose a merchant of record to avoid, failing
+# silently. It is one line and it is the most expensive line here to lose.
+#
+# **Nothing here grants anything.** Starting a checkout is not a payment;
+# `entitlements.grant` is reached only from a verified webhook carrying a billing
+# period end. A checkout that is abandoned leaves no trace but a log line.
+
+#: Where each processor's API lives. `BILLING_API_BASE` overrides it, which is
+#: how you reach Paddle's sandbox (`sandbox-api.paddle.com`) and how the tests
+#: point this at a stub instead of the internet.
+_API_BASES = {
+    STRIPE: "https://api.stripe.com",
+    PADDLE: "https://api.paddle.com",
+    LEMONSQUEEZY: "https://api.lemonsqueezy.com",
+}
+
+
+class CheckoutError(Exception):
+    """No checkout could be started, so nobody was charged.
+
+    Carries a sentence for the person who pressed the button rather than the
+    processor's own words: those name price ids and API versions, which is
+    operator business and reaches the operator through the log instead.
+    """
+
+    def __init__(self, detail: str, *, status_code: int = 502) -> None:
+        super().__init__(detail)
+        self.detail = detail
+        self.status_code = status_code
+
+
+async def start_checkout(household: Household, *, email: str, return_url: str) -> str:
+    """Create a hosted checkout for this household and return where to send them.
+
+    The URL is the processor's, is single-use, and is deliberately never logged:
+    it is a payment page bound to one household.
+    """
+    settings = get_settings()
+    processor = settings.billing_processor
+    base = (settings.billing_api_base or _API_BASES.get(processor, "")).rstrip("/")
+    if not base:
+        raise CheckoutError("this server's billing is not configured", status_code=503)
+
+    try:
+        async with httpx.AsyncClient(timeout=settings.billing_api_timeout_seconds) as client:
+            if processor == STRIPE:
+                url = await _stripe_checkout(client, base, settings, household, email, return_url)
+            elif processor == PADDLE:
+                url = await _paddle_checkout(client, base, settings, household, email)
+            else:
+                url = await _lemonsqueezy_checkout(client, base, settings, household, email, return_url)
+    except httpx.HTTPError as exc:
+        log_event("billing.checkout_failed", household_id=household.id, processor=processor, outcome="unreachable")
+        raise CheckoutError(
+            "the payment processor did not answer, so nothing was charged. Try again in a minute."
+        ) from exc
+
+    log_event("billing.checkout_started", household_id=household.id, processor=processor)
+    return url
+
+
+def _fail(processor: str, household: Household, response: httpx.Response) -> CheckoutError:
+    """One place for "the processor said no", so the operator gets the detail and
+    the caller gets a sentence."""
+    log_event(
+        "billing.checkout_failed",
+        household_id=household.id,
+        processor=processor,
+        outcome="refused",
+        status=response.status_code,
+        # The processor's own words, truncated. They name price ids and API
+        # versions — operator business, and nothing personal.
+        detail=response.text[:300],
+    )
+    return CheckoutError("the payment processor refused to open a checkout, so nothing was charged.")
+
+
+async def _stripe_checkout(
+    client: httpx.AsyncClient, base: str, settings, household: Household, email: str, return_url: str
+) -> str:
+    form = {
+        "mode": "subscription",
+        "line_items[0][price]": settings.billing_price_id,
+        "line_items[0][quantity]": "1",
+        # Stripe as merchant of record for this sale. See the note above: losing
+        # this line does not break the payment, it moves the tax liability.
+        "managed_payments[enabled]": "true",
+        "success_url": return_url,
+        "cancel_url": return_url,
+        # On the subscription, not the session: the webhook reads the
+        # subscription object, and metadata does not travel from one to the other.
+        "subscription_data[metadata][household_id]": str(household.id),
+        # Belt and braces, and what the Dashboard shows beside the payment.
+        "client_reference_id": str(household.id),
+        "customer_email": email,
+    }
+    response = await client.post(
+        f"{base}/v1/checkout/sessions",
+        data=form,
+        auth=(settings.billing_api_key, ""),
+    )
+    if response.status_code >= 400:
+        raise _fail(STRIPE, household, response)
+    url = (response.json() or {}).get("url")
+    if not url:
+        raise _fail(STRIPE, household, response)
+    return str(url)
+
+
+async def _paddle_checkout(client: httpx.AsyncClient, base: str, settings, household: Household, email: str) -> str:
+    # No `checkout.url` is sent: that field names a page of yours hosting
+    # Paddle.js, and this server hosts none. Omitted, Paddle composes the link
+    # from the default payment link in the dashboard, which is the whole of the
+    # setup here.
+    body = {
+        "items": [{"price_id": settings.billing_price_id, "quantity": 1}],
+        "custom_data": {"household_id": str(household.id)},
+        "customer": {"email": email},
+    }
+    response = await client.post(
+        f"{base}/transactions",
+        json=body,
+        headers={"Authorization": f"Bearer {settings.billing_api_key}", "Paddle-Version": "1"},
+    )
+    if response.status_code >= 400:
+        raise _fail(PADDLE, household, response)
+    url = (((response.json() or {}).get("data") or {}).get("checkout") or {}).get("url")
+    if not url:
+        # Paddle answers 200 with a null checkout url when no default payment
+        # link is set, which is a dashboard setting rather than a bad request.
+        raise _fail(PADDLE, household, response)
+    return str(url)
+
+
+async def _lemonsqueezy_checkout(
+    client: httpx.AsyncClient, base: str, settings, household: Household, email: str, return_url: str
+) -> str:
+    body = {
+        "data": {
+            "type": "checkouts",
+            "attributes": {
+                "checkout_data": {"email": email, "custom": {"household_id": str(household.id)}},
+                "product_options": {"redirect_url": return_url},
+            },
+            "relationships": {
+                "store": {"data": {"type": "stores", "id": str(settings.billing_store_id)}},
+                "variant": {"data": {"type": "variants", "id": str(settings.billing_price_id)}},
+            },
+        }
+    }
+    response = await client.post(
+        f"{base}/v1/checkouts",
+        json=body,
+        headers={
+            "Authorization": f"Bearer {settings.billing_api_key}",
+            "Accept": "application/vnd.api+json",
+            "Content-Type": "application/vnd.api+json",
+        },
+    )
+    if response.status_code >= 400:
+        raise _fail(LEMONSQUEEZY, household, response)
+    url = (((response.json() or {}).get("data") or {}).get("attributes") or {}).get("url")
+    if not url:
+        raise _fail(LEMONSQUEEZY, household, response)
+    return str(url)

--- a/backend/app/services/billing.py
+++ b/backend/app/services/billing.py
@@ -513,17 +513,23 @@ async def start_checkout(household: Household, *, email: str, return_url: str) -
 
 
 def _fail(processor: str, household: Household, response: httpx.Response) -> CheckoutError:
-    """One place for "the processor said no", so the operator gets the detail and
-    the caller gets a sentence."""
+    """One place for "the processor said no": a counted, findable log line, and
+    a sentence for whoever pressed the button.
+
+    **The response body is deliberately not logged.** It reads like operator
+    business — price ids, API versions — but a processor that rejects a request
+    commonly quotes the offending parameter back, and one of the parameters here
+    is the customer's email address. `/privacy` promises this server does not
+    write those down, and CodeQL is right to call the shortcut what it is. The
+    status and the processor are enough to find the request in their dashboard,
+    which holds the whole exchange anyway.
+    """
     log_event(
         "billing.checkout_failed",
         household_id=household.id,
         processor=processor,
         outcome="refused",
         status=response.status_code,
-        # The processor's own words, truncated. They name price ids and API
-        # versions — operator business, and nothing personal.
-        detail=response.text[:300],
     )
     return CheckoutError("the payment processor refused to open a checkout, so nothing was charged.")
 

--- a/backend/tests/integration/test_billing_checkout.py
+++ b/backend/tests/integration/test_billing_checkout.py
@@ -1,0 +1,345 @@
+"""Starting a checkout, and reading what a household is subscribed to (#121).
+
+#99 built everything that happens *after* a payment. This is the half before it,
+and the claims worth the test are the ones that cost money to get wrong:
+
+1. **None of it exists unless a deployment turns it on**, and the checkout needs
+   turning on twice over: a server can take webhooks without holding a key that
+   can charge anybody.
+2. **The household id rides where the webhook will look for it.** That thread is
+   the only one tying a payment back to an account; break it and somebody pays
+   and is credited to nobody.
+3. **`managed_payments[enabled]` is on the Stripe request.** Without it the
+   payment still works and Stripe is no longer the merchant of record, which
+   silently moves the EU VAT onto us — the exact thing §7 picked an MoR to
+   avoid, and the failure leaves no trace anywhere else.
+4. **Starting a checkout grants nothing.** Only a verified webhook carrying a
+   billing period end does that.
+
+The three request shapes were read from the live documentation on 2026-08-23:
+Stripe's Checkout Session create, Paddle's create-transaction, and Lemon
+Squeezy's create-checkout.
+"""
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+import respx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app import limits
+from app.models import Household
+from app.services import entitlements
+from tests.conftest import register
+
+SECRET = "a-signing-secret"
+KEY = "sk_test_not_a_real_key"
+
+
+@pytest.fixture
+def sessions(engine):
+    return async_sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest.fixture
+def webhook_only(settings_override):
+    """A server that can be *told* about payments but cannot start one."""
+    settings_override(BILLING_PROCESSOR="stripe", BILLING_WEBHOOK_SECRET=SECRET)
+
+
+@pytest.fixture
+def stripe(settings_override):
+    settings_override(
+        BILLING_PROCESSOR="stripe",
+        BILLING_WEBHOOK_SECRET=SECRET,
+        DEFAULT_HOUSEHOLD_TIER="free",
+        BILLING_API_KEY=KEY,
+        BILLING_PRICE_ID="price_founding_year",
+        BILLING_MANAGE_URL="https://billing.example.com/p/login/test",
+        BILLING_PRICE_PENCE="2000",
+    )
+
+
+@pytest.fixture
+def paddle(settings_override):
+    settings_override(
+        BILLING_PROCESSOR="paddle",
+        BILLING_WEBHOOK_SECRET=SECRET,
+        DEFAULT_HOUSEHOLD_TIER="free",
+        BILLING_API_KEY=KEY,
+        BILLING_PRICE_ID="pri_01example",
+    )
+
+
+@pytest.fixture
+def lemonsqueezy(settings_override):
+    settings_override(
+        BILLING_PROCESSOR="lemonsqueezy",
+        BILLING_WEBHOOK_SECRET=SECRET,
+        DEFAULT_HOUSEHOLD_TIER="free",
+        BILLING_API_KEY=KEY,
+        BILLING_PRICE_ID="998877",
+        BILLING_STORE_ID="12345",
+    )
+
+
+async def only_household(sessions) -> Household:
+    async with sessions() as db:
+        return (await db.execute(select(Household))).scalars().one()
+
+
+# ------------------------------------------------------------------ it is off
+
+
+async def test_neither_route_exists_on_a_server_that_sells_nothing(auth_client):
+    """The default, and every self-hosted instance. Not 403: not there."""
+    assert (await auth_client.get("/billing/subscription")).status_code == 404
+    assert (await auth_client.post("/billing/checkout")).status_code == 404
+
+
+async def test_a_webhook_alone_does_not_open_a_checkout(webhook_only, auth_client):
+    """Receiving payments and taking them are separate switches, and the safer
+    one can be on alone."""
+    subscription = await auth_client.get("/billing/subscription")
+    assert subscription.status_code == 200
+    assert subscription.json()["can_checkout"] is False
+    assert (await auth_client.post("/billing/checkout")).status_code == 404
+
+
+async def test_client_config_says_whether_this_server_sells(stripe, client):
+    """One answer to "is there anything to buy here", unauthenticated because a
+    signup page has nobody to log in as yet."""
+    assert (await client.get("/client-config")).json()["billing_enabled"] is True
+
+
+async def test_client_config_sells_nothing_by_default(client):
+    assert (await client.get("/client-config")).json()["billing_enabled"] is False
+
+
+# ------------------------------------------------------------- what it reports
+
+
+async def test_subscription_reports_a_household_that_has_paid_for_nothing(stripe, auth_client):
+    body = (await auth_client.get("/billing/subscription")).json()
+    assert body["state"] == entitlements.PERMANENT  # no expiry, so it never lapses
+    assert body["paid_until"] is None
+    assert body["source"] is None
+    assert body["price_pence"] is None  # nothing was agreed, so nothing is snapshotted
+    assert body["offer_price_pence"] == 2000  # what it would cost
+    assert body["offer_price_currency"] == "GBP"
+    assert body["manage_url"] == "https://billing.example.com/p/login/test"
+    assert body["can_checkout"] is True
+
+
+async def test_subscription_reports_a_comp(stripe, auth_client, sessions):
+    """A comp is not a purchase, and says so: no processor, and an expiry that
+    is still an expiry."""
+    until = datetime.now(UTC) + timedelta(days=365)
+    async with sessions() as db:
+        household = (await db.execute(select(Household))).scalars().one()
+        await entitlements.grant(db, household, tier=limits.PAID, until=until, source=entitlements.COMP)
+        await db.commit()
+
+    body = (await auth_client.get("/billing/subscription")).json()
+    assert body["tier"] == limits.PAID
+    assert body["state"] == entitlements.PAID
+    assert body["source"] == entitlements.COMP
+    assert body["paid_until"].startswith(until.strftime("%Y-%m-%d"))
+    assert body["grace_ends_at"] is not None
+    # Nothing to buy: a second subscription would be a second charge.
+    assert body["can_checkout"] is False
+
+
+# -------------------------------------------------------------- opening one
+
+
+@respx.mock
+async def test_stripe_checkout_carries_the_household_and_the_merchant_of_record(stripe, auth_client, sessions):
+    route = respx.post("https://api.stripe.com/v1/checkout/sessions").mock(
+        return_value=httpx.Response(200, json={"id": "cs_test_1", "url": "https://checkout.stripe.com/c/pay/cs_test_1"})
+    )
+    household = await only_household(sessions)
+
+    response = await auth_client.post("/billing/checkout")
+    assert response.status_code == 201, response.text
+    assert response.json()["url"] == "https://checkout.stripe.com/c/pay/cs_test_1"
+
+    sent = dict(part.split("=", 1) for part in route.calls.last.request.content.decode().split("&"))
+    from urllib.parse import unquote_plus
+
+    sent = {unquote_plus(k): unquote_plus(v) for k, v in sent.items()}
+    assert sent["mode"] == "subscription"
+    assert sent["line_items[0][price]"] == "price_founding_year"
+    # On the *subscription*, because that is the object the webhook reads;
+    # metadata on the session never reaches it.
+    assert sent["subscription_data[metadata][household_id]"] == str(household.id)
+    # The line that decides who the legal seller is. See the module docstring.
+    assert sent["managed_payments[enabled]"] == "true"
+    assert sent["success_url"].endswith("/app/#/settings")
+    # The key authenticates and is never anywhere else.
+    assert route.calls.last.request.headers["authorization"].startswith("Basic ")
+
+
+@respx.mock
+async def test_paddle_checkout_carries_the_household(paddle, auth_client, sessions):
+    route = respx.post("https://api.paddle.com/transactions").mock(
+        return_value=httpx.Response(
+            200, json={"data": {"id": "txn_1", "checkout": {"url": "https://pay.example.com/?_ptxn=txn_1"}}}
+        )
+    )
+    household = await only_household(sessions)
+
+    response = await auth_client.post("/billing/checkout")
+    assert response.status_code == 201, response.text
+    assert response.json()["url"] == "https://pay.example.com/?_ptxn=txn_1"
+
+    sent = json.loads(route.calls.last.request.content)
+    assert sent["items"] == [{"price_id": "pri_01example", "quantity": 1}]
+    assert sent["custom_data"]["household_id"] == str(household.id)
+    assert route.calls.last.request.headers["paddle-version"] == "1"
+
+
+@respx.mock
+async def test_lemonsqueezy_checkout_carries_the_household(lemonsqueezy, auth_client, sessions):
+    route = respx.post("https://api.lemonsqueezy.com/v1/checkouts").mock(
+        return_value=httpx.Response(
+            201, json={"data": {"attributes": {"url": "https://store.lemonsqueezy.com/checkout/x"}}}
+        )
+    )
+    household = await only_household(sessions)
+
+    response = await auth_client.post("/billing/checkout")
+    assert response.status_code == 201, response.text
+    assert response.json()["url"] == "https://store.lemonsqueezy.com/checkout/x"
+
+    sent = json.loads(route.calls.last.request.content)["data"]
+    assert sent["attributes"]["checkout_data"]["custom"]["household_id"] == str(household.id)
+    assert sent["relationships"]["store"]["data"]["id"] == "12345"
+    assert sent["relationships"]["variant"]["data"]["id"] == "998877"
+
+
+@respx.mock
+async def test_opening_a_checkout_grants_nothing(stripe, auth_client, sessions):
+    """The whole point of the webhook is that this is not a payment."""
+    respx.post("https://api.stripe.com/v1/checkout/sessions").mock(
+        return_value=httpx.Response(200, json={"url": "https://checkout.stripe.com/c/pay/cs_test_1"})
+    )
+    assert (await auth_client.post("/billing/checkout")).status_code == 201
+
+    household = await only_household(sessions)
+    assert household.paid_until is None
+    assert household.entitlement_source is None
+    assert limits.effective_tier(household) == limits.FREE
+
+
+# --------------------------------------------------------------- who, and when
+
+
+async def test_checkout_is_the_leads_alone(stripe, client):
+    """Q23: the lead is the member a household is billed to, and this is the one
+    kind of thing that gates on them. The refusal names who to ask."""
+    lead = await register(client, email="lead@example.com", name="Marcus")
+    client.headers["Authorization"] = f"Bearer {lead['token']}"
+    invite = (await client.post("/auth/invites", json={"expires_in_days": 7})).json()
+
+    joiner = await register(client, email="other@example.com", name="Sam", invite_code=invite["code"])
+    client.headers["Authorization"] = f"Bearer {joiner['token']}"
+
+    response = await client.post("/billing/checkout")
+    assert response.status_code == 403
+    assert "Marcus" in response.json()["detail"]
+    # And the reading half is nobody's secret: everyone can see where they stand.
+    assert (await client.get("/billing/subscription")).status_code == 200
+
+
+@respx.mock
+async def test_checkout_refuses_a_household_that_already_has_one(stripe, auth_client, sessions):
+    route = respx.post("https://api.stripe.com/v1/checkout/sessions")
+    until = datetime.now(UTC) + timedelta(days=200)
+    async with sessions() as db:
+        household = (await db.execute(select(Household))).scalars().one()
+        await entitlements.grant(db, household, tier=limits.PAID, until=until, source="stripe")
+        await db.commit()
+
+    response = await auth_client.post("/billing/checkout")
+    assert response.status_code == 409
+    assert "already on the paid tier" in response.json()["detail"]
+    # Nothing was asked of the processor, so nothing could be charged twice.
+    assert not route.called
+
+
+@respx.mock
+async def test_a_processor_refusal_says_nobody_was_charged(stripe, auth_client, sessions):
+    """A misconfigured price is the operator's problem, and the person who
+    pressed the button needs to know only that their card was not touched."""
+    respx.post("https://api.stripe.com/v1/checkout/sessions").mock(
+        return_value=httpx.Response(400, json={"error": {"message": "No such price: 'price_founding_year'"}})
+    )
+    response = await auth_client.post("/billing/checkout")
+    assert response.status_code == 502
+    assert "nothing was charged" in response.json()["detail"]
+    # The processor's own words stay out of it: they name price ids.
+    assert "price_founding_year" not in response.json()["detail"]
+
+    household = await only_household(sessions)
+    assert household.paid_until is None
+
+
+@respx.mock
+async def test_a_processor_that_does_not_answer_is_not_a_500(stripe, auth_client):
+    respx.post("https://api.stripe.com/v1/checkout/sessions").mock(side_effect=httpx.ConnectError("no route"))
+    response = await auth_client.post("/billing/checkout")
+    assert response.status_code == 502
+    assert "nothing was charged" in response.json()["detail"]
+
+
+@respx.mock
+async def test_paddle_with_no_default_payment_link_is_refused_not_returned(paddle, auth_client):
+    """Paddle answers 200 with no checkout url when the dashboard has no default
+    payment link. Returning that as a URL would send somebody to `null`."""
+    respx.post("https://api.paddle.com/transactions").mock(
+        return_value=httpx.Response(200, json={"data": {"id": "txn_1", "checkout": None}})
+    )
+    assert (await auth_client.post("/billing/checkout")).status_code == 502
+
+
+# ------------------------------------------------------- misconfiguration, loudly
+
+
+def test_selling_to_households_that_start_on_the_top_tier_refuses_to_boot(monkeypatch):
+    """The quiet version of this bug is a checkout every household is refused
+    from, with a 409 that reads like a bug in the app rather than a setting."""
+    from app.config import Settings
+
+    for key, value in {
+        "BILLING_PROCESSOR": "stripe",
+        "BILLING_WEBHOOK_SECRET": SECRET,
+        "BILLING_API_KEY": KEY,
+        "BILLING_PRICE_ID": "price_1",
+        "DEFAULT_HOUSEHOLD_TIER": "unlimited",
+    }.items():
+        monkeypatch.setenv(key, value)
+
+    with pytest.raises(ValueError, match="DEFAULT_HOUSEHOLD_TIER=free"):
+        Settings()
+
+
+def test_lemonsqueezy_without_its_store_refuses_to_boot(monkeypatch):
+    """Its checkout names a store *and* a variant, and the missing one would
+    surface at the first person trying to pay rather than at deploy."""
+    from app.config import Settings
+
+    for key, value in {
+        "BILLING_PROCESSOR": "lemonsqueezy",
+        "BILLING_WEBHOOK_SECRET": SECRET,
+        "BILLING_API_KEY": KEY,
+        "BILLING_PRICE_ID": "998877",
+        "DEFAULT_HOUSEHOLD_TIER": "free",
+    }.items():
+        monkeypatch.setenv(key, value)
+
+    with pytest.raises(ValueError, match="BILLING_STORE_ID"):
+        Settings()

--- a/backend/tests/integration/test_billing_checkout.py
+++ b/backend/tests/integration/test_billing_checkout.py
@@ -281,7 +281,10 @@ async def test_a_processor_refusal_says_nobody_was_charged(stripe, auth_client, 
     response = await auth_client.post("/billing/checkout")
     assert response.status_code == 502
     assert "nothing was charged" in response.json()["detail"]
-    # The processor's own words stay out of it: they name price ids.
+    # The processor's own words stay out of it. They name price ids, and a
+    # rejected request is commonly quoted back with its parameters — one of
+    # which is the customer's email address, which /privacy promises this server
+    # does not write down.
     assert "price_founding_year" not in response.json()["detail"]
 
     household = await only_household(sessions)

--- a/backend/tests/integration/test_misc.py
+++ b/backend/tests/integration/test_misc.py
@@ -142,10 +142,17 @@ class TestPublicPages:
 
     async def test_the_privacy_policy_is_straight_about_money(self, client):
         """`/privacy` is a live App Store URL and it promises this project holds
-        no payment details. That promise needs a section, not a silence."""
+        no payment details. That promise needs a section, not a silence.
+
+        The tense moved from "will never" to "never" when #121 named the
+        processor and built the checkout: the section stopped describing a
+        future and started describing what the code does."""
         text = (await client.get("/privacy")).text
         assert 'id="paying-for-hosting"' in text
-        assert "Card details will never reach this server" in text
+        assert "Card details never reach this server or its author" in text
+        # And who the merchant of record is, which the section promised to say
+        # before any money moved.
+        assert "Stripe Managed Payments" in text
 
     async def test_tables_survive_the_render(self, client):
         """Most of what the privacy policy actually promises lives in its tables,

--- a/planning/08-freemium.md
+++ b/planning/08-freemium.md
@@ -297,17 +297,26 @@ three more on 2026-08-23:
    nothing shows nothing.
 9. Web purchase and subscription management
    ([#121](https://github.com/marco308/meals/issues/121)) — the half of §7 that
-   happens before the webhook. `routers/billing.py` holds one route, so the
-   checkout it waits for is one nothing here can start, and `LimitsOut` cannot
-   describe a subscription it has no `paid_until` for.
+   happens before the webhook. **Done**: `POST /billing/checkout` opens a hosted
+   checkout with the household id where the webhook will look for it,
+   `GET /billing/subscription` says what a household has and where to manage it,
+   and both are absent unless a deployment holds a key that can charge somebody.
+   Two decisions worth keeping: the subscription lives on its own endpoint
+   rather than on `GET /limits`, which stays about allowances and says nothing
+   about money; and managing or cancelling is the processor's page rather than
+   one served here, because with a merchant of record they are the seller and
+   the refund is theirs to give.
 10. Opening registration ([#122](https://github.com/marco308/meals/issues/122)):
     the email verification this codebase does not have, signup rate limits, and
     a policy for reaping abandoned free households. Named in §7's last
     paragraph, carried as a bullet in #99, and closed with it unbuilt.
 
-9 and 10 sit behind §9's gate. 8 does not, because a household on a limited
-server deserves to know where it stands whether or not anything is ever sold,
-and the export button is the same promise §1 makes.
+10 sits behind §9's gate. 8 does not, because a household on a limited server
+deserves to know where it stands whether or not anything is ever sold, and the
+export button is the same promise §1 makes. 9 is built but **not switched on**:
+the code ships inert, and turning it on still needs the two confirmations in §7
+(Managed Payments pricing read off Stripe's own page, and an accountant on the
+UK-seller position), the Postgres separation, and the gate itself.
 
 ## 9. Decision metric
 

--- a/web/js/views/settings.js
+++ b/web/js/views/settings.js
@@ -12,13 +12,16 @@ import { confirmDialog, fmtDate, fmtRel, html, openDialog, parseUtc, render, ske
 
 export async function renderSettings(root) {
   render(root, skeleton());
-  const [user, household, invites, tokens, markets, allowances] = await Promise.all([
+  const [user, household, invites, tokens, markets, allowances, subscription] = await Promise.all([
     api("/auth/me"),
     api("/auth/household"),
     api("/auth/invites"),
     api("/auth/tokens"),
     api("/supermarkets"),
     api("/limits"),
+    // 404 is the answer on every server that has no billing, which is almost
+    // all of them, and it is the server's own answer rather than a guess.
+    api("/billing/subscription").catch(() => null),
   ]);
   session.saveUser(user);
   const youLead = household.lead_user_id === user.id;
@@ -99,6 +102,8 @@ export async function renderSettings(root) {
       </div>
 
       ${allowancesSection(allowances)}
+
+      ${subscriptionSection(subscription, household, youLead, leadName)}
 
       <div class="section card">
         <h2>Supermarkets &amp; aisle order</h2>
@@ -346,6 +351,22 @@ export async function renderSettings(root) {
   // deliberately does not police.
   for (const fill of root.querySelectorAll("[data-fill]")) fill.style.width = `${fill.dataset.fill}%`;
 
+  const subscribe = root.querySelector("[data-subscribe]");
+  if (subscribe) {
+    subscribe.onclick = async () => {
+      subscribe.disabled = true;
+      try {
+        // The URL is the processor's, single-use, and bound to this household.
+        // Leaving the app for it is the whole design: no commerce is served here.
+        const checkout = await api("/billing/checkout", { method: "POST" });
+        window.location.assign(checkout.url);
+      } catch (error) {
+        toast(error.detail || error.message, "error");
+        subscribe.disabled = false;
+      }
+    };
+  }
+
   root.querySelector("[data-export]").onclick = async (event) => {
     const button = event.currentTarget;
     button.disabled = true;
@@ -360,6 +381,78 @@ export async function renderSettings(root) {
   };
 
   root.querySelector("[data-delete-account]").onclick = () => deleteAccountDialog();
+}
+
+// ── the subscription ─────────────────────────────────────────────────────
+//
+// The only commerce in this project, and it is here rather than in the iPhone
+// app on purpose (planning/08-freemium.md §6): the app carries no price, no
+// button and no link to one, and the App Store listing rests on that.
+//
+// `GET /billing/subscription` 404s on every server with no billing configured,
+// which is almost all of them, so a null here means the card is absent — the
+// same rule the allowances card follows, from the same §1.
+//
+// Paying leaves this app entirely. The processor is the merchant of record, so
+// the checkout, the card details, the invoices and any refund are theirs, and
+// this server never sees a card number.
+
+function subscriptionSection(subscription, household, youLead, leadName) {
+  if (!subscription) return "";
+  return html`
+    <div class="section card">
+      <h2>Subscription</h2>
+      <p class="sub">${subscriptionState(subscription)}</p>
+      ${subscription.can_checkout && !youLead
+        ? html`<p class="sub">${leadName} leads “${household.name}”, so this is theirs to arrange.</p>`
+        : ""}
+      <div class="dialog-actions">
+        ${subscription.can_checkout && youLead
+          ? html`<button class="btn" data-subscribe>${subscribeLabel(subscription)}</button>`
+          : ""}
+        ${subscription.manage_url
+          ? html`<a class="btn ghost" href="${subscription.manage_url}" target="_blank" rel="noopener">
+              Manage billing
+            </a>`
+          : ""}
+      </div>
+    </div>
+  `;
+}
+
+function subscriptionState(subscription) {
+  const paid = money(subscription.price_pence, subscription.price_currency);
+  const from = subscription.source === "comp" ? ", with the compliments of whoever runs it" : "";
+  switch (subscription.state) {
+    case "paid":
+      return `Paid until ${fmtDate(subscription.paid_until)}${from}${paid ? `, at ${paid} a year` : ""}.`;
+    case "grace":
+      // §5: lapsing reduces what a household can add, and takes nothing away.
+      return `This ran out on ${fmtDate(subscription.paid_until)}. The free tier's limits come back on
+        ${fmtDate(subscription.grace_ends_at)} and nothing is deleted, then or ever.`;
+    case "lapsed":
+      return `This ran out on ${fmtDate(subscription.paid_until)}, so the free tier's limits apply again.
+        Everything already here stayed, and the shopping list never stopped.`;
+    default:
+      // No expiry at all: a standing comp, or a household that has never paid.
+      return subscription.source
+        ? "This household is paid up, with no expiry."
+        : "This household pays nothing here.";
+  }
+}
+
+function subscribeLabel(subscription) {
+  const offer = money(subscription.offer_price_pence, subscription.offer_price_currency);
+  return offer ? `Subscribe — ${offer} a year` : "Subscribe";
+}
+
+function money(pence, currency) {
+  if (pence === null || pence === undefined) return "";
+  return new Intl.NumberFormat("en-GB", {
+    style: "currency",
+    currency: currency || "GBP",
+    minimumFractionDigits: pence % 100 === 0 ? 0 : 2,
+  }).format(pence / 100);
 }
 
 // ── what this server allows ──────────────────────────────────────────────


### PR DESCRIPTION
Closes #121.

#99 built everything that happens after a payment. This is the beginning, which
was missing: `routers/billing.py` held one route, so the checkout it waited for
was one nothing in this repo could start.

## What's here

**`POST /billing/checkout`** opens a hosted checkout at the processor and
answers with the URL. Stripe, Paddle and Lemon Squeezy, each request shape read
from the live documentation on 2026-08-23. The lead's alone (Q23 gates on them
exactly when money is involved), and refused for a household that already has a
subscription, since a second one is a second charge for the same year.

**`GET /billing/subscription`** says what a household has, until when, where it
came from, and where to manage it. Deliberately *not* on `GET /limits`, which
stays about allowances and holds no numbers of its own.

**`GET /client-config` gains `billing_enabled`** — one answer to "does this
server sell anything", which is a different question from whether it limits
anything, and one a client would otherwise infer from a 404.

**The web app gains a Subscription card**, absent wherever billing is not
configured. Paying leaves the app: the processor is the merchant of record, so
the checkout, the card, the invoices and any refund are theirs.

**`PRIVACY.md` names the processor** — Stripe Managed Payments for the hosted
service — which that section promised to do before any money moved, plus exactly
what is sent to them at checkout (an email address and a household id).

## The four lines worth reviewing

1. **`managed_payments[enabled]=true`** on the Stripe request. Without it the
   payment still succeeds and Stripe is no longer the merchant of record, so the
   EU VAT is ours to file. It fails silently and leaves no trace anywhere else,
   which is why there is a test asserting the parameter itself.
2. **The household id rides on `subscription_data[metadata]`**, not the session's
   metadata, because the webhook reads the subscription object and one does not
   reach the other. Same thread, both ends, or somebody pays for nothing.
3. **Nothing here grants.** Only a verified webhook with a billing period end
   does. There is a test that a completed checkout leaves `paid_until` null.
4. **A server that sells needs somebody to sell to.** With billing configured and
   `DEFAULT_HOUSEHOLD_TIER` anything but `free`, the app now refuses to boot: the
   quiet version of that bug is a checkout every household is refused from, with
   a 409 that reads like a bug in the app rather than a setting.

## Still inert

Taking payments remains two switches. `BILLING_PROCESSOR` + `BILLING_WEBHOOK_SECRET`
let this server be *told* about payments; `BILLING_API_KEY` + `BILLING_PRICE_ID`
let it start one, and until both halves are set `POST /billing/checkout` does not
exist and `billing_enabled` is false. Turning it on is still gated on §9's
waitlist, §7's two confirmations (Managed Payments pricing off Stripe's own page,
and an accountant on the UK-seller position), and the Postgres separation.

## Verification

17 new tests, including one per processor asserting the exact request shape, the
lead gate, the already-subscribed 409 with no call made to the processor, a
processor refusal answering 502 without leaking price ids into the sentence, and
the two misconfigurations that now refuse to boot.

Also driven end to end in a browser against a local server with a stubbed
processor API: the outgoing request carried the metadata, the merchant-of-record
flag and the return URLs; `billing.checkout_started` logged with no URL and no
email in it; and all four subscription states (never paid, comped, in grace,
lapsed) render, with the allowances card agreeing each time.

No migrations. `make lint` clean, `make test-fast` green (886 backend, 67 mcp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
