### PR TITLE
Don't offer a password reset a server can't send

### DIFF
--- a/backend/tests/unit/test_web_client.py
+++ b/backend/tests/unit/test_web_client.py
@@ -73,3 +73,25 @@ def test_per_item_allowances_are_still_per_item(name):
     """The two the signup note leaves out are left out because of this flag, so
     if one ever becomes household-wide the note has to gain it."""
     assert limits.RESOURCES[name].household_wide is False
+
+
+async def test_login_hides_the_reset_link_by_the_key_the_server_publishes():
+    """A server with no SMTP answers 503 to POST /auth/password-reset, so the
+    sign-in foot asks first rather than offering a door nobody can open — the
+    same thing the iOS app does (issue #49). It has to read the key that is
+    actually published, so a rename here fails rather than silently reverting
+    the link to always-on."""
+    from app.main import client_config
+
+    published = await client_config()
+    assert "password_reset_enabled" in published, "/client-config no longer publishes the key login.js reads"
+
+    source = (WEB / "login.js").read_text()
+    assert "config === null || config.password_reset_enabled === false" in source, (
+        "web/js/views/login.js should withhold the reset link until /client-config settles, then "
+        "hide it on an explicit false only — absent means an older server that does send reset codes"
+    )
+    assert ".catch(() => {\n      config = {};" in source, (
+        "the failed fetch must still settle config, or a /client-config that errors hides the reset "
+        "link for good rather than for a moment"
+    )

--- a/web/app.css
+++ b/web/app.css
@@ -682,6 +682,9 @@ table.plain tr:last-child td { border-bottom: 0; }
 .login-tabs button.on { background: var(--card); color: var(--ink); box-shadow: var(--shadow-sm); }
 .login-card .btn { width: 100%; justify-content: center; padding: .65rem 1rem; font-size: 1rem; margin-top: .4rem; }
 .login-foot { text-align: center; margin-top: 1.1rem; font-size: .85rem; color: var(--ink-mute); }
+/* A server with no SMTP has no reset link to offer, so the foot can be empty
+   on the sign-in tab — don't leave its margin behind. */
+.login-foot:empty { display: none; }
 
 .seg { display: flex; gap: .3rem; background: var(--cream-2); border-radius: 999px; padding: .22rem; margin-bottom: 1rem; }
 .seg button { flex: 1; border: 0; background: none; padding: .35rem .5rem; border-radius: 999px; font-weight: 600; font-size: .85rem; color: var(--ink-mute); cursor: pointer; }

