### PR TITLE
Credit the open source this is built on, at /credits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,10 +132,12 @@ jobs:
           curl -fsS --max-time 10 http://localhost:8000/privacy > privacy.html
           grep -q '<h1' privacy.html
           curl -fsS --max-time 10 -o /dev/null http://localhost:8000/support
-          # /terms rides the same rails and is COPYed the same way, so it can
-          # be forgotten the same way.
+          # /terms and /credits ride the same rails and are COPYed the same
+          # way, so they can be forgotten the same way.
           curl -fsS --max-time 10 http://localhost:8000/terms > terms.html
           grep -q '<h1' terms.html
+          curl -fsS --max-time 10 http://localhost:8000/credits > credits.html
+          grep -q '<table' credits.html
           # The web client is COPYed into the image separately from app/ too —
           # a build that forgets it serves a 404 where the big-screen UI was.
           curl -fsS --max-time 10 http://localhost:8000/app/ > app.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,29 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 
 ## Unreleased
 
-Nothing merged since the release below.
+### Added
+
+- **`/credits`**, served by every deployment from
+  [CREDITS.md](CREDITS.md) on the same rails as `/privacy`, `/support` and
+  `/terms`: what the server is built on, under which licences, with a note on
+  each of the fifteen dependencies this project actually chose. Neither client
+  ships third-party code, and the page says so rather than letting anyone
+  assume otherwise. Nothing obliges it (the wheels carry their own licence
+  files into the image, which is what MIT, BSD and Apache-2.0 ask of a
+  distribution) beyond it being the decent thing to do.
+- `backend/tests/unit/test_credits.py` resolves both `uv.lock` files down to
+  what installs on Linux and fails when a shipped package is uncredited, when a
+  credited one no longer ships, or when a row names no licence. A credits page
+  nobody lints is a credits page that quietly stops being true.
+- **An About card in the web app's Settings**, which is the first link anywhere
+  in the web client to `/privacy`, `/support`, `/terms` and `/credits`. Linted
+  against the pages router, so a fifth page fails CI until somebody decides
+  where it belongs.
+- **A Credits link in the iPhone app's Settings**, following the connected
+  server like the privacy and support links do. Still no link to `/terms` from
+  iOS, deliberately: that is the page with the price on it, and 3.1.3(f) is
+  what the listing rests on. A lint in the Python suite keeps it that way,
+  since there is no iOS job in CI.
 
 ## 2026-08-23 — pin the version that decides who is selling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,8 +409,8 @@ one, so the constraints it adds are load-bearing:
 `{{API_URL}}` substituted from the request's forwarded-proto/host headers.
 Keep `SKILL.md`, `prompt-pack.md` and the API in step when endpoints change.
 
-`PRIVACY.md`, `SUPPORT.md` and `TERMS.md` ship the same way and render at
-`/privacy`, `/support` and `/terms` (`routers/pages.py`). **The first two are the
+`PRIVACY.md`, `SUPPORT.md`, `TERMS.md` and `CREDITS.md` ship the same way and
+render at `/privacy`, `/support`, `/terms` and `/credits` (`routers/pages.py`). **The first two are the
 App Store's privacy and support URLs**, so a build that fails to COPY them takes
 down a live store listing — which is why CI curls all three against the built
 image. They're also exempt from the client gate: someone stuck on the upgrade
@@ -422,6 +422,26 @@ the same test the limit refusals have to pass. Cross-page links are written as
 prose plus a code span (`/privacy`) rather than as markdown links: a
 root-relative link 404s for anyone reading the file on GitHub, and a repo-
 relative one 404s on the served page.
