### PR TITLE
Cut 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,25 @@ The API contract is additive-only (see CLAUDE.md), so **Removed** and
 
 Nothing merged since the release below.
 
+## 2026-09-03 — hide what's in the trolley
+
+Released as **1.6.1**. No migrations, nothing in the API contract changed;
+the web app alone.
+
+### Added
+
+- **The shopping list can hide what is already ticked**
+  ([#142](https://github.com/marco308/meals/pull/142)). By the end of a shop
+  most of the list is struck through and the rows still worth walking to are
+  buried among them; a "Hide ticked" toggle in the page head walks the list
+  down to what is left. The rows stay in the DOM and only CSS hides them, so
+  the tallies stay honest, the optimistic tick still hides a row before the
+  server answers, and one click brings everything back for a mis-tick. An aisle
+  whose every line is done goes with its rows, a fully ticked list says so
+  rather than looking empty, and the toggle flips in place — no refetch, no
+  lost scroll position halfway down an aisle. The "already have it" pile is
+  left alone.
+
 ## 2026-09-03 — what the webhook was throwing away
 
 Released as **1.6.0**. **One migration** (`b9d33848e592`), additive: one

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -58,7 +58,7 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
 app = FastAPI(
     lifespan=lifespan,
     title="Meals API",
-    version="1.6.0",
+    version="1.6.1",
     description=(
         "A meal *options* planner (not a rigid Mon–Sun grid) with a recipe library and an "
         "aisle-sorted shopping list. Designed to be driven by any AI assistant: every error "

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meals-backend"
-version = "1.6.0"
+version = "1.6.1"
 description = "Meal options planner backend — recipes, meals, plans, aisle-sorted shopping list, AI-friendly API"
 requires-python = ">=3.12"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -829,7 +829,7 @@ wheels = [
 
 [[package]]
 name = "meals-backend"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosmtplib" },
@@ -890,7 +890,7 @@ dev = [
 
 [[package]]
 name = "meals-mcp"
-version = "1.6.0"
+version = "1.6.1"
 source = { directory = "../mcp" }
 dependencies = [
     { name = "httpx" },

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meals-mcp"
-version = "1.6.0"
+version = "1.6.1"
 description = "MCP server wrapping the Meals REST API with task-level tools for AI assistants"
 requires-python = ">=3.12"
 dependencies = [

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -365,7 +365,7 @@ wheels = [
 
 [[package]]
 name = "meals-mcp"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## What and why

Release cut for the one change since 1.6.0: the web shopping list can hide what is already ticked (#142). No migrations, nothing in the API contract changed; the web app alone.

The six files a cut touches: `CHANGELOG.md` (Unreleased → a dated 1.6.1 section), the FastAPI `version=` in `app/main.py`, both `pyproject.toml`s and both `uv.lock`s (the Dockerfiles sync `--frozen`, which fails on a lock whose project version disagrees with its pyproject). The release job checks that all three version strings agree before it builds.

After merge: `git push origin v1.6.1`, let `release.yml` publish the images, then `MEALS_VERSION=1.6.1 make deploy`.

## Checklist

- [x] **API contract stayed additive** — no API change.

Not applicable: no model change, no query, no shopping-list quantity code, no skill or prompt-pack change, no new 4xx strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)