--- a/web/js/views/login.js
+++ b/web/js/views/login.js
@@ -22,7 +22,7 @@ export function renderLogin(root) {
         </div>
         <form data-form>${formBody()}</form>
         <div data-allowances></div>
-        <p class="login-foot">${footNote()}</p>
+        <p class="login-foot" data-foot></p>
       </div>
     </div>
   `);
@@ -34,21 +34,6 @@ export function renderLogin(root) {
       renderLogin(root);
     };
   }
-  const forgot = root.querySelector("[data-forgot]");
-  if (forgot) {
-    forgot.onclick = () => {
-      mode = "reset";
-      resetStage = "request";
-      renderLogin(root);
-    };
-  }
-  const back = root.querySelector("[data-back]");
-  if (back) {
-    back.onclick = () => {
-      mode = "signin";
-      renderLogin(root);
-    };
-  }
   for (const seg of root.querySelectorAll("[data-join]")) {
     seg.onclick = () => {
       joinMode = seg.dataset.join;
@@ -56,7 +41,9 @@ export function renderLogin(root) {
     };
   }
 
+  paintFoot(root);
   paintAllowances(root);
+  loadConfig(root);
 
   const form = root.querySelector("[data-form]");
   form.onsubmit = async (event) => {
@@ -74,15 +61,24 @@ export function renderLogin(root) {
   };
 }
 
-// ── what an account here includes ────────────────────────────────────────
+// ── what this server can do, and what an account here includes ───────────
 //
 // planning/08-freemium.md §4: the numbers ride on the unauthenticated
 // GET /client-config precisely so this page can show them, since a signup page
 // has nobody to log in as yet. On a server that limits nothing every one of
 // them is null and this says nothing at all, which is §1 doing its job.
 //
-// Shown only when starting a household: an invite code joins somebody else's,
-// whose allowances are theirs and not these.
+// The same answer says whether the server can send email at all, which is what
+// decides the reset link below: a deployment with no SMTP answers 503 to
+// POST /auth/password-reset, so offering it regardless points people at a door
+// they can do nothing about (issue #49 fixed exactly this in the iOS app).
+//
+// It lands after the card is on screen, so both readers paint their own slot
+// rather than re-rendering: the form may be half typed by then.
+//
+// Which is also why the fetch settles into `config` whether it succeeded or
+// not. The link is withheld until the answer is in, so a rejection that left
+// it null would hide a working feature for good rather than for a moment.
 
 const ALLOWANCES = [
   // The order is the order the wall is met in: the member limit is the gate.
@@ -96,21 +92,31 @@ const ALLOWANCES = [
   ["ingests_per_month", (n) => `${n} recipes read from a URL each month`],
 ];
 
-let allowances = null; // null until asked; {} once the answer is in
+let config = null; // the answer, or {} if it could not be had; null until it settles
+let asked = false; // a re-render mid-flight must not ask a second time
+
+function loadConfig(root) {
+  if (asked) return;
+  asked = true;
+  api("/client-config")
+    .then((answer) => {
+      config = answer || {};
+    })
+    .catch(() => {
+      config = {}; // a server that cannot answer this has a louder problem
+    })
+    .finally(() => {
+      paintFoot(root);
+      paintAllowances(root);
+    });
+}
 
 function paintAllowances(root) {
   const slot = root.querySelector("[data-allowances]");
   if (!slot || mode !== "register" || joinMode !== "new") return;
-  if (allowances === null) {
-    allowances = {};
-    api("/client-config")
-      .then((config) => {
-        allowances = config.free_tier_limits || {};
-        paintAllowances(root); // painting a slot, never re-rendering: the form may be half typed
-      })
-      .catch(() => {}); // a server that cannot answer this has a louder problem
-    return;
-  }
+  // Shown only when starting a household: an invite code joins somebody else's,
+  // whose allowances are theirs and not these.
+  const allowances = config?.free_tier_limits || {};
   const rows = ALLOWANCES.filter(([name]) => allowances[name] !== null && allowances[name] !== undefined);
   if (rows.length === 0) return;
   render(slot, html`
@@ -119,6 +125,30 @@ function paintAllowances(root) {
       <ul>${rows.map(([name, phrase]) => html`<li>${phrase(allowances[name])}</li>`)}</ul>
     </div>
   `);
+}
+
+// The foot's buttons are bound here rather than in renderLogin because a
+// repaint replaces them, and the reset link only learns whether it belongs
+// once /client-config has answered.
+function paintFoot(root) {
+  const slot = root.querySelector("[data-foot]");
+  if (!slot) return;
+  render(slot, footNote());
+  const forgot = slot.querySelector("[data-forgot]");
+  if (forgot) {
+    forgot.onclick = () => {
+      mode = "reset";
+      resetStage = "request";
+      renderLogin(root);
+    };
+  }
+  const back = slot.querySelector("[data-back]");
+  if (back) {
+    back.onclick = () => {
+      mode = "signin";
+      renderLogin(root);
+    };
+  }
 }
 
 function formBody() {
@@ -170,7 +200,16 @@ function formBody() {
 }
 
 function footNote() {
-  if (mode === "signin") return html`<button class="link-btn" data-forgot>Forgotten your password?</button>`;
+  if (mode === "signin") {
+    // Withheld until /client-config has settled, so it never appears and then
+    // vanishes. After that only an explicit false keeps it away: absent means a
+    // server that never published the key, and those do send reset codes — the
+    // same reading the iOS app takes. A fetch that failed settles to {} for
+    // exactly that reason, so being unable to ask offers the link rather than
+    // quietly removing one that works.
+    if (config === null || config.password_reset_enabled === false) return html``;
+    return html`<button class="link-btn" data-forgot>Forgotten your password?</button>`;
+  }
   if (mode === "register") {
     return joinMode === "new"
       ? html`Your recipes, plan and list are visible only to your household.`


### PR DESCRIPTION
`web/js/views/login.js` always painted "Forgotten your password?" into the sign-in foot. On a deployment with no SMTP, `POST /auth/password-reset` answers 503, so the link led somewhere the person could do nothing about. The iOS app already asks first (issue #49); this is the web client catching up, and `GET /client-config` publishes `password_reset_enabled` for exactly this.

## What changed

`login.js` already fetched `/client-config` for the signup allowances (#120), so the two readers now share one answer. The fetch moved out of `paintAllowances` into `loadConfig`, because the allowances only ever asked on the register tab and the reset link lives on sign-in, which is the default one.

The foot became a painted slot like the allowances note, since the answer lands after the card is on screen and the form may be half typed by then. Its buttons are bound in `paintFoot` rather than `renderLogin` for the same reason: a repaint replaces them.

The link is **withheld until the fetch settles**, so it never appears and then vanishes. That makes the failure path load-bearing: the `catch` settles `config` to `{}` and the repaint happens in `finally`, or a `/client-config` that errors would hide a working feature for good rather than for a moment. Once settled, only an explicit `false` keeps the link away — absent means an older server that never published the key, and those do send reset codes, which is the same reading `Session.swift` takes.

`.login-foot:empty` collapses the foot, or the hidden link leaves its margin behind.

## Verification

Driven against real servers rather than reasoned about:

| Case | Result |
|---|---|
| Slow server, SMTP on, request in flight | link absent, foot collapsed |
| same, after the answer lands | link appears and works; reset and back both reachable |
| same, form half typed across the settle | email, password, focus and caret survive on the same DOM node |
| No SMTP, MutationObserver across the settle | link never appeared, not for a frame |
| `/client-config` returns 500 | link present and works |
| Register tab | allowances note and foot text unaffected |

`make lint` clean; 870 backend + 67 mcp tests pass.

The added lint asserts both halves of the contract: the guard expression, and that the failed fetch still settles `config` — so a future edit can't silently turn the link back on, or leave it hidden forever.

## Note on history

This change was originally committed onto `marvin/github-issue-120-web-allowances`, but that branch was pushed and merged as #123 at the preceding commit, so it never reached `main`. This is the same commit cherry-picked onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)