### PR TITLE
Let a blank environment value mean "unset"

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,8 +1,84 @@
+import json
 from functools import lru_cache
-from typing import Self
+from typing import Annotated, Any, Self
 
-from pydantic import model_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import BeforeValidator, model_validator
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
+
+
+def _blank_is_unset(value: object) -> object:
+    """An empty or whitespace-only string means "not set".
+
+    `- MAX_HOUSEHOLDS=${MAX_HOUSEHOLDS:-}` is the ordinary way to wire an
+    optional value through a compose or stack file, and "unset" is what a
+    deployer means by it. The string-valued settings already behave that way
+    without anybody arranging it (`METRICS_TOKEN=` arrives as `""`, which every
+    reader here treats as falsy), so without this the two kinds of setting
+    disagree for no reason that is visible from the outside, and they disagree
+    by refusing to boot on the node rather than by failing anything the deploy
+    could have caught. Wiring a number the way a token is wired is not a
+    mistake worth a crash.
+    """
+    if isinstance(value, str) and not value.strip():
+        return None
+    return value
+
+
+# An int a deployment may leave unset, including by wiring it to an empty
+# `${VAR:-}` expansion. `None` is the only spelling of "unset" any reader sees.
+OptionalInt = Annotated[int | None, BeforeValidator(_blank_is_unset)]
+
+
+def _json_object_or_unset(value: object) -> object:
+    """The same rule for a setting whose value is JSON: blank overrides nothing.
+
+    This one needs `NoDecode` beside it, because a dict field is "complex" and
+    pydantic-settings JSON-decodes it in the environment source, before any
+    validator of ours can be reached. Blank therefore failed with a
+    `SettingsError` naming no line of JSON and offering no fix, which is a
+    worse boot crash than the ints got. Taking the decoding over costs one
+    `json.loads` and buys a refusal that says which setting and what was wrong
+    with it.
+    """
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return {}
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"not valid JSON ({exc}); leave it empty to override nothing") from exc
+    return value
+
+
+# A JSON object a deployment may leave unset the same way, e.g.
+# `- LIMITS_OVERRIDES=${LIMITS_OVERRIDES:-}`. Empty means "override nothing",
+# which is the profile as published.
+JsonOverrides = Annotated[
+    dict[str, dict[str, int | None]],
+    NoDecode,
+    BeforeValidator(_json_object_or_unset),
+]
+
+
+class BlankIsDefault:
+    """Annotation marker: blank means "use the default written on the field".
+
+    `OptionalInt` and `JsonOverrides` can say that with a validator, because
+    "unset" has a spelling in their type. A setting with a real default has
+    none, so this is a marker instead: `_blank_means_default` below drops the
+    value before pydantic sees it, and the default is then taken from the one
+    place it is written down. That is the point rather than a detail of the
+    mechanism. The stack file repeats six of these defaults today
+    (`- SMTP_PORT=${SMTP_PORT:-587}`) for no reason except that an empty string
+    would fail validation at boot, and a default written in two places is one
+    that will eventually disagree with itself.
+
+    It is opt-in per setting on purpose. `DATABASE_URL=${DATABSE_URL:-}` with
+    the variable name fat-fingered is a typo, and a server that quietly booted
+    onto the default SQLite path instead of failing would hide it until
+    somebody went looking for their data.
+    """
 
 
 class Settings(BaseSettings):
@@ -21,7 +97,7 @@ class Settings(BaseSettings):
     # docker-compose overrides this with the Postgres URL.
     database_url: str = "sqlite+aiosqlite:///./data/meals.db"
 
-    registration_enabled: bool = True
+    registration_enabled: Annotated[bool, BlankIsDefault] = True
     session_token_ttl_days: int = 30
 
     # Where a *browser* hitting the API root lands. Unset, it falls back to
@@ -85,9 +161,9 @@ class Settings(BaseSettings):
     #                           on. Existing households keep whatever their row
     #                           says, which for every household that predates
     #                           this is "unlimited".
