### PR TITLE
Web: hide ticked items on the shopping list

### DIFF
--- a/web/app.css
+++ b/web/app.css
@@ -480,6 +480,13 @@ select { cursor: pointer; }
 .shop-item .i-actions { display: flex; gap: .35rem; opacity: 0; transition: opacity .15s; }
 .shop-item:hover .i-actions, .shop-item:focus-within .i-actions { opacity: 1; }
 
+/* "Hide ticked" walks the list down to what is still to get. The rows stay in
+   the DOM so the tallies and the untick are one toggle away, and an aisle whose
+   every line is done goes with them (JS sets .all-ticked). The "already have
+   it" pile is left alone — it answers a different question. */
+.hide-ticked .aisle-columns .shop-item.done,
+.hide-ticked .aisle-group.all-ticked { display: none; }
+
 .icon-btn {
   border: 1px solid var(--line);
   background: var(--card);

--- a/web/js/views/shopping.js
+++ b/web/js/views/shopping.js
@@ -8,6 +8,7 @@ import { confirmDialog, emptyState, fmtDate, html, render, skeleton, toast } fro
 let staplesMode = false;
 let showExcluded = false;
 let hideTicked = false;
+const hideLabel = () => (hideTicked ? "👀 Show ticked" : "🙈 Hide ticked");
 
 export async function renderShopping(root) {
   render(root, skeleton());
@@ -47,9 +48,7 @@ export async function renderShopping(root) {
           </p>
         </div>
         <div class="page-actions">
-          <button class="btn ghost" data-hide-ticked aria-pressed="${hideTicked ? "true" : "false"}">
-            ${hideTicked ? "👀 Show ticked" : "🙈 Hide ticked"}
-          </button>
+          <button class="btn ghost" data-hide-ticked aria-pressed="${hideTicked ? "true" : "false"}">${hideLabel()}</button>
           <button class="btn ghost" data-staples>🧂 Staples check</button>
           <a class="btn ghost" href="#/list/archived">Previous shops</a>
           <button class="btn" data-finish>Finish the shop</button>
@@ -172,9 +171,16 @@ function bind(root, list, markets) {
       }
     };
   }
-  root.querySelector("[data-hide-ticked]").onclick = () => {
+  // Hiding is a view of what is already on screen, so it flips in place: a
+  // re-render would refetch the list and throw away the scroll position
+  // halfway down an aisle. The other two toggles change the query, and do.
+  const hideButton = root.querySelector("[data-hide-ticked]");
+  hideButton.onclick = () => {
     hideTicked = !hideTicked;
-    renderShopping(root);
+    root.querySelector(".page").classList.toggle("hide-ticked", hideTicked);
+    hideButton.textContent = hideLabel();
+    hideButton.setAttribute("aria-pressed", String(hideTicked));
+    syncHidden(root);
   };
   root.querySelector("[data-show-excluded]").onclick = () => {
     showExcluded = !showExcluded;

--- a/web/js/views/shopping.js
+++ b/web/js/views/shopping.js
@@ -7,6 +7,7 @@ import { confirmDialog, emptyState, fmtDate, html, render, skeleton, toast } fro
 
 let staplesMode = false;
 let showExcluded = false;
+let hideTicked = false;
 
 export async function renderShopping(root) {
   render(root, skeleton());
@@ -29,7 +30,7 @@ export async function renderShopping(root) {
   const excluded = list.items.filter((i) => i.excluded);
 
   render(root, html`
-    <div class="page">
+    <div class="page ${hideTicked ? "hide-ticked" : ""}">
       <div class="page-head">
         <div>
           <h1>Shopping list</h1>
@@ -46,6 +47,9 @@ export async function renderShopping(root) {
           </p>
         </div>
         <div class="page-actions">
+          <button class="btn ghost" data-hide-ticked aria-pressed="${hideTicked ? "true" : "false"}">
+            ${hideTicked ? "👀 Show ticked" : "🙈 Hide ticked"}
+          </button>
           <button class="btn ghost" data-staples>🧂 Staples check</button>
           <a class="btn ghost" href="#/list/archived">Previous shops</a>
           <button class="btn" data-finish>Finish the shop</button>
@@ -60,6 +64,7 @@ export async function renderShopping(root) {
       ${list.items.length === 0
         ? emptyState("🛒", "The list writes itself", "Add meals to the plan and their ingredients appear here, merged and sorted by aisle. Or add one-offs above.")
         : html`<div class="aisle-columns">${aisleGroups(list)}</div>`}
+      <p class="menu-foot" data-all-ticked hidden>Everything on the list is in the trolley.</p>
 
       ${excluded.length > 0 &&
       html`
@@ -77,6 +82,7 @@ export async function renderShopping(root) {
   `);
 
   bind(root, list, markets);
+  syncHidden(root);
 }
 
 function groupByAisle(items) {
@@ -166,6 +172,10 @@ function bind(root, list, markets) {
       }
     };
   }
+  root.querySelector("[data-hide-ticked]").onclick = () => {
+    hideTicked = !hideTicked;
+    renderShopping(root);
+  };
   root.querySelector("[data-show-excluded]").onclick = () => {
     showExcluded = !showExcluded;
     renderShopping(root);
@@ -320,6 +330,22 @@ function stapleRow(item) {
   `;
 }
 
+// An aisle whose every line is in the trolley would leave its header floating
+// over nothing once the rows are hidden, so the group goes with them — and when
+// the whole list is done the page says so rather than looking empty. Only the
+// aisles are touched: the “already have it” pile is a different question.
+function syncHidden(root) {
+  for (const group of root.querySelectorAll(".aisle-group")) {
+    group.classList.toggle("all-ticked", group.querySelectorAll(".shop-item:not(.done)").length === 0);
+  }
+  const note = root.querySelector("[data-all-ticked]");
+  if (note) {
+    const rows = root.querySelectorAll(".aisle-columns .shop-item").length;
+    const left = root.querySelectorAll(".aisle-columns .shop-item:not(.done)").length;
+    note.hidden = !hideTicked || rows === 0 || left > 0;
+  }
+}
+
 // Keep the header and per-aisle tallies honest during optimistic ticking,
 // without a full re-render that would cut the strike animation short.
 function updateCounts(root) {
@@ -333,6 +359,7 @@ function updateCounts(root) {
   const done = root.querySelectorAll(".aisle-columns .shop-item.done").length;
   const label = root.querySelector("[data-count]");
   if (label) label.textContent = rows.length === 0 ? "nothing to get" : `${done} of ${rows.length} in the trolley`;
+  syncHidden(root);
 }
 
 // "2 l milk" / "500g flour" / "2 tins of chopped tomatoes" / plain "milk".


### PR DESCRIPTION
## What and why

By the end of a shop most of the list is struck through and the rows still
worth walking to are buried among them. A **🙈 Hide ticked** toggle in the
shopping list's page head (flipping to **👀 Show ticked**) walks the list down
to what is left to get.

Web only — no API change, no iOS change.

### How it works

- The page gets a `hide-ticked` class and CSS hides `.shop-item.done` inside
  `.aisle-columns`. The rows stay in the DOM, so the header tally
  ("8 of 22 in the trolley") and each aisle's `7/7` stay honest, and one click
  on the toggle brings everything back to undo a mis-tick.
- Ticking with hiding on removes the row on the existing optimistic path, before
  the PATCH lands; the existing rollback restores it if the server disagrees.
- An aisle whose every line is ticked is hidden too (`syncHidden` sets
  `.all-ticked`) rather than leaving a header floating over nothing, and a fully
  ticked list shows "Everything on the list is in the trolley." instead of
  looking empty.
- Scoped to the aisle columns: the "already have it" pile answers a different
  question and is untouched, including an excluded item that happens to be
  ticked.
- The toggle is session state, like the staples and excluded-pile toggles beside
  it — a reload starts with everything shown.

### Verification

Local API on SQLite with `app.seed`'s 22-item list, driven in a browser:
tick 8 → 14 rows visible and the 2 emptied aisles hidden; tick the rest → all
groups gone and the all-done note shown; toggle back → all 22 return; ticking
while hidden removes the row immediately with the count still correct.
`make lint` and `backend/tests/unit/test_web_client.py` pass.

## Checklist

- [x] **API contract stayed additive** — no API change at all.
- [x] **Shopping-list quantities still derive from `ListItemSource`** — nothing
      touches quantities; this is presentation only.

Not applicable: no model change, no new query, no endpoint/unit/aisle/value-tier
change (nothing for the skill to learn), no new 4xx strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)