### PR TITLE
Cut 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 
 ## Unreleased
 
+Nothing merged since the release below.
+
+## 2026-08-23 — the web half of it
+
+Released as **1.3.0**, and **not yet deployed**: unlike the sections below this
+one, `meals.marcuslab.uk` is still on 1.2.0 until `make deploy` runs. **No
+migrations**, so the rollout is an image swap.
+
+Nothing here is switched on for that deployment either. It sets no
+`LIMITS_PROFILE` and no `BILLING_API_KEY`, so the usage panel, the signup table
+and the subscription card are all absent, `POST /billing/checkout` does not
+exist, and `billing_enabled` is false. What changes for a user of it is one
+button: their household's data, in one file, from Settings.
+
 The web half of the money, and the web half of the limits. Two issues, both of
 them the same shape: the freemium machinery existed and nothing a household
 could see used it.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -57,7 +57,7 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(
     lifespan=lifespan,
     title="Meals API",
-    version="1.2.0",
+    version="1.3.0",
     description=(
         "A meal *options* planner (not a rigid Mon–Sun grid) with a recipe library and an "
         "aisle-sorted shopping list. Designed to be driven by any AI assistant: every error "

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meals-backend"
-version = "1.2.0"
+version = "1.3.0"
 description = "Meal options planner backend — recipes, meals, plans, aisle-sorted shopping list, AI-friendly API"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "meals-backend"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosmtplib" },
@@ -890,7 +890,7 @@ dev = [
 
 [[package]]
 name = "meals-mcp"
-version = "1.2.0"
+version = "1.3.0"
 source = { directory = "../mcp" }
 dependencies = [
     { name = "httpx" },

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meals-mcp"
-version = "1.2.0"
+version = "1.3.0"
 description = "MCP server wrapping the Meals REST API with task-level tools for AI assistants"
 requires-python = ">=3.12"
 dependencies = [

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -365,7 +365,7 @@ wheels = [
 
 [[package]]
 name = "meals-mcp"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Version bump and changelog for **1.3.0**, covering #120 and #121.

`backend/pyproject.toml`, `mcp/pyproject.toml` and the FastAPI `version=` all
read 1.3.0, which the release job checks against the tag before it publishes
anything — v1.0.1 once shipped an API reporting 1.0.0 and the deploy compares
the live `api_version` against the release it deployed.

**No migrations**, so the rollout is an image swap.

The changelog section says plainly that this is released and *not yet deployed*.
Every dated section below it means "live on `meals.marcuslab.uk`"; this one will
not until `make deploy` runs, and saying so beats quietly bending the convention.

Nothing in the release is switched on for that deployment: it sets no
`LIMITS_PROFILE` and no `BILLING_API_KEY`, so the usage panel, the signup table
and the subscription card are all absent and `POST /billing/checkout` does not
exist. What changes for a user of it is one button — their household's data, in
one file, from Settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