-    limits_profile: str = "unlimited"
-    limits_overrides: dict[str, dict[str, int | None]] = {}
-    default_household_tier: str = "unlimited"
+    limits_profile: Annotated[str, BlankIsDefault] = "unlimited"
+    limits_overrides: JsonOverrides = {}
+    default_household_tier: Annotated[str, BlankIsDefault] = "unlimited"
 
     # Instance ceilings (planning/08-freemium.md §3, "Per instance"). The
     # limits above bound what one household costs; these bound how many
@@ -100,8 +176,8 @@ class Settings(BaseSettings):
     #                   onto a box with no room for them.
     #   MAX_USERS       the same for accounts, because an invited member grows
     #                   the user count without growing the household count.
-    max_households: int | None = None
-    max_users: int | None = None
+    max_households: OptionalInt = None
+    max_users: OptionalInt = None
 
     # Entitlements (app/services/entitlements.py, planning/08-freemium.md §5).
     # Only ever read for a household that has a `paid_until`, which on a
@@ -169,8 +245,8 @@ class Settings(BaseSettings):
     billing_store_id: str | None = None
     billing_api_base: str | None = None
     billing_manage_url: str | None = None
-    billing_price_pence: int | None = None
-    billing_price_currency: str = "GBP"
+    billing_price_pence: OptionalInt = None
+    billing_price_currency: Annotated[str, BlankIsDefault] = "GBP"
     billing_api_timeout_seconds: float = 20.0
 
     @property
@@ -203,11 +279,11 @@ class Settings(BaseSettings):
     # broken feature. Plain SMTP rather than a provider SDK, so any relay works
     # and nobody is pushed towards a paid account.
     smtp_host: str | None = None
-    smtp_port: int = 587
+    smtp_port: Annotated[int, BlankIsDefault] = 587
     smtp_username: str | None = None
     smtp_password: str | None = None
     smtp_from: str | None = None  # falls back to smtp_username
-    smtp_start_tls: bool = True
+    smtp_start_tls: Annotated[bool, BlankIsDefault] = True
     # Reset codes are short-lived on purpose: emailed in plaintext, and holding
     # one is enough to change a password.
     password_reset_ttl_minutes: int = 30
@@ -219,6 +295,22 @@ class Settings(BaseSettings):
     @property
     def email_sender(self) -> str:
         return self.smtp_from or self.smtp_username or "meals@localhost"
