### PR TITLE
Cut 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,12 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 
 ## Unreleased
 
-**One migration** (`b9d33848e592`), additive: one nullable column on
-`households`.
+Nothing merged since the release below.
+
+## 2026-09-03 — what the webhook was throwing away
+
+Released as **1.6.0**. **One migration** (`b9d33848e592`), additive: one
+nullable column on `households`.
 
 Both fixes came out of putting a real Stripe sandbox payment through the
 deployment. The grant itself was right — signature verified, one ledger row,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -58,7 +58,7 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(
     lifespan=lifespan,
     title="Meals API",
-    version="1.5.0",
+    version="1.6.0",
     description=(
         "A meal *options* planner (not a rigid Mon–Sun grid) with a recipe library and an "
         "aisle-sorted shopping list. Designed to be driven by any AI assistant: every error "

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meals-backend"
-version = "1.5.0"
+version = "1.6.0"
 description = "Meal options planner backend — recipes, meals, plans, aisle-sorted shopping list, AI-friendly API"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "meals-backend"
-version = "1.5.0"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosmtplib" },
@@ -890,7 +890,7 @@ dev = [
 
 [[package]]
 name = "meals-mcp"
-version = "1.5.0"
+version = "1.6.0"
 source = { directory = "../mcp" }
 dependencies = [
     { name = "httpx" },

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meals-mcp"
-version = "1.5.0"
+version = "1.6.0"
 description = "MCP server wrapping the Meals REST API with task-level tools for AI assistants"
 requires-python = ">=3.12"
 dependencies = [

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -365,7 +365,7 @@ wheels = [
 
 [[package]]
 name = "meals-mcp"
-version = "1.5.0"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Version bump to **1.6.0** in `backend/pyproject.toml`, `mcp/pyproject.toml`, the FastAPI `version=` and both `uv.lock` files, and the changelog's Unreleased section becomes the release note. No code change.

The release carries PR #130 (issues #128 and #129): founding price from the event, keep-on-renewal, stored customer id and `POST /billing/portal`. One additive migration, `b9d33848e592`, safe for a start-first rollout.

After merge: `git push origin v1.6.0` on the merge commit, then `MEALS_VERSION=1.6.0 make deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)