### PR TITLE
Pin the Stripe API version, and cut 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,24 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 
 Nothing merged since the release below.
 
+## 2026-08-23 — pin the version that decides who is selling
+
+Released as **1.3.1**. No migrations.
+
+### Fixed
+
+- **The Stripe API version is pinned on the checkout request** rather than
+  inherited from the account's default. `managed_payments[enabled]` — the
+  parameter that makes Stripe the merchant of record, and the whole reason §7
+  chose one — exists only from `2025-03-31.basil`. An account on an older
+  default would have rejected it and failed every checkout, and the setting that
+  decides it is one this server cannot see. Found while setting up a sandbox:
+  Stripe's own integration snippet sends the header and this code did not.
+
 ## 2026-08-23 — the web half of it
 
-Released as **1.3.0**, and **not yet deployed**: unlike the sections below this
-one, `meals.marcuslab.uk` is still on 1.2.0 until `make deploy` runs. **No
-migrations**, so the rollout is an image swap.
+Released as **1.3.0** and deployed to `meals.marcuslab.uk` the same evening.
+**No migrations**, so the rollout was an image swap.
 
 Nothing here is switched on for that deployment either. It sets no
 `LIMITS_PROFILE` and no `BILLING_API_KEY`, so the usage panel, the signup table

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -57,7 +57,7 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(
     lifespan=lifespan,
     title="Meals API",
-    version="1.3.0",
+    version="1.3.1",
     description=(
         "A meal *options* planner (not a rigid Mon–Sun grid) with a recipe library and an "
         "aisle-sorted shopping list. Designed to be driven by any AI assistant: every error "

--- a/backend/app/services/billing.py
+++ b/backend/app/services/billing.py
@@ -458,6 +458,17 @@ def count(outcome: str) -> None:
 # `entitlements.grant` is reached only from a verified webhook carrying a billing
 # period end. A checkout that is abandoned leaves no trace but a log line.
 
+#: The Stripe API version this integration is written against, sent on every
+#: request rather than left to the account's default.
+#:
+#: `managed_payments` exists from `2025-03-31.basil`, and the account default is
+#: a dashboard setting this server cannot see. Left unpinned, an account on an
+#: older version would reject the parameter and every checkout would fail — or,
+#: worse for the one thing §7 turns on, a future default could change what it
+#: means. The version that decides who the legal seller is should not be
+#: invisible, so it is written here where it can be read and changed on purpose.
+STRIPE_API_VERSION = "2025-03-31.basil"
+
 #: Where each processor's API lives. `BILLING_API_BASE` overrides it, which is
 #: how you reach Paddle's sandbox (`sandbox-api.paddle.com`) and how the tests
 #: point this at a stub instead of the internet.
@@ -564,6 +575,7 @@ async def _stripe_checkout(
         f"{base}/v1/checkout/sessions",
         data=form,
         auth=(settings.billing_api_key, ""),
+        headers={"Stripe-Version": STRIPE_API_VERSION},
     )
     if response.status_code >= 400:
         raise _fail(household, response)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meals-backend"
-version = "1.3.0"
+version = "1.3.1"
 description = "Meal options planner backend — recipes, meals, plans, aisle-sorted shopping list, AI-friendly API"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/tests/integration/test_billing_checkout.py
+++ b/backend/tests/integration/test_billing_checkout.py
@@ -181,6 +181,9 @@ async def test_stripe_checkout_carries_the_household_and_the_merchant_of_record(
     assert sent["success_url"].endswith("/app/#/settings")
     # The key authenticates and is never anywhere else.
     assert route.calls.last.request.headers["authorization"].startswith("Basic ")
+    # Pinned, not inherited: `managed_payments` exists from this version on, and
+    # the account default is a dashboard setting this server cannot see.
+    assert route.calls.last.request.headers["stripe-version"] == "2025-03-31.basil"
 
 
 @respx.mock

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "meals-backend"
-version = "1.3.0"
+version = "1.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosmtplib" },
@@ -890,7 +890,7 @@ dev = [
 
 [[package]]
 name = "meals-mcp"
-version = "1.3.0"
+version = "1.3.1"
 source = { directory = "../mcp" }
 dependencies = [
     { name = "httpx" },

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meals-mcp"
-version = "1.3.0"
+version = "1.3.1"
 description = "MCP server wrapping the Meals REST API with task-level tools for AI assistants"
 requires-python = ">=3.12"
 dependencies = [

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -365,7 +365,7 @@ wheels = [
 
 [[package]]
 name = "meals-mcp"
-version = "1.3.0"
+version = "1.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
`managed_payments[enabled]` is the parameter that makes Stripe the merchant of
record for a sale, and it exists only from API version `2025-03-31.basil`. The
checkout request sent no version header, so it inherited the account's default:
a dashboard setting this server cannot read, on an account it does not own.

An account below that version would have rejected the parameter and failed every
checkout — that is the loud failure. The reason to pin rather than hope is the
quiet one: the version that decides who the legal seller is should be written
somewhere a person can read it, next to the flag it governs.

Found while setting up a sandbox for dogfooding. Stripe's own integration
snippet sends the header; this code did not.

One constant, one header, one assertion in the Stripe checkout test. No
migrations. Also cuts **1.3.1**, and corrects the 1.3.0 changelog entry, which
said "not yet deployed" and was overtaken by the deploy an hour later.

`make lint` clean, `make test-fast` green (887 backend, 67 mcp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