+
+    @model_validator(mode="before")
+    @classmethod
+    def _blank_means_default(cls, values: Any) -> Any:
+        # Dropping the key is what makes pydantic fall back to the default, so
+        # this has to run before field validation rather than after it. Only
+        # fields carrying the marker are dropped; see BlankIsDefault for why
+        # that is not every field.
+        if not isinstance(values, dict):
+            return values
+        marked = {name for name, field in cls.model_fields.items() if BlankIsDefault in field.metadata}
+        return {
+            key: value
+            for key, value in values.items()
+            if not (key in marked and isinstance(value, str) and not value.strip())
+        }
 
     @model_validator(mode="after")
     def _a_server_that_sells_needs_somebody_to_sell_to(self) -> Self:

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -1,0 +1,210 @@
+"""Settings that a deployment may leave unset have to survive being wired to
+nothing.
+
+`- MAX_HOUSEHOLDS=${MAX_HOUSEHOLDS:-}` is how an optional value travels through
+a compose or stack file, and it hands the process an empty string. The
+string-valued settings have always taken that as "unset" by accident, so the
+ones with a real type have to take it that way on purpose: the alternative is a
+boot crash on the node, which is the last place anyone wants to discover that a
+number is wired differently from a token.
+
+Blank means `None` where the type has a spelling for "unset", and the field's
+own default where it does not. The second half is what lets the stack file stop
+repeating those defaults, so these tests read every one of them off the model
+rather than writing it down again here.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app import limits
+from app.config import BlankIsDefault, Settings
+
+BLANK = ["", "   ", "\t", "\n"]
+
+# Every optional int, by env var and attribute. Add a row when a setting joins
+# them, because the failure this guards against only ever shows up at boot.
+OPTIONAL_INTS = [
+    ("MAX_HOUSEHOLDS", "max_households"),
+    ("MAX_USERS", "max_users"),
+    ("BILLING_PRICE_PENCE", "billing_price_pence"),
+]
+
+# Settings with a real default that the deployment wires through an optional
+# variable. `test_the_marked_fields_are_exactly_these` keeps the list honest in
+# both directions.
+BLANK_IS_DEFAULT = [
+    ("REGISTRATION_ENABLED", "registration_enabled"),
+    ("SMTP_PORT", "smtp_port"),
+    ("SMTP_START_TLS", "smtp_start_tls"),
+    ("LIMITS_PROFILE", "limits_profile"),
+    ("DEFAULT_HOUSEHOLD_TIER", "default_household_tier"),
+    ("BILLING_PRICE_CURRENCY", "billing_price_currency"),
+]
+
+# A real value for each, different from the default, so "blank falls back" and
+# "a set value wins" are told apart.
+SET_VALUES = {
+    "REGISTRATION_ENABLED": ("false", False),
+    "SMTP_PORT": ("25", 25),
+    "SMTP_START_TLS": ("false", False),
+    "LIMITS_PROFILE": ("hosted", "hosted"),
+    "DEFAULT_HOUSEHOLD_TIER": ("free", "free"),
+    "BILLING_PRICE_CURRENCY": ("USD", "USD"),
+}
+
+
+def _settings(monkeypatch, **env: str) -> Settings:
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    # _env_file=None so a developer's own backend/.env can't decide this.
+    return Settings(_env_file=None)
+
+
+class TestOptionalInts:
+    @pytest.mark.parametrize(("env_var", "attribute"), OPTIONAL_INTS)
+    @pytest.mark.parametrize("blank", BLANK)
+    def test_a_blank_value_means_unset(self, monkeypatch, env_var, attribute, blank):
+        assert getattr(_settings(monkeypatch, **{env_var: blank}), attribute) is None
+
+    @pytest.mark.parametrize(("env_var", "attribute"), OPTIONAL_INTS)
+    def test_an_actual_number_still_arrives(self, monkeypatch, env_var, attribute):
+        assert getattr(_settings(monkeypatch, **{env_var: " 25 "}), attribute) == 25
+
+    @pytest.mark.parametrize(("env_var", "attribute"), OPTIONAL_INTS)
+    def test_nonsense_is_still_refused(self, monkeypatch, env_var, attribute):
+        # Blank is the one string that means anything. "none", "off" and a typo
+        # are all still a misconfiguration, and boot is the right place to say so.
+        with pytest.raises(ValueError):
+            _settings(monkeypatch, **{env_var: "none"})
+
+    @pytest.mark.parametrize(("env_var", "attribute"), OPTIONAL_INTS)
+    def test_unset_is_unchanged(self, monkeypatch, env_var, attribute):
+        monkeypatch.delenv(env_var, raising=False)
+        assert getattr(_settings(monkeypatch), attribute) is None
+
+
+class TestLimitsOverrides:
+    """The same rule, for the setting that carries JSON.
+
+    This one is decoded in the settings source rather than by a validator, so
+    it is a separate mechanism (`NoDecode`) and gets its own tests: blank has to
+    mean "override nothing", and every way of actually setting it has to still
+    work, from the environment and from a `.env` file alike.
+    """
+
+    @pytest.mark.parametrize("blank", BLANK)
+    def test_a_blank_value_overrides_nothing(self, monkeypatch, blank):
+        assert _settings(monkeypatch, LIMITS_OVERRIDES=blank).limits_overrides == {}
+
+    def test_unset_overrides_nothing(self, monkeypatch):
+        monkeypatch.delenv("LIMITS_OVERRIDES", raising=False)
+        assert _settings(monkeypatch).limits_overrides == {}
+
+    def test_real_json_still_parses(self, monkeypatch):
+        # Including a null, which is how a profile's number is turned back into
+        # unlimited and the reason the values are int | None.
+        overrides = {"free": {"recipes": 100}, "ceiling": {"ingredients": None}}
+        settings = _settings(monkeypatch, LIMITS_OVERRIDES=json.dumps(overrides))
+        assert settings.limits_overrides == overrides
+
+    def test_json_in_a_dotenv_file_still_parses(self, monkeypatch, tmp_path: Path):
+        # NoDecode takes the decoding away from every source, not just the
+        # environment, so the file path has to be exercised too.
+        env_file = tmp_path / ".env"
+        env_file.write_text('LIMITS_OVERRIDES={"free": {"recipes": 7}}\n')
+        monkeypatch.delenv("LIMITS_OVERRIDES", raising=False)
+        assert Settings(_env_file=env_file).limits_overrides == {"free": {"recipes": 7}}
+
+    def test_a_blank_dotenv_value_overrides_nothing(self, monkeypatch, tmp_path: Path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("LIMITS_OVERRIDES=\n")
+        monkeypatch.delenv("LIMITS_OVERRIDES", raising=False)
+        assert Settings(_env_file=env_file).limits_overrides == {}
+
+    def test_broken_json_is_refused_by_name(self, monkeypatch):
+        # The old failure was a SettingsError that named no field and suggested
+        # nothing. A deployment that fat-fingers this should be told which
+        # setting is wrong and that blank is the way to mean "none".
+        with pytest.raises(ValueError) as caught:
+            _settings(monkeypatch, LIMITS_OVERRIDES="{recipes: 100}")
+        message = str(caught.value)
+        assert "limits_overrides" in message
+        assert "not valid JSON" in message
+
+    def test_a_dict_passed_in_code_is_untouched(self, monkeypatch):
+        monkeypatch.delenv("LIMITS_OVERRIDES", raising=False)
+        overrides = {"free": {"recipes": 5}}
+        assert Settings(_env_file=None, limits_overrides=overrides).limits_overrides == overrides
+
+
+class TestBlankMeansDefault:
+    """The other half: settings with a real default, wired the same way.
+
+    `- SMTP_PORT=${SMTP_PORT:-587}` is the shape the stack file has to use
+    today, and the 587 in it is a copy of the one in `config.py`. Blank has to
+    reach the field's own default so the copy can go.
+    """
+
+    def test_the_marked_fields_are_exactly_these(self):
+        # Adding the marker to a field without adding it here would leave it
+        # untested; the reverse would leave a test passing for a rule that had
+        # been taken off.
+        marked = {name for name, field in Settings.model_fields.items() if BlankIsDefault in field.metadata}
+        assert marked == {attribute for _, attribute in BLANK_IS_DEFAULT}
+
+    @pytest.mark.parametrize(("env_var", "attribute"), BLANK_IS_DEFAULT)
+    @pytest.mark.parametrize("blank", BLANK)
+    def test_a_blank_value_falls_back_to_the_default(self, monkeypatch, env_var, attribute, blank):
+        expected = Settings.model_fields[attribute].default
+        assert getattr(_settings(monkeypatch, **{env_var: blank}), attribute) == expected
+
+    @pytest.mark.parametrize(("env_var", "attribute"), BLANK_IS_DEFAULT)
+    def test_a_set_value_still_wins(self, monkeypatch, env_var, attribute):
+        raw, expected = SET_VALUES[env_var]
+        assert getattr(_settings(monkeypatch, **{env_var: raw}), attribute) == expected
+
+    @pytest.mark.parametrize("env_var", ["REGISTRATION_ENABLED", "SMTP_PORT", "SMTP_START_TLS"])
+    def test_a_typed_setting_still_refuses_nonsense(self, monkeypatch, env_var):
+        # Blank is the only string that means "I did not set this". Anything
+        # else that is not a number or a bool is still a misconfiguration, and
+        # boot is the right place to say so.
+        with pytest.raises(ValueError):
+            _settings(monkeypatch, **{env_var: "wat"})
+
+    @pytest.mark.parametrize("env_var", ["LIMITS_PROFILE", "DEFAULT_HOUSEHOLD_TIER"])
+    def test_a_vocabulary_setting_still_refuses_nonsense(self, settings_override, env_var):
+        # These two are plain strings, so pydantic lets them through and
+        # limits.check_settings refuses them at import in app/main.py. Falling
+        # back to the default must not have made that check unreachable: an
+        # unknown profile is still fatal, and it is now the only way to reach
+        # that branch, since blank no longer does.
+        settings_override(**{env_var: "wat"})
+        with pytest.raises(ValueError, match=env_var):
+            limits.check_settings()
+
+    @pytest.mark.parametrize(("env_var", "attribute"), BLANK_IS_DEFAULT)
+    def test_a_blank_value_leaves_the_settings_valid(self, settings_override, env_var, attribute):
+        # The counterpart: the default is by definition something the startup
+        # check accepts, so a deployment that wires the variable and sets
+        # nothing boots.
+        settings_override(**{env_var: ""})
+        limits.check_settings()
+
+    def test_a_blank_dotenv_value_falls_back_too(self, monkeypatch, tmp_path: Path):
+        monkeypatch.delenv("SMTP_PORT", raising=False)
+        env_file = tmp_path / ".env"
+        env_file.write_text("SMTP_PORT=\n")
+        assert Settings(_env_file=env_file).smtp_port == Settings.model_fields["smtp_port"].default
+
+    def test_an_unmarked_setting_is_left_alone(self, monkeypatch):
+        """The marker is opt-in, and DATABASE_URL is the reason why.
+
+        `DATABASE_URL=${DATABSE_URL:-}` with the variable name mistyped must not
+        quietly become the default SQLite file: that server would come up
+        healthy, serve an empty database, and take a while to be noticed.
+        """
+        assert _settings(monkeypatch, DATABASE_URL="").database_url == ""
+        assert Settings.model_fields["database_url"].default != ""


### PR DESCRIPTION
`- MAX_HOUSEHOLDS=${MAX_HOUSEHOLDS:-}` is the ordinary way to wire an optional
value through a compose or stack file, and it hands the process an empty
string. The string-valued settings have always read that as unset by accident
(`METRICS_TOKEN=` arrives as `""`, which every reader treats as falsy). The
typed ones failed validation instead, so the API refused to boot on the node,
which is the last place to discover that a number is wired differently from a
token.

Found while wiring `BILLING_*` into the deployment for #121, where the private
stack file worked around it by giving `BILLING_PRICE_PENCE` a concrete default:
a number living somewhere it does not belong.

## Three mechanisms, each opt-in per setting

- **`OptionalInt`** maps blank to `None`, for `MAX_HOUSEHOLDS`, `MAX_USERS` and
  `BILLING_PRICE_PENCE`.
- **`JsonOverrides`** does the same for `LIMITS_OVERRIDES`, and needs `NoDecode`
  beside it because a dict field is decoded in the settings source before any
  validator of ours can run. Broken JSON now fails by field name rather than as
  a `SettingsError` that quotes no line and suggests nothing.
- **`BlankIsDefault`** marks the six settings the swarm stack file wires with a
  copied default (`REGISTRATION_ENABLED`, `SMTP_PORT`, `SMTP_START_TLS`,
  `LIMITS_PROFILE`, `DEFAULT_HOUSEHOLD_TIER`, `BILLING_PRICE_CURRENCY`) so blank
  reaches the default written on the field. It is a marker plus one
  `model_validator(mode="before")` rather than a per-field validator, because a
  validator would have to carry the default itself, which just moves the
  duplicated `587` from the stack file into the annotation.

Opt-in rather than blanket: `DATABASE_URL` wired to an empty string is a typo,
and a server that quietly booted onto the default SQLite path instead of
failing would hide it until somebody went looking for their data. Fifteen
settings still refuse a blank value, deliberately, and none of them is wired in
`docker-compose.yml` or the stack file.

## Tests

`backend/tests/unit/test_config.py`, 75 cases. Blank in four spellings of
whitespace, from the environment and from a `.env` file; a set value still
wins; nonsense is still refused, split by mechanism because these fail in two
different places (pydantic for the typed ones, `limits.check_settings()` at
import for `LIMITS_PROFILE` and `DEFAULT_HOUSEHOLD_TIER`); and one test asserts
the set of marked fields is exactly the set under test, so a seventh marked
setting cannot arrive untested.

## Deployment note

`docker-compose.yml` is unchanged: it wires no optional setting at all, so
adding these would make limits the only pass-through in the reference
deployment. The private swarm stack file has been updated to drop seven copied
defaults, and it now requires an image carrying this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)