### PR TITLE
CI: move the Docker actions off Node.js 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,19 +92,19 @@ jobs:
 
       # arm64 matters here: a lot of self-hosting happens on a Pi or an ARM
       # VPS, and an amd64-only image is a bug report rather than a download.
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
         if: github.event_name != 'workflow_dispatch'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
           # v1.2.3 publishes :1.2.3, :1.2 and :latest. No :1, because a major
@@ -118,7 +118,7 @@ jobs:
             org.opencontainers.image.description=Yet Another Meal Planner — self-hosted meal planning with an AI-first API
             org.opencontainers.image.licenses=AGPL-3.0-only
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
@@ -146,7 +146,7 @@ jobs:
       # not strictly needed today. It stays because package visibility is a
       # setting with no API behind it, and a job that can only verify a public
       # image is a job that breaks the day somebody changes that setting.
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}


### PR DESCRIPTION
Every release run now prints:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: docker/build-push-action@v6, docker/login-action@v3, docker/metadata-action@v5, docker/setup-buildx-action@v3, docker/setup-qemu-action@v3.

Each of those actions has cut a new major whose change is the Node 24 runtime, so this pins them:

| Action | Was | Now |
|---|---|---|
| docker/setup-qemu-action | v3 | v4 |
| docker/setup-buildx-action | v3 | v4 |
| docker/login-action | v3 | v4 |
| docker/metadata-action | v5 | v6 |
| docker/build-push-action | v6 | v7 |

Verified each new major's `action.yml` declares `node24` and read the major release notes. buildx v4 removed some deprecated inputs and build-push v7 removed the `DOCKER_BUILD_NO_SUMMARY` / `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs; the workflow uses none of them. The other three carry only dependency bumps.

The release workflow only runs on a tag or a manual dispatch, so a `workflow_dispatch` run after merge (builds both architectures, pushes nothing) is the way to see the warning gone before the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