+
+`CREDITS.md` is the odd one out: no licence in the image requires it (every
+wheel installs its own licence file, which is what MIT, BSD and Apache-2.0
+actually ask of a distribution), so it exists because a project that asks to be
+self-hosted should be able to say what it stands on. That makes rot the only
+real risk, so it is linted rather than trusted: `tests/unit/test_credits.py`
+resolves both `uv.lock` files to what `uv sync --no-dev` installs **on Linux**
+and fails on a shipped-but-uncredited package, a credited-but-gone one, or a row
+with no licence. Direct dependencies live in the first table with a line saying
+what they do here, and that split is linted too, against the two `pyproject.toml`
+files. Everything that is not a Python package (Postgres, rclone, SwiftUI) is
+hand-written in bullets, which the lint ignores by only reading table rows.
+
+The web app's Settings has an **About card**, and it is the only route from
+`web/` to any of those four pages; `tests/unit/test_web_client.py` lints it
+against the pages router, so a new page fails until it is linked. iOS links
+`/credits` and, deliberately, **never `/terms`** — that is the page with the
+price on it, and the listing rests on 3.1.3(f). Because there is no iOS job in
+CI, that absence is asserted from `tests/unit/test_app_store_metadata.py`
+alongside the metadata lint.
 
 ## Testing
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,126 @@
+# Credits
+
+YAMP is AGPL-3.0 (`LICENSE` in the repository), and it stands on a great deal of other people's
+work. This page names it.
+
+The two clients carry none of it. The iPhone app has no Swift package
+dependencies at all (`ios/Meals/project.yml` declares none), and the web app has
+no build step, no bundler and no CDN, just hand-written CSS and ES modules the
+browser loads directly. Everything below therefore ships inside the server
+image.
+
+Nothing here is a compliance exercise. MIT, BSD, Apache-2.0 and the rest ask
+that the copyright notice and the licence text travel with the software, and
+they do: every package installs its own licence file into `site-packages`
+inside the image, where `find` will turn up all of them. This page exists
+because naming what you are built on is the decent thing to do.
+
+Every deployment serves it at `/credits`, rendered from this file, the same way
+`/privacy`, `/support` and `/terms` are.
+
+## What the server is built on
+
+The fifteen dependencies this project actually chose, in
+`backend/pyproject.toml` and `mcp/pyproject.toml`.
+
+| Package | Licence | What it does here |
+| --- | --- | --- |
+| [aiosmtplib](https://github.com/cole/aiosmtplib) | MIT | Sends the password-reset and dunning mail without blocking the event loop. |
+| [aiosqlite](https://github.com/omnilib/aiosqlite) | MIT | The async SQLite driver: the default one-container database, and every test in this repo. |
+| [alembic](https://alembic.sqlalchemy.org) | MIT | Schema migrations, applied on boot on both engines. |
+| [asyncpg](https://github.com/MagicStack/asyncpg) | Apache-2.0 | The async Postgres driver the deployed stack runs on. |
+| [bcrypt](https://github.com/pyca/bcrypt) | Apache-2.0 | Password hashing, and the hashing behind API tokens and invite codes. |
+| [beautifulsoup4](https://www.crummy.com/software/BeautifulSoup/bs4/) | MIT | Finds the JSON-LD block in a recipe page. The backend never calls an LLM, so this is the whole of ingestion. |
+| [fastapi](https://github.com/fastapi/fastapi) | MIT | The API: routing, dependency injection, and the OpenAPI schema `/docs` serves. |
+| [httpx](https://github.com/encode/httpx) | BSD-3-Clause | Fetching recipe pages, and how the mounted MCP server calls the API over loopback. |
+| [markdown-it-py](https://github.com/executablebooks/markdown-it-py) | MIT | Renders this page, along with `/privacy`, `/support` and `/terms`. |
+| [mcp](https://modelcontextprotocol.io) | MIT | The Model Context Protocol SDK the server at `/mcp` is built on. |
+| [prometheus-client](https://github.com/prometheus/client_python) | Apache-2.0 AND BSD-2-Clause | The counters and histograms behind `/metrics`. |
+| [pydantic](https://github.com/pydantic/pydantic) | MIT | Every request and response schema, and the validation that lets a 422 say something useful. |
+| [pydantic-settings](https://github.com/pydantic/pydantic-settings) | MIT | Configuration from the environment, in one typed place. |
+| [sqlalchemy](https://www.sqlalchemy.org) | MIT | The async ORM, and the only thing in the product that touches the database. |
+| [uvicorn](https://uvicorn.dev) | BSD-3-Clause | The ASGI server that runs all of it. |
+
+## What those bring with them
+
+Nobody picked these directly. They are holding the thing up all the same.
+
+| Package | Licence |
+| --- | --- |
+| [annotated-doc](https://github.com/fastapi/annotated-doc) | MIT |
+| [annotated-types](https://github.com/annotated-types/annotated-types) | MIT |
+| [anyio](https://github.com/agronholm/anyio) | MIT |
+| [attrs](https://github.com/python-attrs/attrs) | MIT |
+| [certifi](https://github.com/certifi/python-certifi) | MPL-2.0 |
+| [cffi](https://github.com/python-cffi/cffi) | MIT-0 |
+| [click](https://github.com/pallets/click) | BSD-3-Clause |
+| [cryptography](https://github.com/pyca/cryptography) | Apache-2.0 OR BSD-3-Clause |
+| [dnspython](https://www.dnspython.org) | ISC |
+| [email-validator](https://github.com/JoshData/python-email-validator) | Unlicense |
+| [greenlet](https://greenlet.readthedocs.io) | MIT AND PSF-2.0 |
+| [h11](https://github.com/python-hyper/h11) | MIT |
+| [httpcore](https://www.encode.io/httpcore/) | BSD-3-Clause |
+| [httpcore2](https://github.com/pydantic/httpx2) | BSD-3-Clause |
+| [httptools](https://github.com/MagicStack/httptools) | MIT |
+| [httpx2](https://github.com/pydantic/httpx2) | BSD-3-Clause |
+| [idna](https://github.com/kjd/idna) | BSD-3-Clause |
+| [jsonschema](https://github.com/python-jsonschema/jsonschema) | MIT |
+| [jsonschema-specifications](https://github.com/python-jsonschema/jsonschema-specifications) | MIT |
+| [mako](https://www.makotemplates.org/) | MIT |
+| [markupsafe](https://github.com/pallets/markupsafe) | BSD-3-Clause |
+| [mcp-types](https://modelcontextprotocol.io) | MIT |
+| [mdurl](https://github.com/executablebooks/mdurl) | MIT |
+| [opentelemetry-api](https://github.com/open-telemetry/opentelemetry-python) | Apache-2.0 |
+| [pycparser](https://github.com/eliben/pycparser) | BSD-3-Clause |
+| [pydantic-core](https://github.com/pydantic/pydantic-core) | MIT |
+| [pyjwt](https://github.com/jpadilla/pyjwt) | MIT |
+| [python-dotenv](https://github.com/theskumar/python-dotenv) | BSD-3-Clause |
+| [python-multipart](https://github.com/Kludex/python-multipart) | Apache-2.0 |
+| [pyyaml](https://pyyaml.org/) | MIT |
+| [referencing](https://github.com/python-jsonschema/referencing) | MIT |
+| [rpds-py](https://github.com/crate-py/rpds) | MIT |
+| [soupsieve](https://github.com/facelessuser/soupsieve) | MIT |
+| [sse-starlette](https://github.com/sysid/sse-starlette) | BSD-3-Clause |
+| [starlette](https://github.com/Kludex/starlette) | BSD-3-Clause |
+| [truststore](https://github.com/sethmlarson/truststore) | MIT |
+| [typing-extensions](https://github.com/python/typing_extensions) | PSF-2.0 |
+| [typing-inspection](https://github.com/pydantic/typing-inspection) | MIT |
+| [uvloop](https://github.com/MagicStack/uvloop) | MIT OR Apache-2.0 |
+| [watchfiles](https://github.com/samuelcolvin/watchfiles) | MIT |
+| [websockets](https://github.com/python-websockets/websockets) | BSD-3-Clause |
+
+## Everything that isn't a Python package
+
+The images are made of software too, and the backup sidecar is mostly other
+people's programs wired together.
+
+- [Python](https://www.python.org/) (PSF-2.0) and [Debian](https://www.debian.org/) (many licences, GPL-compatible), by way of the [uv](https://github.com/astral-sh/uv) base image (MIT OR Apache-2.0). `uv` also resolves and locks everything in the two tables above.
+- [SQLite](https://www.sqlite.org/) (public domain), the default database of a one-container install, reached through `aiosqlite`.
+- [PostgreSQL](https://www.postgresql.org/) (PostgreSQL Licence), the database the reference deployment runs, and the `pg_dump` and `pg_restore` the whole of `backup/` is built around.
+- [Alpine Linux](https://alpinelinux.org/) (MIT), underneath the backup sidecar via `postgres:17-alpine`.
+- [rclone](https://rclone.org/) (MIT) and [GnuPG](https://gnupg.org/) (GPL-3.0), which encrypt each nightly dump and push it off the node.
+- [Docker](https://www.docker.com/) (Apache-2.0), which is how any of it runs anywhere.
+
+The iPhone app is [SwiftUI](https://developer.apple.com/xcode/swiftui/),
+Foundation and XCTest, all Apple's and all shipped with the OS. Its Xcode
+project is generated by [XcodeGen](https://github.com/yonaskolb/XcodeGen) (MIT),
+which builds the app without ever shipping inside it.
+
+## Leaned on, never shipped
+
+Not in the image, and the work would be worse without them:
+[ruff](https://docs.astral.sh/ruff) (MIT),
+[pytest](https://docs.pytest.org) with `pytest-asyncio` and `pytest-cov` (MIT
+and Apache-2.0), [respx](https://lundberg.github.io/respx/) (BSD-3-Clause) and
+[coverage.py](https://github.com/coveragepy/coveragepy) (Apache-2.0).
+
+## How this page stays true
+
+A hand-written list of dependencies is a list that rots, so this one is linted.
+`backend/tests/unit/test_credits.py` resolves both `uv.lock` files down to the packages that actually install on
+Linux, and fails when one of them ships uncredited or stays credited after it
+has gone. Adding a dependency breaks CI until it is named here, which is the
+same trick that keeps the export field list and the limits vocabulary honest.
+
+Missing or wrong attribution here is a bug worth reporting, on the same footing
+as any other, and `/support` says where to send it.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,8 +24,9 @@ COPY skill ./skill
 COPY web ./web
 # The App Store's privacy and support URLs point at /privacy and /support, which
 # render these. If they don't ship, those URLs 404 and the listing is broken.
-# TERMS.md rides along for /terms, and is just as easy to forget.
-COPY PRIVACY.md SUPPORT.md TERMS.md ./
+# TERMS.md and CREDITS.md ride along for /terms and /credits, and are just
+# as easy to forget.
+COPY PRIVACY.md SUPPORT.md TERMS.md CREDITS.md ./
 RUN uv sync --frozen --no-dev
 
 # Runs as a normal user, and one that owns nothing it doesn't need to write.

--- a/backend/app/client_gate.py
+++ b/backend/app/client_gate.py
@@ -44,6 +44,9 @@ EXEMPT_PREFIXES = (
     "/privacy",
     "/support",
     "/terms",
+    # And an attribution page that a licence upstream might one day depend on
+    # is not something to put behind a client version.
+    "/credits",
 )
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -221,6 +221,7 @@ async def root(request: Request) -> Response:
         "privacy": f"{base}/privacy",
         "support": f"{base}/support",
         "terms": f"{base}/terms",
+        "credits": f"{base}/credits",
     }
     if _mcp_attached:
         # This deployment serves the MCP endpoint itself, so an assistant can

--- a/backend/app/routers/pages.py
+++ b/backend/app/routers/pages.py
@@ -1,10 +1,11 @@
-"""Human-readable pages: the privacy policy, the support page and the terms.
+"""Human-readable pages: the privacy policy, the support page, the terms and the credits.
 
 The App Store requires the first two to be publicly reachable URLs, and the
 deployment is the only thing this project already hosts — so they are served
 from here rather than from a second piece of infrastructure that could rot
 independently. `/terms` joins them on the same rails because taking money needs
-one and because it is the same three lines of code (issue #98).
+one and because it is the same three lines of code (issue #98), and `/credits`
+for the same three lines again.
 
 Rendered from the same markdown that GitHub shows, for the same reason `/skill`
 is served from `skill/SKILL.md`: one copy, so the published page can't drift
@@ -126,3 +127,15 @@ async def terms() -> str:
     why the page opens by saying that almost none of it applies to a
     self-hosted instance."""
     return _page("TERMS.md")
+
+
+@router.get("/credits", response_class=HTMLResponse, include_in_schema=False)
+async def credits_page() -> str:
+    """What this server is built on, and under which licences. No auth required.
+
+    Nothing obliges this page: the wheels install their own licence files into
+    site-packages, which is what MIT, BSD and Apache-2.0 actually ask for. It
+    is here because a project that asks people to self-host it should be able
+    to say what it stands on, and because `tests/unit/test_credits.py` can then
+    make an uncredited dependency a CI failure rather than an oversight."""
+    return _page("CREDITS.md")

--- a/backend/tests/integration/test_client_gate.py
+++ b/backend/tests/integration/test_client_gate.py
@@ -102,7 +102,7 @@ class TestExemptions:
         The terms are the same argument with money in it: deciding whether to
         keep paying must not require updating an app first."""
         min_build(99)
-        for path in ("/privacy", "/support", "/terms"):
+        for path in ("/privacy", "/support", "/terms", "/credits"):
             assert (await client.get(path, headers=ios(1))).status_code == 200, path
 
 

--- a/backend/tests/integration/test_misc.py
+++ b/backend/tests/integration/test_misc.py
@@ -140,6 +140,32 @@ class TestPublicPages:
         assert "If you self-host, almost none of this applies" in text
         assert "Nothing is on sale yet" in text
 
+    async def test_credits_page_renders_as_html(self, client):
+        """What this server is built on. Not an App Store URL and not required
+        by any licence here, but the page a self-hoster should be able to reach
+        without cloning the repo."""
+        response = await client.get("/credits")
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/html")
+        assert "<h1" in response.text
+        assert "Credits" in response.text
+        assert "## What the server is built on" not in response.text  # rendered, not dumped
+
+    async def test_the_credits_are_a_table_of_licences(self, client):
+        """Its substance is in the tables, same as the privacy policy, so a
+        renderer without them would drop the whole point of the page."""
+        text = (await client.get("/credits")).text
+        assert "<table>" in text
+        assert "BSD-3-Clause" in text
+        assert "sqlalchemy" in text
+
+    async def test_the_credits_are_honest_about_the_clients(self, client):
+        """Neither client ships third-party code, and a credits page that let
+        somebody assume otherwise would be the one lie it could tell."""
+        text = (await client.get("/credits")).text
+        assert "no build step" in text
+        assert "no Swift package" in text
+
     async def test_the_privacy_policy_is_straight_about_money(self, client):
         """`/privacy` is a live App Store URL and it promises this project holds
         no payment details. That promise needs a section, not a silence.
@@ -169,7 +195,7 @@ class TestPublicPages:
 
     async def test_pages_need_no_auth(self, client):
         """`client` is unauthenticated — Apple's reviewer opens these in a browser."""
-        for path in ("/privacy", "/support", "/terms"):
+        for path in ("/privacy", "/support", "/terms", "/credits"):
             assert (await client.get(path)).status_code == 200, path
 
     async def test_missing_documents_404_not_500(self, client, monkeypatch):
@@ -184,6 +210,7 @@ class TestPublicPages:
         assert landing["privacy"] == "http://test/privacy"
         assert landing["support"] == "http://test/support"
         assert landing["terms"] == "http://test/terms"
+        assert landing["credits"] == "http://test/credits"
 
 
 # The playbook's guidance, pinned to the version that announces it. The digest

--- a/backend/tests/unit/test_app_store_metadata.py
+++ b/backend/tests/unit/test_app_store_metadata.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import pytest
 
 METADATA = Path(__file__).resolve().parents[3] / "ios" / "AppStore" / "metadata.md"
+IOS = Path(__file__).resolve().parents[3] / "ios" / "Meals" / "Meals"
 
 #: Words that would either invite a 3.1.3 problem or stop being true the day the
 #: hosted tier opens. "Subscription" is on the list in both directions: as a
@@ -84,3 +85,25 @@ def test_the_prose_is_free_to_explain_the_rule():
     use the words, or the rule could not be written down next to the copy."""
     text = METADATA.read_text(encoding="utf-8").lower()
     assert "subscription" in text, "the reasoning for this rule should live beside the copy it constrains"
+
+
+def test_the_app_links_the_credits_and_never_the_terms():
+    """Settings gained a link to `/credits` and must not gain one to `/terms`.
+
+    Both pages are served by every deployment and the web app links all four,
+    but they are not alike from Cupertino: the terms are where the price is
+    written down, and 3.1.3(f) exempts this app only while it carries no call
+    to action for a purchase outside it. The credits carry no such sentence.
+
+    This lives here rather than in XCTest for the reason at the top of the
+    file: there is no iOS job in CI, so a "for consistency" commit adding the
+    terms link would otherwise reach TestFlight unchallenged, and a build
+    cannot be recalled."""
+    settings = (IOS / "Views" / "SettingsView.swift").read_text()
+    links = (IOS / "App" / "AppLinks.swift").read_text()
+
+    assert "AppLinks.credits(" in settings, "the About section should link the connected server's credits page"
+    assert 'page("/credits"' in links
+
+    for source, name in ((settings, "SettingsView.swift"), (links, "AppLinks.swift")):
+        assert '"/terms"' not in source, f"ios/Meals/Meals/.../{name} links the terms, which 3.1.3(f) does not allow"

--- a/backend/tests/unit/test_credits.py
+++ b/backend/tests/unit/test_credits.py
@@ -1,0 +1,168 @@
+"""CREDITS.md against the lockfiles.
+
+`/credits` names what this server is built on. Nothing obliges that page: the
+wheels install their own licence files into site-packages, which is what MIT,
+BSD and Apache-2.0 actually ask of a distribution. It exists because a project
+that asks people to self-host it should be able to say what it stands on.
+
+A hand-written list of dependencies is a list that rots, though, and a credits
+page that has quietly stopped being true is worse than none. So this reads the
+two `uv.lock` files, resolves what actually installs in the image, and makes an
+uncredited package a CI failure rather than something to notice a year later.
+Same shape as the export field list and the limits vocabulary: the second place
+a thing is written down is linted from the first.
+
+Two deliberate narrowings:
+
+- **Runtime only.** `uv sync --no-dev` is what both Dockerfiles run, so ruff,
+  pytest and respx never reach anybody's machine. CREDITS.md thanks them in
+  prose instead, outside the tables this reads.
+- **Linux only.** The images are Linux, so the markers that pull in `pywin32`
+  or `colorama` never fire and crediting them would be a small lie.
+
+Everything that is not a Python package (Postgres, rclone, SwiftUI) is written
+by hand in bullets, which is why this only ever looks at table rows.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+from packaging.markers import Marker
+
+REPO = Path(__file__).resolve().parents[3]
+CREDITS = REPO / "CREDITS.md"
+LOCKS = {"meals-backend": REPO / "backend" / "uv.lock", "meals-mcp": REPO / "mcp" / "uv.lock"}
+
+#: What the image is. Only the keys the locks' markers actually test need to be
+#: right, but a full-ish environment keeps a new marker from raising instead of
+#: evaluating.
+LINUX = {
+    "sys_platform": "linux",
+    "platform_system": "Linux",
+    "platform_machine": "x86_64",
+    "os_name": "posix",
+    "platform_python_implementation": "CPython",
+    "implementation_name": "cpython",
+    "python_version": "3.13",
+    "python_full_version": "3.13.0",
+    "implementation_version": "3.13.0",
+    "extra": "",
+}
+
+#: Our own packages: the backend and the MCP server it mounts. They are the
+#: roots of the graph, not something to credit ourselves for.
+OURS = frozenset(LOCKS)
+
+#: `| [name](url) | licence |` or the same with a third "what it does" cell.
+#: Only table rows, which is what keeps the hand-written bullets about Postgres
+#: and SwiftUI out of the comparison.
+_ROW = re.compile(r"^\|\s*\[([a-z0-9][a-z0-9._-]*)\]\(https?://[^)]+\)\s*\|(.*)$", re.MULTILINE)
+
+
+class Row:
+    """One credited package: its name, its licence, and its note if it has one."""
+
+    def __init__(self, match: re.Match):
+        cells = [cell.strip() for cell in match.group(2).split("|")]
+        self.name = match.group(1)
+        self.licence = cells[0] if cells else ""
+        self.note = cells[1] if len(cells) > 1 else ""
+
+
+def _wanted(dependency: dict) -> bool:
+    marker = dependency.get("marker")
+    return marker is None or Marker(marker).evaluate(LINUX)
+
+
+def _shipped(lock: Path, root: str) -> set[str]:
+    """The packages `uv sync --no-dev` installs from one lockfile, on Linux.
+
+    Walks the resolved graph from the project rather than reading pyproject:
+    the transitive half is most of the list and all of the half that changes
+    without anybody deciding to change it. Extras are followed by name, so
+    `pydantic[email]` credits email-validator and a plain `pydantic` doesn't.
+    """
+    packages = {package["name"]: package for package in tomllib.loads(lock.read_text())["package"]}
+    reached: set[str] = set()
+    seen: set[tuple[str, tuple[str, ...]]] = set()
+    stack = [(root, ())]
+    while stack:
+        name, extras = stack.pop()
+        if (name, extras) in seen:
+            continue
+        seen.add((name, extras))
+        package = packages.get(name)
+        if package is None:
+            continue
+        reached.add(name)
+        wanted = list(package.get("dependencies", []))
+        for extra in extras:
+            wanted += package.get("optional-dependencies", {}).get(extra, [])
+        for dependency in wanted:
+            if _wanted(dependency):
+                stack.append((dependency["name"], tuple(dependency.get("extra", []))))
+    return reached
+
+
+@pytest.fixture(scope="module")
+def shipped() -> set[str]:
+    return {name for root, lock in LOCKS.items() for name in _shipped(lock, root)} - OURS
+
+
+@pytest.fixture(scope="module")
+def credited() -> list[Row]:
+    rows = [Row(match) for match in _ROW.finditer(CREDITS.read_text())]
+    assert rows, "CREDITS.md has no package rows at all, so the rest of this file would pass vacuously"
+    return rows
+
+
+def test_every_shipped_package_is_credited(shipped, credited):
+    """The one that matters: adding a dependency fails CI until it is named."""
+    missing = shipped - {row.name for row in credited}
+    assert missing == set(), (
+        f"CREDITS.md credits nothing for {sorted(missing)}, which ship inside the image. "
+        "Add a row (with its licence) to one of its tables."
+    )
+
+
+def test_nothing_is_credited_that_no_longer_ships(shipped, credited):
+    """The other direction, which is how the page stays a fact rather than a
+    fossil. A dropped dependency should lose its row in the same commit."""
+    stale = {row.name for row in credited} - shipped
+    assert stale == set(), (
+        f"CREDITS.md still credits {sorted(stale)}, which nothing installs any more. "
+        "Drop the row, or move it to the prose if it is a tool rather than a dependency."
+    )
+
+
+def test_every_row_names_a_licence(credited):
+    """A credits table with a blank licence column is decoration."""
+    blank = [row.name for row in credited if not row.licence]
+    assert blank == [], f"CREDITS.md has no licence for {blank}"
+
+
+def test_the_direct_dependencies_are_the_ones_with_a_note(shipped, credited):
+    """The first table is what this project *chose*, and each row says what the
+    thing does here. Keeping it in step with the two pyproject files is the
+    difference between a credits page and a `pip freeze`."""
+    direct = set()
+    for lock in LOCKS.values():
+        packages = {package["name"]: package for package in tomllib.loads(lock.read_text())["package"]}
+        for root in OURS:
+            if root in packages:
+                direct |= {
+                    dependency["name"] for dependency in packages[root].get("dependencies", []) if _wanted(dependency)
+                }
+    direct -= OURS
+    noted = {row.name for row in credited if row.note}
+    assert direct - noted == set(), (
+        f"{sorted(direct - noted)} is a dependency this project picked deliberately, so it belongs in the "
+        "first table of CREDITS.md with a line saying what it does here."
+    )
+    assert noted - direct == set(), (
+        f"{sorted(noted - direct)} is in the first table of CREDITS.md but is not a direct dependency of "
+        "backend/pyproject.toml or mcp/pyproject.toml any more."
+    )
+    assert direct <= shipped

--- a/backend/tests/unit/test_web_client.py
+++ b/backend/tests/unit/test_web_client.py
@@ -1,4 +1,5 @@
-"""The web client's half of the limits vocabulary (issue #120).
+"""The web client's half of the limits vocabulary (issue #120), and the pages
+it is the only route to.
 
 `web/` ships inside this image and calls `GET /limits` and `GET /client-config`
 to tell a household what it is allowed. Both answer with the resource *names*
@@ -94,4 +95,26 @@ async def test_login_hides_the_reset_link_by_the_key_the_server_publishes():
     assert ".catch(() => {\n      config = {};" in source, (
         "the failed fetch must still settle config, or a /client-config that errors hides the reset "
         "link for good rather than for a moment"
+    )
+
+
+def test_settings_links_every_page_this_server_publishes():
+    """`/privacy`, `/support`, `/terms` and `/credits` are served by every
+    deployment, and the web app is the only client that can reach all four
+    (the iPhone app deliberately carries no link to the terms). A page the
+    server renders and nothing links to is a page nobody reads, so the About
+    card is linted against the router rather than against a list written here:
+    adding a fifth page fails until somebody decides where it belongs.
+
+    Relative hrefs, because `web/` is mounted at `/app/` on the same origin as
+    the API and hardcoding a host would break every self-hosted install."""
+    from app.routers import pages as pages_router
+
+    published = {route.path for route in pages_router.router.routes}
+    assert published, "the pages router serves nothing, so this would pass vacuously"
+
+    source = (WEB / "settings.js").read_text()
+    missing = [path for path in sorted(published) if f'href="..{path}"' not in source]
+    assert missing == [], (
+        f"web/js/views/settings.js links to none of {missing}, which this server renders. Add them to the About card."
     )

--- a/ios/Meals/Meals/App/AppLinks.swift
+++ b/ios/Meals/Meals/App/AppLinks.swift
@@ -24,6 +24,21 @@ enum AppLinks {
     static func privacy(server: String) -> URL { page("/privacy", server: server) }
     static func support(server: String) -> URL { page("/support", server: server) }
 
+    /// What the connected server is built on, and under which licences. Follows
+    /// the server for the same reason the policy does: the credits describe the
+    /// build that is running, not whatever is on main today.
+    ///
+    /// The app itself has no third-party code at all — no Swift packages, only
+    /// Apple's own frameworks — so this credits the server, and the page says
+    /// so rather than letting anyone assume otherwise.
+    ///
+    /// `/terms` is served by every deployment too and is deliberately *not*
+    /// linked here: it is the page with the prices on it, and the App Store
+    /// listing rests on this app carrying no call to action for a purchase
+    /// outside it (planning/08-freemium.md §6). The credits carry no such
+    /// sentence, which is what makes them safe to link.
+    static func credits(server: String) -> URL { page("/credits", server: server) }
+
     /// The AI-facing pages every deployment serves: the skill is an
     /// assistant's operating manual for this server, the prompt pack a
     /// paste-anywhere version. Linked next to API tokens, which is where

--- a/ios/Meals/Meals/Views/SettingsView.swift
+++ b/ios/Meals/Meals/Views/SettingsView.swift
@@ -148,6 +148,9 @@ struct SettingsView: View {
             Link(destination: AppLinks.support(server: session.serverURL)) {
                 Label("Help & support", systemImage: "questionmark.circle")
             }
+            Link(destination: AppLinks.credits(server: session.serverURL)) {
+                Label("Credits", systemImage: "heart")
+            }
             Link(destination: AppLinks.sourceCode) {
                 Label("Source code", systemImage: "chevron.left.forwardslash.chevron.right")
             }

--- a/ios/Meals/MealsTests/AccountTests.swift
+++ b/ios/Meals/MealsTests/AccountTests.swift
@@ -146,7 +146,7 @@ final class AccountTests: XCTestCase {
 
     func testPolicyLinksFollowTheConnectedServer() {
         // The operator of your data is whoever runs your server, so that's
-        // whose policy Settings should open — every deployment serves both.
+        // whose policy Settings should open — every deployment serves all three.
         XCTAssertEqual(
             AppLinks.privacy(server: "https://meals.example.com").absoluteString,
             "https://meals.example.com/privacy"
@@ -154,6 +154,10 @@ final class AccountTests: XCTestCase {
         XCTAssertEqual(
             AppLinks.support(server: "http://localhost:8000").absoluteString,
             "http://localhost:8000/support"
+        )
+        XCTAssertEqual(
+            AppLinks.credits(server: "https://meals.example.com").absoluteString,
+            "https://meals.example.com/credits"
         )
     }
 

--- a/web/app.css
+++ b/web/app.css
@@ -292,6 +292,15 @@ select { cursor: pointer; }
   padding: 1.4rem 1.5rem;
 }
 
+/* A row of plain links: the About card's pages, and anywhere else a card
+   ends in "here is where to read more" rather than in a button. */
+.links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .35rem 1.1rem;
+  margin: .9rem 0 0;
+}
+
 .chip {
   display: inline-flex;
   align-items: center;

--- a/web/js/views/settings.js
+++ b/web/js/views/settings.js
@@ -1,7 +1,12 @@
 // Settings: account, the household and who is in it (Q19/Q23), supermarkets &
 // aisle order, AI access tokens, what this server allows, taking your data
-// away, and the danger zone (Q20). Invite codes and API tokens are shown
-// exactly once — the server stores only hashes.
+// away, the pages this server publishes about itself, and the danger zone
+// (Q20). Invite codes and API tokens are shown exactly once — the server
+// stores only hashes.
+//
+// The About card is the web app's only route to /privacy, /support, /terms and
+// /credits, which is why test_web_client.py lints it against the pages router:
+// a page the server serves and nothing links to is a page nobody reads.
 //
 // The lead is the only member who can invite, remove or rename (Q23), so those
 // controls are hidden rather than shown-and-refused for everyone else. Leaving
@@ -200,6 +205,23 @@ export async function renderSettings(root) {
           never be the hard part.
         </p>
         <div class="dialog-actions"><button class="btn ghost" data-export>Download everything</button></div>
+      </div>
+
+      <div class="section card">
+        <h2>About this server</h2>
+        <p class="sub">
+          These describe <em>this</em> server, the one actually holding your data.
+          Every deployment serves its own copy, rendered from the same files the
+          repository shows. The credits name what it is built on, which is a good
+          deal of other people's work under a good many licences.
+        </p>
+        <p class="links">
+          <a href="../privacy" target="_blank" rel="noopener">Privacy policy</a>
+          <a href="../support" target="_blank" rel="noopener">Help &amp; support</a>
+          <a href="../terms" target="_blank" rel="noopener">Terms &amp; refunds</a>
+          <a href="../credits" target="_blank" rel="noopener">Credits</a>
+          <a href="https://github.com/marco308/meals" target="_blank" rel="noopener">Source code</a>
+        </p>
       </div>
 
       <div class="section card danger-zone">


### PR DESCRIPTION
## What

`CREDITS.md` at the repo root, rendered at **`/credits`** by `routers/pages.py` on the same rails as `/privacy`, `/support` and `/terms`. It names the fifteen dependencies this project chose (with a line each on what they do here), the forty-one they pull in, the software in the images that is not a Python package at all, and the tools leaned on but never shipped.

## Why, given nothing required it

Every wheel installs its own licence file into `site-packages` inside the image, which is what MIT, BSD and Apache-2.0 ask of a distribution, and the manifests are public anyway. So this is a courtesy, not compliance. It exists because a project that asks people to self-host it should be able to say what it stands on without cloning it first.

The page opens by saying neither client ships third-party code (no Swift packages, no build step, no CDN), which is the one thing a credits page here could accidentally imply.

## Kept true rather than trusted

`backend/tests/unit/test_credits.py` resolves both `uv.lock` files down to what `uv sync --no-dev` installs **on Linux**, and fails on:

- a shipped package with no row,
- a row for something that no longer ships,
- a row naming no licence,
- a direct dependency that is not in the first table with a note (linted against the two `pyproject.toml` files).

All four mutations were checked by hand. Everything that is not a Python package is hand-written in bullets, which the lint ignores by only reading table rows.

## The links that were missing

The web app had no route to `/privacy`, `/support` or `/terms` at all. Settings now ends with an **About this server** card carrying all four plus the source, linted against the pages router rather than a list written in the test, so a fifth page fails CI until somebody decides where it belongs.

## iOS

A **Credits** row in Settings' About section, following the connected server like the privacy link does.

**No terms link, deliberately** — that is the page with the price on it, and the listing rests on 3.1.3(f) (`planning/08-freemium.md` §6). Since there is no iOS job in CI, that absence is asserted from `tests/unit/test_app_store_metadata.py`, next to the metadata lint, where it will actually run.

## Verification

- `make lint` clean; `make test-fast` 896 + 67 passing; `make ios-test` 146 passing.
- Rendered `/credits` against a local server: 2 tables, 56 package rows, no relative links left (the first draft used repo-relative markdown links, which 404 on the served page — the rule the other prose pages already follow).
- Rendered the About card in the web app: right position, all five hrefs resolving to the served origin.

## Not in scope

- `deploy/deploy.sh` verifies the three existing pages through Traefik and is gitignored, so `/credits` is not in its list yet.
- The marketing site in `docs/` has no credits link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)