### PR TITLE
Cut 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 
 ## Unreleased
 
+Nothing merged since the release below.
+
+## 2026-08-24 — say what this is built on
+
+Released as **1.4.0**. No migrations.
+
 ### Added
 
 - **`/credits`**, served by every deployment from

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -57,7 +57,7 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(
     lifespan=lifespan,
     title="Meals API",
-    version="1.3.1",
+    version="1.4.0",
     description=(
         "A meal *options* planner (not a rigid Mon–Sun grid) with a recipe library and an "
         "aisle-sorted shopping list. Designed to be driven by any AI assistant: every error "

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meals-backend"
-version = "1.3.1"
+version = "1.4.0"
 description = "Meal options planner backend — recipes, meals, plans, aisle-sorted shopping list, AI-friendly API"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "meals-backend"
-version = "1.3.1"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosmtplib" },
@@ -890,7 +890,7 @@ dev = [
 
 [[package]]
 name = "meals-mcp"
-version = "1.3.1"
+version = "1.4.0"
 source = { directory = "../mcp" }
 dependencies = [
     { name = "httpx" },

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meals-mcp"
-version = "1.3.1"
+version = "1.4.0"
 description = "MCP server wrapping the Meals REST API with task-level tools for AI assistants"
 requires-python = ">=3.12"
 dependencies = [

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -365,7 +365,7 @@ wheels = [
 
 [[package]]
 name = "meals-mcp"
-version = "1.3.1"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Releases `/credits` and the web app's About card ([#131](https://github.com/marco308/meals/pull/131)).

- Version moved to **1.4.0** in all three places the release job checks: `backend/pyproject.toml`, `mcp/pyproject.toml` and the FastAPI `version=` in `backend/app/main.py`.
- Both `uv.lock` files move with it. The Dockerfiles run `uv sync --frozen`, which fails on a lock whose project version disagrees with its `pyproject.toml`.
- `CHANGELOG.md`'s Unreleased section is now dated.

No migrations. Nothing in the API contract changed: one new unauthenticated page and one new key on the JSON landing, both additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)