### PR TITLE
Cut 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 
 ## Unreleased
 
+Nothing merged since the release below.
+
+## 2026-08-24 — record the price, absorb the races
+
+Released as **1.4.1**. No migrations.
+
 ### Fixed
 
 - **A payment now records what was agreed.** `households.price_pence` was

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -57,7 +57,7 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(
     lifespan=lifespan,
     title="Meals API",
-    version="1.4.0",
+    version="1.4.1",
     description=(
         "A meal *options* planner (not a rigid Mon–Sun grid) with a recipe library and an "
         "aisle-sorted shopping list. Designed to be driven by any AI assistant: every error "

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meals-backend"
-version = "1.4.0"
+version = "1.4.1"
 description = "Meal options planner backend — recipes, meals, plans, aisle-sorted shopping list, AI-friendly API"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "meals-backend"
-version = "1.4.0"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosmtplib" },
@@ -890,7 +890,7 @@ dev = [
 
 [[package]]
 name = "meals-mcp"
-version = "1.4.0"
+version = "1.4.1"
 source = { directory = "../mcp" }
 dependencies = [
     { name = "httpx" },

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meals-mcp"
-version = "1.4.0"
+version = "1.4.1"
 description = "MCP server wrapping the Meals REST API with task-level tools for AI assistants"
 requires-python = ">=3.12"
 dependencies = [

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -365,7 +365,7 @@ wheels = [
 
 [[package]]
 name = "meals-mcp"
-version = "1.4.0"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Release cut for the billing fixes already on main (#135, #136): price
snapshot on first grant, webhook double-delivery absorbed as a duplicate,
registration race answering 409. No migrations; version strings and both
lockfiles move together, CHANGELOG dated section added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)